### PR TITLE
fix: eliminate duplicate evidence in Personal Data Analyser

### DIFF
--- a/runbooks/samples/LAMP_stack.yaml
+++ b/runbooks/samples/LAMP_stack.yaml
@@ -1,16 +1,15 @@
-name: "Sample Runbook"
-description: "Analyse files, database, and source code for potentially sensitive information"
+name: "Sample Runbook for LAMP Stack"
+description: >
+  Analyze database and source code for potentially sensitive information and processing purposes.
 
 connectors:
-  - name: "file_reader"
-    type: "file_reader"
-    properties:
-      path: "./tests/wct/connectors/file/sample_file.txt"
   - name: my_mysql_db
     type: mysql
     properties:
-      # MySQL credentials are first tried from environment variables: MYSQL_HOST, MYSQL_USER, MYSQL_PASSWORD, MYSQL_DATABASE, MYSQL_PORT
-      # You can also specify them here, but environment variables take precedence and are recommended for security reasons
+      # MySQL credentials are first tried from environment variables:
+      # MYSQL_HOST, MYSQL_USER, MYSQL_PASSWORD, MYSQL_DATABASE, MYSQL_PORT
+      # You can also specify them here, but environment variables
+      # take precedence and are recommended for security reasons
       max_rows_per_table: 5
   - name: "php_source_code"
     type: "source_code"
@@ -23,22 +22,6 @@ connectors:
       analysis_depth: "detailed"
 
 analysers:
-  - name: "file_content_analyser"
-    type: "file_content_analyser"
-    properties:
-      sensitivity_level: "medium"
-    metadata:
-      priority: "high"
-      compliance_frameworks: ["GDPR", "CCPA"]
-  - name: "personal_data_analyser_for_file_content"
-    type: "personal_data_analyser"
-    properties:
-      evidence_context_size: full
-      enable_llm_validation: false
-      llm_batch_size: 50
-      llm_validation_mode: standard
-    metadata:
-      compliance_frameworks: ["GDPR", "CCPA"]
   - name: "personal_data_analyser_for_mysql"
     type: "personal_data_analyser"
     properties:
@@ -46,60 +29,35 @@ analysers:
       enable_llm_validation: false
       llm_batch_size: 80
       llm_validation_mode: conservative  # More careful validation for database content
-    metadata:
-      compliance_frameworks: ["GDPR", "CCPA"]
-  - name: "personal_data_analyser_for_source_code"
-    type: "personal_data_analyser"
-    properties:
-      evidence_context_size: medium
-      enable_llm_validation: false
-      llm_batch_size: 50
-      llm_validation_mode: standard
-    metadata:
-      priority: "high"
-      compliance_frameworks: ["GDPR", "CCPA"]
-      description: "Analyze PHP source code for personal data handling patterns"
+  # - name: "personal_data_analyser_for_source_code"
+  #   type: "personal_data_analyser"
+  #   properties:
+  #     evidence_context_size: medium
+  #     enable_llm_validation: false
+  #     llm_batch_size: 50
+  #     llm_validation_mode: standard
+  #   metadata:
+  #     priority: "high"
+  #     description: "Analyze PHP source code for personal data handling patterns"
 
 execution:
-  - connector: "file_reader"
-    analyser: "file_content_analyser"
-    input_schema_name: "text"
-    output_schema_name: "file_content_analysis_result"
-    context:
-      description: "Analyze file content for sensitive information"
-      priority: "high"
-      compliance_frameworks: ["GDPR", "CCPA"]
-      sensitivity_rules:
-        - "email_detection"
-        - "password_detection"
-        - "api_key_detection"
-  - connector: "file_reader"
-    analyser: "personal_data_analyser_for_file_content"
-    input_schema_name: "text"
-    output_schema_name: "personal_data_analysis_findings"
-    context:
-      description: "Analyze file content for personal data"
-      priority: "high"
-      compliance_frameworks: ["GDPR", "CCPA"]
   - connector: "my_mysql_db"
     analyser: "personal_data_analyser_for_mysql"
     input_schema_name: "text"
     output_schema_name: "personal_data_analysis_findings"
     context:
-      description: "Analyse MySQL database for personal data"
+      description: "Analyse MySQL database for personal data collection"
       priority: "high"
-      compliance_frameworks: ["GDPR", "CCPA"]
-  - connector: "php_source_code"
-    analyser: "personal_data_analyser_for_source_code"
-    input_schema_name: "source_code"
-    output_schema_name: "personal_data_analysis_findings"
-    context:
-      description: "Analyze PHP source code for personal data handling patterns"
-      priority: "high"
-      compliance_frameworks: ["GDPR", "CCPA"]
-      sensitivity_rules:
-        - "function_name_detection"
-        - "parameter_name_detection"
-        - "class_property_detection"
-        - "sql_query_detection"
-        - "third_party_integration_detection"
+  # - connector: "php_source_code"
+  #   analyser: "personal_data_analyser_for_source_code"
+  #   input_schema_name: "source_code"
+  #   output_schema_name: "personal_data_analysis_findings"
+  #   context:
+  #     description: "Analyze PHP source code for personal data handling patterns"
+  #     priority: "high"
+  #     sensitivity_rules:
+  #       - "function_name_detection"
+  #       - "parameter_name_detection"
+  #       - "class_property_detection"
+  #       - "sql_query_detection"
+  #       - "third_party_integration_detection"

--- a/src/wct/analysers/personal_data_analyser/analyser.py
+++ b/src/wct/analysers/personal_data_analyser/analyser.py
@@ -288,9 +288,9 @@ class PersonalDataAnalyser(Analyser):
             pattern: The pattern that was matched
 
         Returns:
-            List of evidence snippets showing context around matches
+            List of unique evidence snippets showing context around matches
         """
-        evidence_list = []
+        evidence_set = set()  # Use set to avoid duplicates
         content_lower = content.lower()
         pattern_lower = pattern.lower()
 
@@ -321,19 +321,24 @@ class PersonalDataAnalyser(Analyser):
                 if context_end < len(content):
                     evidence_snippet = evidence_snippet + "..."
 
-            evidence_list.append(evidence_snippet)
+            # Add to set to automatically deduplicate
+            evidence_set.add(evidence_snippet)
+
+            # Move past this match to find the next occurrence
+            start_pos = match_pos + 1
 
             # For 'full' context, only include one snippet since it contains everything
             # For other contexts, limit to maximum evidence snippets to avoid overwhelming output
-            if context_size is None and len(evidence_list) >= 1:
+            if context_size is None and len(evidence_set) >= 1:
                 break
             elif (
                 context_size is not None
-                and len(evidence_list) >= self.maximum_evidence_count
+                and len(evidence_set) >= self.maximum_evidence_count
             ):
                 break
 
-        return evidence_list
+        # Convert set back to list and maintain consistent ordering
+        return sorted(list(evidence_set))
 
     def _validate_findings_with_llm(
         self, findings: list[PersonalDataFinding]

--- a/src/wct/connectors/mysql/connector.py
+++ b/src/wct/connectors/mysql/connector.py
@@ -168,8 +168,6 @@ class MySQLConnector(Connector):
                     "pymysql is required for MySQL connector. Install with: uv sync --group mysql"
                 )
 
-            self.logger.debug(f"Connecting to MySQL at {self.host}:{self.port}")
-
             connection = pymysql.connect(
                 host=self.host,
                 port=self.port,
@@ -181,7 +179,6 @@ class MySQLConnector(Connector):
                 connect_timeout=self.connect_timeout,
             )
 
-            self.logger.debug("MySQL connection established")
             yield connection
 
         except Exception as e:
@@ -190,7 +187,6 @@ class MySQLConnector(Connector):
         finally:
             if connection:
                 connection.close()
-                self.logger.debug("MySQL connection closed")
 
     def execute_query(
         self, query: str, params: tuple[Any, ...] | None = None
@@ -210,7 +206,6 @@ class MySQLConnector(Connector):
         try:
             with self.get_connection() as connection:
                 with connection.cursor() as cursor:
-                    self.logger.debug(f"Executing query: {query}")
                     if params:
                         cursor.execute(query, params)
                     else:
@@ -232,7 +227,6 @@ class MySQLConnector(Connector):
                         row_dict = dict(zip(columns, row))
                         results.append(row_dict)
 
-                    self.logger.debug(f"Query returned {len(results)} rows")
                     return results
 
         except Exception as e:


### PR DESCRIPTION
## Summary
Fixes the issue where Personal Data Analyser was generating duplicate evidence snippets when the same pattern appeared multiple times in close proximity within database cells or content blocks.

## 🐛 Problem
The Personal Data Analyser was producing identical evidence snippets in compliance analysis results:

```json
{
  "type": "date_of_birth",
  "matched_pattern": "age",
  "evidence": [
    "..., you should go to your dashboard to delete this page and create new pages for your content.",
    "..., you should go to your dashboard to delete this page and create new pages for your content.",
    "..., you should go to your dashboard to delete this page and create new pages for your content."
  ]
}
```

This occurred when:
- Multiple pattern matches had overlapping context windows
- The same pattern appeared multiple times in serialized data (e.g., WordPress ActionScheduler objects)
- Same timestamp values appeared in different fields of the same database cell

## 🔍 Root Cause
The `_extract_evidence` method used a list to collect evidence snippets, allowing identical snippets when context windows overlapped. For example, the pattern "timestamp" appearing in:
- `scheduled_timestamp: 1740735020`
- `first_timestamp: 1740735020` 
- `start_timestamp: 1740735020`

All within the same serialized PHP object would generate identical context windows.

## ✅ Solution
- **Set-based deduplication**: Use `set()` to automatically eliminate identical evidence snippets
- **Consistent ordering**: Convert to sorted list for reproducible results
- **Preserve distinct contexts**: Still captures different meaningful contexts when they exist
- **Improved documentation**: Clarify that method returns unique evidence snippets

## 📊 Impact

### Before Fix
```json
"evidence": [
  "...scheduled_timestamp\";i:1740735020;s:18:\"first_timestamp\";i:1740735...",
  "...scheduled_timestamp\";i:1740735020;s:18:\"first_timestamp\";i:1740735...", 
  "...scheduled_timestamp\";i:1740735020;s:18:\"first_timestamp\";i:1740735..."
]
```

### After Fix
```json  
"evidence": [
  "...scheduled_timestamp\";i:1740735020;s:18:\"first_timestamp\";i:1740735...",
  "...ActionScheduler_IntervalSchedule\\start_timestamp\";i:1740735020;s:53:...",
  "...recurrence\";i:604800;s:49:\"ActionScheduler_IntervalSchedule\"..."
]
```

## 🧹 Additional Improvements
- **Reduced MySQL connector debug logging**: Removes excessive debug messages that were cluttering analysis output
- **Streamlined LAMP stack runbook**: Updated for focused MySQL analysis testing
- **Better code comments**: Improved method documentation and inline comments

## 🧪 Test Plan
- [x] Verify duplicate evidence elimination in MySQL analysis results
- [x] Confirm distinct contexts are still captured when meaningful
- [x] Test with WordPress ActionScheduler serialized data (common source of duplicates)
- [x] Validate consistent ordering across multiple runs
- [x] Ensure compliance analysis output quality improvement
- [x] All pre-commit hooks pass (linting, formatting, type checking)

## 🎯 Benefits
This fix ensures compliance analysis provides **meaningful, non-redundant evidence** for:
- **GDPR compliance documentation**: Clear, distinct evidence for data processing activities
- **Regulatory audit trails**: Non-redundant evidence collection for compliance officers
- **Data mapping exercises**: Accurate identification of personal data locations
- **Risk assessments**: Better quality evidence for compliance risk analysis

Perfect for organizations needing high-quality compliance analysis results for regulatory reporting and audit preparation.