### PR TITLE
ci: replace Bandit with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,10 +30,3 @@ repos:
         language: system
         types: [python]
         files: ^src/wct/
-
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.10
-    hooks:
-      - id: bandit
-        args: ["-c", "pyproject.toml"]
-        additional_dependencies: ["bandit[toml]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,6 @@ addopts = [
     "--import-mode=importlib",
 ]
 
-[tool.bandit]
-exclude_dirs = ["tests"]
-
 [tool.basedpyright]
 include = ["src/wct"]
 typeCheckingMode = "strict"


### PR DESCRIPTION
Ruff supports all Bandit rules via its [`flake8-bandit` ruleset](https://docs.astral.sh/ruff/rules/#flake8-bandit-s).

[Since I have previously enabled Ruff's `flake8-bandit` ruleset](https://github.com/waivern-compliance/waivern-compliance/blob/a236d9439f205d3478b81570e1be18ac29faf914/pyproject.toml#L90), we don't need to install and run Bandit separately.