### PR TITLE
feat: migrate to Python-standard logging with YAML configuration (#38)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ outputs/
 
 # Environment variables
 .env
+
+# Logs
+logs/*.log
+logs/*.log.*

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,64 @@
+# WCT Configuration
+
+This directory contains configuration files for the Waivern Compliance Tool.
+
+## Logging Configuration
+
+WCT uses Python's standard `logging.config.dictConfig()` with YAML configuration files:
+
+- **`logging.yaml`** - Default logging configuration for production
+- **`logging-dev.yaml`** - Development configuration with debug logging and Rich formatting
+- **`logging-test.yaml`** - Minimal logging for test environments
+
+### Environment Selection
+
+The logging system automatically selects configuration based on:
+
+1. **`WCT_ENV` environment variable**: Set to `dev`, `test`, or `prod`
+2. **Explicit config**: Pass config path to `setup_logging()`
+3. **Default fallback**: Uses `logging.yaml` if no environment specified
+
+### Configuration Structure
+
+Each logging config follows Python's standard logging configuration format:
+
+```yaml
+version: 1
+disable_existing_loggers: false
+
+formatters:
+  standard:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: INFO
+    formatter: standard
+
+loggers:
+  wct:
+    level: INFO
+    handlers: [console]
+    propagate: false
+
+root:
+  level: WARNING
+  handlers: [console]
+```
+
+### Adding New Configurations
+
+To add environment-specific logging:
+
+1. Create `config/logging-{environment}.yaml`
+2. Set `WCT_ENV={environment}` in your environment
+3. The logging system will automatically use your configuration
+
+### Rich Console Output
+
+Development and default configurations use Rich formatting for enhanced console output with:
+- Syntax highlighting
+- Progress bars
+- Better tracebacks
+- Timestamps and paths

--- a/config/logging-dev.yaml
+++ b/config/logging-dev.yaml
@@ -1,0 +1,40 @@
+version: 1
+disable_existing_loggers: false
+
+formatters:
+  dev:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    datefmt: '%H:%M:%S'
+
+  debug:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(module)s:%(funcName)s:%(lineno)d - %(message)s'
+    datefmt: '%H:%M:%S'
+
+handlers:
+  dev_console:
+    class: rich.logging.RichHandler
+    level: DEBUG
+    formatter: dev
+    markup: true
+    rich_tracebacks: true
+    tracebacks_show_locals: true
+    show_time: true
+    show_path: true
+
+  debug_file:
+    class: logging.FileHandler
+    level: DEBUG
+    formatter: debug
+    filename: logs/wct-debug.log
+    mode: w
+    encoding: utf8
+
+loggers:
+  wct:
+    level: DEBUG
+    handlers: [dev_console, debug_file]
+    propagate: false
+
+root:
+  level: INFO
+  handlers: [dev_console]

--- a/config/logging-test.yaml
+++ b/config/logging-test.yaml
@@ -1,0 +1,23 @@
+version: 1
+disable_existing_loggers: false
+
+formatters:
+  test:
+    format: '%(levelname)s - %(name)s - %(message)s'
+
+handlers:
+  test_console:
+    class: logging.StreamHandler
+    level: WARNING
+    formatter: test
+    stream: ext://sys.stderr
+
+loggers:
+  wct:
+    level: WARNING
+    handlers: [test_console]
+    propagate: false
+
+root:
+  level: ERROR
+  handlers: [test_console]

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -1,0 +1,72 @@
+version: 1
+disable_existing_loggers: false
+
+formatters:
+  standard:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    datefmt: '%Y-%m-%d %H:%M:%S'
+
+  detailed:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(module)s:%(lineno)d - %(message)s'
+    datefmt: '%Y-%m-%d %H:%M:%S'
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: INFO
+    formatter: standard
+    stream: ext://sys.stderr
+
+  rich_console:
+    class: rich.logging.RichHandler
+    level: INFO
+    formatter: standard
+    markup: true
+    rich_tracebacks: true
+    tracebacks_show_locals: false
+    show_time: true
+    show_path: false
+
+  file:
+    class: logging.handlers.RotatingFileHandler
+    level: DEBUG
+    formatter: detailed
+    filename: logs/wct.log
+    maxBytes: 10485760  # 10MB
+    backupCount: 5
+    encoding: utf8
+
+loggers:
+  wct:
+    level: INFO
+    handlers: [rich_console]
+    propagate: false
+
+  wct.executor:
+    level: INFO
+    handlers: [rich_console]
+    propagate: false
+
+  wct.connectors:
+    level: INFO
+    handlers: [rich_console]
+    propagate: false
+
+  wct.analysers:
+    level: INFO
+    handlers: [rich_console]
+    propagate: false
+
+  wct.rulesets:
+    level: INFO
+    handlers: [rich_console]
+    propagate: false
+
+  wct.cli:
+    level: INFO
+    handlers: [rich_console]
+    propagate: false
+
+root:
+  level: WARNING
+  handlers: [console]

--- a/logs/.gitkeep
+++ b/logs/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this directory in git but ignore log files

--- a/src/wct/analysers/base.py
+++ b/src/wct/analysers/base.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import abc
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
 from typing_extensions import Self
 
-from wct.logging import get_analyser_logger
 from wct.message import Message
 from wct.schemas import Schema, SchemaLoadError
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,14 +41,8 @@ class Analyser(abc.ABC):
     """
 
     def __init__(self) -> None:
-        """Initialise the analyser with a configured logger.
-
-        The logger is automatically set up using the analyser's class name
-        in lowercase, following WCT logging conventions.
-        """
-        # Get the analyser name from the class and set up logger
-        analyser_name = self.get_name()
-        self.logger = get_analyser_logger(analyser_name)
+        """Initialise the analyser."""
+        pass
 
     @classmethod
     @abc.abstractmethod

--- a/src/wct/analysers/personal_data_analyser/analyser.py
+++ b/src/wct/analysers/personal_data_analyser/analyser.py
@@ -1,5 +1,6 @@
 """Personal data analysis analyser for GDPR compliance."""
 
+import logging
 from pprint import pformat
 from typing import Any
 
@@ -20,6 +21,8 @@ from .pattern_matcher import personal_data_pattern_matcher
 from .source_code_schema_input_handler import SourceCodeSchemaInputHandler
 
 # from .types import PersonalDataFinding  # Only needed for LLM validation strategy
+
+logger = logging.getLogger(__name__)
 
 SUPPORTED_INPUT_SCHEMAS: list[Schema] = [
     StandardInputSchema(),
@@ -198,7 +201,7 @@ class PersonalDataAnalyser(Analyser):
                 "validation_mode": self.config["llm_validation_mode"],
             }
 
-            self.logger.info(
+            logger.info(
                 f"LLM validation completed: {original_count} → {validated_count} findings "
                 f"({false_positives_removed} false positives removed)"
             )
@@ -212,7 +215,7 @@ class PersonalDataAnalyser(Analyser):
         # Validate the output message against the output schema
         output_message.validate()
 
-        self.logger.debug(
+        logger.debug(
             f"PersonalDataAnalyser processed with findings:\n{pformat(findings)}"
         )
 

--- a/src/wct/analysers/personal_data_analyser/llm_validation_strategy.py
+++ b/src/wct/analysers/personal_data_analyser/llm_validation_strategy.py
@@ -1,10 +1,10 @@
 """LLM validation strategy for personal data analysis."""
 
 import json
+import logging
 from logging import Logger
 from typing import Any
 
-from wct.logging import get_analyser_logger
 from wct.prompts.personal_data_validation import (
     RecommendedAction,
     ValidationResult,
@@ -13,6 +13,8 @@ from wct.prompts.personal_data_validation import (
 )
 
 from .types import PersonalDataFinding
+
+logger = logging.getLogger(__name__)
 
 
 def personal_data_validation_strategy(
@@ -31,7 +33,7 @@ def personal_data_validation_strategy(
     Returns:
         List of validated findings with false positives removed
     """
-    logger = get_analyser_logger("personal_data_validation")
+    # Use module-level logger
 
     if not findings:
         logger.debug("No findings to validate")

--- a/src/wct/analysers/processing_purpose_analyser/analyser.py
+++ b/src/wct/analysers/processing_purpose_analyser/analyser.py
@@ -1,5 +1,6 @@
 """Processing purpose analysis analyser for GDPR compliance."""
 
+import logging
 from typing import Any
 
 from typing_extensions import Self, override
@@ -14,6 +15,8 @@ from wct.schemas import (
 )
 
 from .pattern_matcher import processing_purpose_pattern_matcher
+
+logger = logging.getLogger(__name__)
 
 SUPPORTED_INPUT_SCHEMAS: list[Schema] = [
     StandardInputSchema(),
@@ -133,14 +136,14 @@ class ProcessingPurposeAnalyser(Analyser):
         message: Message,
     ) -> Message:
         """Process data to identify processing purposes using runners."""
-        self.logger.info("Starting processing purpose analysis")
+        logger.info("Starting processing purpose analysis")
 
         # Validate input message
         Analyser.validate_input_message(message, input_schema)
 
         # Extract content from message
         data = message.content
-        self.logger.debug(f"Processing data with schema: {input_schema.name}")
+        logger.debug(f"Processing data with schema: {input_schema.name}")
 
         # Process standard_input schema using pattern runner
         findings = self._process_standard_input_with_runners(data)
@@ -178,9 +181,7 @@ class ProcessingPurposeAnalyser(Analyser):
         # Validate the output message against the output schema
         output_message.validate()
 
-        self.logger.debug(
-            f"Processing purpose analysis completed with data: {result_data}"
-        )
+        logger.debug(f"Processing purpose analysis completed with data: {result_data}")
 
         return output_message
 

--- a/src/wct/analysers/runners/pattern_matching_runner.py
+++ b/src/wct/analysers/runners/pattern_matching_runner.py
@@ -1,13 +1,15 @@
 """Pattern matching analysis runner."""
 
+import logging
 from collections.abc import Callable
 from typing import Any
 
 from wct.analysers.runners.base import AnalysisRunner, AnalysisRunnerError
 from wct.analysers.utilities import EvidenceExtractor
-from wct.logging import get_analyser_logger
 from wct.rulesets import RulesetLoader
 from wct.rulesets.types import Rule
+
+logger = logging.getLogger(__name__)
 
 # Type alias for pattern matcher function
 PatternMatcherFn = Callable[
@@ -32,7 +34,6 @@ class PatternMatchingRunner(AnalysisRunner[dict[str, Any]]):
         """
         self.evidence_extractor = EvidenceExtractor()
         self._patterns_cache = {}  # Cache loaded rulesets
-        self.logger = get_analyser_logger("pattern_matching_runner")
         self.pattern_matcher = (
             pattern_matcher
             if pattern_matcher is not None
@@ -66,12 +67,12 @@ class PatternMatchingRunner(AnalysisRunner[dict[str, Any]]):
         try:
             ruleset_name = config.get("ruleset_name", "personal_data")
 
-            self.logger.debug(f"Running pattern analysis with ruleset: {ruleset_name}")
+            logger.debug(f"Running pattern analysis with ruleset: {ruleset_name}")
 
             # Load rules (with caching)
             rules = self._get_rules(ruleset_name)
             if not rules:
-                self.logger.warning(f"No rules found in ruleset: {ruleset_name}")
+                logger.warning(f"No rules found in ruleset: {ruleset_name}")
 
             # Run pattern matching using the provided strategy
             findings = []
@@ -97,7 +98,7 @@ class PatternMatchingRunner(AnalysisRunner[dict[str, Any]]):
 
                         if finding:
                             findings.append(finding)
-                            self.logger.debug(
+                            logger.debug(
                                 f"Found pattern '{pattern}' in rule '{rule.name}'"
                             )
             return findings
@@ -168,7 +169,7 @@ class PatternMatchingRunner(AnalysisRunner[dict[str, Any]]):
             self._patterns_cache[ruleset_name] = RulesetLoader.load_ruleset(
                 ruleset_name
             )
-            self.logger.info(f"Loaded ruleset: {ruleset_name}")
+            logger.info(f"Loaded ruleset: {ruleset_name}")
 
         return self._patterns_cache[ruleset_name]
 
@@ -178,4 +179,4 @@ class PatternMatchingRunner(AnalysisRunner[dict[str, Any]]):
         Useful for testing or when rulesets are updated.
         """
         self._patterns_cache.clear()
-        self.logger.debug("Pattern cache cleared")
+        logger.debug("Pattern cache cleared")

--- a/src/wct/analysers/utilities/llm_service_manager.py
+++ b/src/wct/analysers/utilities/llm_service_manager.py
@@ -1,7 +1,10 @@
 """Utility for managing LLM service lifecycle."""
 
+import logging
+
 from wct.llm_service import LLMServiceError, LLMServiceFactory
-from wct.logging import get_analyser_logger
+
+logger = logging.getLogger(__name__)
 
 
 class LLMServiceManager:
@@ -15,7 +18,6 @@ class LLMServiceManager:
         """
         self.enable_llm_validation = enable_llm_validation
         self._llm_service = None
-        self.logger = get_analyser_logger("llm_service_manager")
 
     @property
     def llm_service(self):
@@ -23,9 +25,9 @@ class LLMServiceManager:
         if self._llm_service is None and self.enable_llm_validation:
             try:
                 self._llm_service = LLMServiceFactory.create_anthropic_service()
-                self.logger.info("LLM service initialised for compliance analysis")
+                logger.info("LLM service initialised for compliance analysis")
             except LLMServiceError as e:
-                self.logger.warning(
+                logger.warning(
                     f"Failed to initialise LLM service: {e}. Continuing without LLM validation."
                 )
                 self.enable_llm_validation = False

--- a/src/wct/cli.py
+++ b/src/wct/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import typer
@@ -16,10 +17,10 @@ from wct.analysis import AnalysisResult, AnalysisResultsExporter
 from wct.connectors import BUILTIN_CONNECTORS
 from wct.executor import Executor
 from wct.llm_service import LLMServiceError, LLMServiceFactory
-from wct.logging import get_cli_logger, setup_logging
+from wct.logging import setup_logging
 from wct.runbook import Runbook, RunbookLoader
 
-logger = get_cli_logger()
+logger = logging.getLogger(__name__)
 console = Console()
 
 

--- a/src/wct/connectors/base.py
+++ b/src/wct/connectors/base.py
@@ -7,15 +7,17 @@ This module provides:
 """
 
 import abc
+import logging
 from dataclasses import dataclass
 from typing import Any
 
 from typing_extensions import Self
 
 from wct.errors import WCTError
-from wct.logging import get_connector_logger
 from wct.message import Message
 from wct.schemas import Schema
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,14 +38,8 @@ class Connector(abc.ABC):
     """
 
     def __init__(self) -> None:
-        """Initialise the connector with a configured logger.
-
-        The logger is automatically set up using the connector's class name
-        in lowercase, following WCT logging conventions.
-        """
-        # Get the connector name from the class and set up logger
-        connector_name = self.get_name()
-        self.logger = get_connector_logger(connector_name)
+        """Initialise the connector."""
+        pass
 
     @classmethod
     @abc.abstractmethod

--- a/src/wct/connectors/source_code/connector.py
+++ b/src/wct/connectors/source_code/connector.py
@@ -1,5 +1,6 @@
 """Source code connector for WCT."""
 
+import logging
 from collections.abc import Generator
 from datetime import datetime
 from pathlib import Path
@@ -22,6 +23,8 @@ from wct.message import Message
 
 # Import the actual schema instances
 from wct.schemas import Schema, SourceCodeSchema
+
+logger = logging.getLogger(__name__)
 
 SUPPORTED_OUTPUT_SCHEMAS = {
     "source_code": SourceCodeSchema(),
@@ -163,9 +166,7 @@ class SourceCodeConnector(Connector):
                 )
 
             if not output_schema:
-                self.logger.warning(
-                    "No schema provided, using default source_code schema"
-                )
+                logger.warning("No schema provided, using default source_code schema")
                 output_schema = SUPPORTED_OUTPUT_SCHEMAS["source_code"]
 
             # Analyse source code
@@ -181,7 +182,7 @@ class SourceCodeConnector(Connector):
             return message
 
         except Exception as e:
-            self.logger.error(f"Failed to extract from source code {self.path}: {e}")
+            logger.error(f"Failed to extract from source code {self.path}: {e}")
             raise ConnectorExtractionError(
                 f"Failed to analyse source code {self.path}: {e}"
             ) from e
@@ -226,7 +227,7 @@ class SourceCodeConnector(Connector):
         try:
             # Check file size
             if file_path.stat().st_size > self.max_file_size:
-                self.logger.warning(f"Skipping large file: {file_path}")
+                logger.warning(f"Skipping large file: {file_path}")
                 return [], 0, 0
 
             # Detect language if needed
@@ -246,7 +247,7 @@ class SourceCodeConnector(Connector):
             return [file_data], 1, line_count
 
         except Exception as e:
-            self.logger.error(f"Failed to analyse file {file_path}: {e}")
+            logger.error(f"Failed to analyse file {file_path}: {e}")
             return [], 0, 0
 
     def _analyse_directory(
@@ -273,7 +274,7 @@ class SourceCodeConnector(Connector):
             total_files += file_count
             total_lines += line_count
 
-        self.logger.info(f"Processed {total_files} source code files")
+        logger.info(f"Processed {total_files} source code files")
         return files_data, total_files, total_lines
 
     def _get_source_files(self) -> Generator[Path, None, None]:

--- a/src/wct/executor.py
+++ b/src/wct/executor.py
@@ -10,6 +10,7 @@ between connectors and analysers based on runbook configurations.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -17,9 +18,10 @@ from wct.analysers import Analyser, AnalyserConfig, AnalyserError
 from wct.analysis import AnalysisResult
 from wct.connectors import Connector, ConnectorConfig, ConnectorError
 from wct.errors import WCTError
-from wct.logging import get_executor_logger
 from wct.runbook import ExecutionStep, Runbook, RunbookLoader
 from wct.schemas import Schema
+
+logger = logging.getLogger(__name__)
 
 
 class Executor:
@@ -35,7 +37,6 @@ class Executor:
     def __init__(self):
         self.connectors: dict[str, type[Connector]] = {}
         self.analysers: dict[str, type[Analyser]] = {}
-        self.logger = get_executor_logger()
 
     # The following four methods allow for dynamic registration of connectors and analysers.
     # They are for system-wide registration of available connectors and analysers,
@@ -200,7 +201,7 @@ class Executor:
         self, step: ExecutionStep, error: Exception
     ) -> AnalysisResult:
         """Handle execution errors and return appropriate error result."""
-        self.logger.error(f"Step execution failed for {step.analyser}: {error}")
+        logger.error(f"Step execution failed for {step.analyser}: {error}")
         return self._create_error_result(
             step.analyser,
             error_message=str(error),

--- a/src/wct/llm_service.py
+++ b/src/wct/llm_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any
 
@@ -9,7 +10,8 @@ from langchain_anthropic import ChatAnthropic
 from pydantic import SecretStr
 
 from wct.errors import WCTError
-from wct.logging import get_logger
+
+logger = logging.getLogger(__name__)
 
 
 class LLMServiceError(WCTError):
@@ -47,7 +49,7 @@ class AnthropicLLMService:
         Raises:
             LLMConfigurationError: If API key is not provided or found in environment
         """
-        self.logger = get_logger(__name__)
+        # Logger is available at module level
 
         # Get model name from parameter, environment, or default
         self.model_name = (
@@ -63,9 +65,7 @@ class AnthropicLLMService:
             )
 
         self._llm = None
-        self.logger.info(
-            f"Initialised Anthropic LLM service with model: {self.model_name}"
-        )
+        logger.info(f"Initialised Anthropic LLM service with model: {self.model_name}")
 
     def _get_llm(self):
         """Get or create the LangChain LLM instance.
@@ -88,7 +88,7 @@ class AnthropicLLMService:
                 timeout=300,  # Increased timeout for LLM requests
                 stop=None,  # Stop sequences for clean output
             )
-            self.logger.debug("Created LangChain ChatAnthropic instance")
+            logger.debug("Created LangChain ChatAnthropic instance")
 
         return self._llm
 
@@ -102,7 +102,7 @@ class AnthropicLLMService:
             LLMConnectionError: If connection test fails
         """
         try:
-            self.logger.info("Testing connection to Anthropic API...")
+            logger.info("Testing connection to Anthropic API...")
 
             llm = self._get_llm()
 
@@ -114,7 +114,7 @@ class AnthropicLLMService:
             response = llm.invoke(test_prompt)
             response_text = str(response.content).strip()
 
-            self.logger.info("Connection test successful")
+            logger.info("Connection test successful")
 
             return {
                 "status": "success",
@@ -124,7 +124,7 @@ class AnthropicLLMService:
             }
 
         except Exception as e:
-            self.logger.error(f"Connection test failed: {e}")
+            logger.error(f"Connection test failed: {e}")
             raise LLMConnectionError(f"Failed to connect to Anthropic API: {e}") from e
 
     def analyse_data(self, text: str, analysis_prompt: str) -> str:
@@ -141,7 +141,7 @@ class AnthropicLLMService:
             LLMConnectionError: If LLM request fails
         """
         try:
-            self.logger.debug(f"Analysing text (length: {len(text)} chars)")
+            logger.debug(f"Analysing text (length: {len(text)} chars)")
 
             llm = self._get_llm()
 
@@ -151,14 +151,14 @@ class AnthropicLLMService:
             response = llm.invoke(full_prompt)
             result = str(response.content).strip()
 
-            self.logger.debug(
+            logger.debug(
                 f"LLM analysis completed (response length: {len(result)} chars)"
             )
 
             return result
 
         except Exception as e:
-            self.logger.error(f"Text analysis failed: {e}")
+            logger.error(f"Text analysis failed: {e}")
             raise LLMConnectionError(f"LLM text analysis failed: {e}") from e
 
 

--- a/src/wct/logging.py
+++ b/src/wct/logging.py
@@ -1,133 +1,288 @@
-"""Logging configuration for the WCT system."""
+"""Python-standard logging configuration for WCT.
 
+This module provides centralized logging setup following Python best practices
+using logging.config.dictConfig() with YAML configuration files stored in config/.
+"""
+
+from __future__ import annotations
+
+import importlib.util
 import logging
+import logging.config
+import os
 import sys
+from pathlib import Path
+from typing import Any, cast
 
-from rich.console import Console
-from rich.logging import RichHandler
-from typing_extensions import override
+import yaml
 
 
-class ColoredFormatter(logging.Formatter):
-    """Custom formatter with colored output for different log levels."""
+class LoggingError(Exception):
+    """Exception raised for logging configuration errors."""
 
-    # ANSI color codes
-    COLORS = {
-        "DEBUG": "\033[36m",  # Cyan
-        "INFO": "\033[32m",  # Green
-        "WARNING": "\033[33m",  # Yellow
-        "ERROR": "\033[31m",  # Red
-        "CRITICAL": "\033[35m",  # Magenta
-    }
-    RESET = "\033[0m"
+    pass
 
-    @override
-    def format(self, record: logging.LogRecord) -> str:
-        """Format the log record with colored level names.
 
-        Args:
-            record: The log record to format
+def get_project_root() -> Path:
+    """Get the project root directory using robust discovery methods.
 
-        Returns:
-            Formatted log message string with colored level name
-        """
-        # Add color to the level name
-        if record.levelname in self.COLORS:
-            record.levelname = (
-                f"{self.COLORS[record.levelname]}{record.levelname}{self.RESET}"
-            )
-        return super().format(record)
+    This function follows industry-standard approaches used by tools like pytest,
+    black, and setuptools to find the project root:
+    1. Package location via importlib (handles installed packages)
+    2. Upward search for project markers (handles development)
+
+    Returns:
+        Path to the project root directory
+
+    Raises:
+        LoggingError: If project root cannot be determined
+    """
+    # Method 1: Use package location if installed (preferred)
+    try:
+        spec = importlib.util.find_spec("wct")
+        if spec and spec.origin:
+            package_path = Path(spec.origin).parent
+
+            # For development installs, the package might be a symlink to src/wct
+            if package_path.is_symlink():
+                real_package = package_path.resolve()
+                if real_package.name == "wct" and real_package.parent.name == "src":
+                    potential_root = real_package.parent.parent
+                    if (potential_root / "config").is_dir():
+                        return potential_root
+
+            # For regular installs, search upward from package location
+            for path in [package_path, *package_path.parents]:
+                if (path / "config").is_dir():
+                    return path
+    except (ImportError, AttributeError):
+        # Package not found via importlib, continue to marker-based discovery
+        pass
+
+    # Method 2: Search upward from current file for project markers (development)
+    current_path = Path(__file__).parent.resolve()
+
+    for path in [current_path, *current_path.parents]:
+        # Look for common project root markers
+        markers = [
+            path / "pyproject.toml",  # Modern Python project file
+            path / "setup.py",  # Legacy setup file
+            path / ".git",  # Git repository root
+            path / "src" / "wct",  # Our package structure
+        ]
+
+        if any(marker.exists() for marker in markers):
+            # Verify this looks like our project by checking for config/
+            if (path / "config").is_dir():
+                return path
+
+    # If both methods fail, provide clear error message
+    raise LoggingError(
+        f"Could not determine project root. Searched:\n"
+        f"1. Package location via importlib.util.find_spec('wct')\n"
+        f"2. Upward from {current_path} for project markers\n"
+        f"Expected to find a directory containing 'config/' subdirectory."
+    )
+
+
+def get_config_path(
+    config_name: str | None = None, environment: str | None = None
+) -> Path:
+    """Get the path to a logging configuration file.
+
+    Args:
+        config_name: Name of config file (without extension)
+        environment: Environment (dev, test, prod) for environment-specific configs
+
+    Returns:
+        Path to the logging configuration file
+
+    Raises:
+        LoggingError: If no suitable configuration file is found
+    """
+    project_root = get_project_root()
+    config_dir = project_root / "config"
+
+    # Determine config file name based on environment
+    if config_name:
+        config_file = f"{config_name}.yaml"
+    elif environment:
+        config_file = f"logging-{environment}.yaml"
+    else:
+        # Default priority: environment-specific -> general
+        env = os.getenv("WCT_ENV", "").lower()
+        if env and env in ["dev", "development", "test", "prod", "production"]:
+            if env in ["development"]:
+                env = "dev"
+            elif env in ["production"]:
+                env = "prod"
+            config_file = f"logging-{env}.yaml"
+        else:
+            config_file = "logging.yaml"
+
+    config_path = config_dir / config_file
+
+    # Fallback to default if specific config doesn't exist
+    if not config_path.exists() and config_file != "logging.yaml":
+        config_path = config_dir / "logging.yaml"
+
+    if not config_path.exists():
+        raise LoggingError(
+            f"No logging configuration found. Expected at: {config_path}\n"
+            f"Available configs: {list(config_dir.glob('logging*.yaml')) if config_dir.exists() else 'config directory not found'}"
+        )
+
+    return config_path
+
+
+def load_config(config_path: Path) -> dict[str, Any]:
+    """Load logging configuration from YAML file.
+
+    Args:
+        config_path: Path to the YAML configuration file
+
+    Returns:
+        Logging configuration dictionary
+
+    Raises:
+        LoggingError: If configuration cannot be loaded or parsed
+    """
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+
+        if not isinstance(config, dict):
+            raise LoggingError(f"Invalid configuration format in {config_path}")
+
+        # Type checker safety: yaml.safe_load returns Any, but we've verified it's a dict
+        return config  # type: ignore[return-value]
+
+    except yaml.YAMLError as e:
+        raise LoggingError(f"Failed to parse YAML config {config_path}: {e}") from e
+    except OSError as e:
+        raise LoggingError(f"Failed to read config file {config_path}: {e}") from e
+
+
+def create_log_directories(config: dict[str, Any]) -> None:
+    """Create log directories referenced in the configuration.
+
+    Args:
+        config: Logging configuration dictionary
+    """
+    handlers = config.get("handlers", {})
+    project_root = get_project_root()
+
+    for handler_config in handlers.values():
+        if isinstance(handler_config, dict) and "filename" in handler_config:
+            # Make log file paths relative to project root
+            log_file_path = cast(str, handler_config["filename"])
+            if not os.path.isabs(log_file_path):
+                log_file = project_root / log_file_path
+            else:
+                log_file = Path(log_file_path)
+
+            log_file.parent.mkdir(parents=True, exist_ok=True)
 
 
 def setup_logging(
-    level: str = "INFO",
-    format_string: str | None = None,
-    use_colors: bool = True,
-    use_rich: bool = True,
+    config_path: Path | str | None = None,
+    level: str | None = None,
+    environment: str | None = None,
+    force_basic: bool = False,
 ) -> None:
-    """Configure logging for the WCT system.
+    """Configure logging using Python standard dictConfig.
 
     Args:
-        level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-        format_string: Custom format string for log messages
-        use_colors: Whether to use colored output (default: True)
-        use_rich: Whether to use Rich formatting (default: True)
+        config_path: Path to logging configuration file
+        level: Override log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+        environment: Environment for config selection (dev, test, prod)
+        force_basic: Force basic console logging (fallback mode)
+
+    Raises:
+        LoggingError: If logging setup fails
     """
-    # Convert string level to logging constant
+    if force_basic:
+        _setup_basic_logging(level or "INFO")
+        return
+
+    try:
+        # Determine config path
+        if isinstance(config_path, str):
+            config_path = Path(config_path)
+        elif config_path is None:
+            config_path = get_config_path(environment=environment)
+
+        # Load and apply configuration
+        config = load_config(config_path)
+
+        # Override log level if specified
+        if level:
+            numeric_level = getattr(logging, level.upper(), None)
+            if numeric_level is None:
+                raise LoggingError(f"Invalid log level: {level}")
+
+            # Update all loggers in config
+            for logger_name in config.get("loggers", {}):
+                config["loggers"][logger_name]["level"] = level
+
+            # Update root logger
+            if "root" in config:
+                config["root"]["level"] = level
+
+            # Update all handlers to respect the new level
+            # (handlers can filter out messages below their level)
+            for handler_name, handler_config in config.get("handlers", {}).items():
+                if isinstance(handler_config, dict) and "level" in handler_config:
+                    # Only lower the handler level if the new level is more verbose
+                    handler_level_str = cast(
+                        str, handler_config["level"]
+                    )  # We know it's a string from config
+                    current_handler_level = getattr(
+                        logging, handler_level_str, logging.INFO
+                    )
+                    if numeric_level < current_handler_level:
+                        config["handlers"][handler_name]["level"] = level
+
+        # Create necessary directories
+        create_log_directories(config)
+
+        # Apply configuration
+        logging.config.dictConfig(config)
+
+        logger = logging.getLogger(__name__)
+        logger.info(
+            "Logging configured from: %s", config_path.relative_to(get_project_root())
+        )
+
+    except (LoggingError, ImportError, KeyError, ValueError) as e:
+        # Fallback to basic logging on any configuration error
+        fallback_level = level or "INFO"
+        _setup_basic_logging(fallback_level)
+
+        fallback_logger = logging.getLogger(__name__)
+        fallback_logger.warning(
+            "Failed to configure logging from file (%s), using basic console logging at %s level",
+            e,
+            fallback_level,
+        )
+
+
+def _setup_basic_logging(level: str) -> None:
+    """Set up basic console logging as fallback.
+
+    Args:
+        level: Logging level string
+    """
     numeric_level = getattr(logging, level.upper(), logging.INFO)
 
-    # Configure root logger
-    root_logger = logging.getLogger()
-    root_logger.setLevel(numeric_level)
-
-    # Remove existing handlers
-    for handler in root_logger.handlers[:]:
-        root_logger.removeHandler(handler)
-
-    # Create console handler with Rich or traditional formatting
-    if use_rich and sys.stderr.isatty():
-        console = Console(stderr=True, force_terminal=True)
-        console_handler = RichHandler(
-            console=console,
-            show_time=True,
-            show_path=False,
-            markup=True,
-            rich_tracebacks=True,
-            tracebacks_show_locals=False,
-        )
-        # Rich handler uses its own formatting
-        console_handler.setLevel(numeric_level)
-    else:
-        # Fallback to traditional colored formatter
-        if format_string is None:
-            format_string = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-
-        if use_colors and sys.stderr.isatty():
-            formatter = ColoredFormatter(format_string)
-        else:
-            formatter = logging.Formatter(format_string)
-
-        console_handler = logging.StreamHandler(sys.stderr)
-        console_handler.setLevel(numeric_level)
-        console_handler.setFormatter(formatter)
-
-    # Add handler to root logger
-    root_logger.addHandler(console_handler)
+    # Configure basic logging
+    logging.basicConfig(
+        level=numeric_level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        stream=sys.stderr,
+        force=True,  # Override existing configuration
+    )
 
 
-def get_logger(name: str) -> logging.Logger:
-    """Get a logger instance for the given name.
-
-    Args:
-        name: Logger name (typically __name__ of the module)
-
-    Returns:
-        Logger instance
-    """
-    return logging.getLogger(name)
-
-
-# Pre-configured loggers for common WCT components
-def get_executor_logger() -> logging.Logger:
-    """Get logger for executor components."""
-    return get_logger("wct.executor")
-
-
-def get_connector_logger(connector_name: str) -> logging.Logger:
-    """Get logger for connector components."""
-    return get_logger(f"wct.connectors.{connector_name}")
-
-
-def get_analyser_logger(analyser_name: str) -> logging.Logger:
-    """Get logger for analyser components."""
-    return get_logger(f"wct.analysers.{analyser_name}")
-
-
-def get_ruleset_logger(ruleset_name: str) -> logging.Logger:
-    """Get logger for ruleset components."""
-    return get_logger(f"wct.rulesets.{ruleset_name}")
-
-
-def get_cli_logger() -> logging.Logger:
-    """Get logger for CLI components."""
-    return get_logger("wct.cli")
+# Standard Python logging - users should use logging.getLogger(__name__) directly

--- a/src/wct/rulesets/base.py
+++ b/src/wct/rulesets/base.py
@@ -1,10 +1,12 @@
 """Base classes and utilities for rulesets."""
 
 import abc
+import logging
 from typing import Any
 
-from wct.logging import get_ruleset_logger
 from wct.rulesets.types import Rule
+
+logger = logging.getLogger(__name__)
 
 
 class Ruleset(abc.ABC):
@@ -17,11 +19,8 @@ class Ruleset(abc.ABC):
     """
 
     def __init__(self) -> None:
-        """Initialise the ruleset.
-
-        Uses the ruleset's canonical name for logging purposes.
-        """
-        self.logger = get_ruleset_logger(self.name)
+        """Initialise the ruleset."""
+        pass
 
     @property
     @abc.abstractmethod

--- a/src/wct/rulesets/personal_data.py
+++ b/src/wct/rulesets/personal_data.py
@@ -4,12 +4,15 @@ This module defines a ruleset for detecting personal data patterns.
 It serves as a base for compliance with GDPR and other privacy regulations.
 """
 
+import logging
 from typing import Final
 
 from typing_extensions import override
 
 from wct.rulesets.base import Ruleset
 from wct.rulesets.types import Rule, RuleData
+
+logger = logging.getLogger(__name__)
 
 # Version constant for this ruleset (private)
 _VERSION: Final[str] = "1.0.0"
@@ -512,7 +515,7 @@ class PersonalDataRuleset(Ruleset):
         """Initialise the personal data ruleset."""
         super().__init__()
         self.rules: tuple[Rule, ...] | None = None
-        self.logger.debug(f"Initialised {self.name} ruleset version {self.version}")
+        logger.debug(f"Initialised {self.name} ruleset version {self.version}")
 
     @property
     @override
@@ -546,6 +549,6 @@ class PersonalDataRuleset(Ruleset):
                     )
                 )
             self.rules = tuple(rules_list)
-            self.logger.debug(f"Generated {len(self.rules)} personal data rules")
+            logger.debug(f"Generated {len(self.rules)} personal data rules")
 
         return self.rules

--- a/src/wct/rulesets/processing_purposes.py
+++ b/src/wct/rulesets/processing_purposes.py
@@ -1,11 +1,14 @@
 """Known processing purposes to search for during analysis."""
 
+import logging
 from typing import Final
 
 from typing_extensions import override
 
 from wct.rulesets.base import Ruleset
 from wct.rulesets.types import Rule, RuleData
+
+logger = logging.getLogger(__name__)
 
 # Version constant for this ruleset (private)
 _VERSION: Final[str] = "1.0.0"
@@ -465,7 +468,7 @@ class ProcessingPurposesRuleset(Ruleset):
         """Initialise the processing purposes ruleset."""
         super().__init__()
         self.rules: tuple[Rule, ...] | None = None
-        self.logger.debug(f"Initialised {self.name} ruleset version {self.version}")
+        logger.debug(f"Initialised {self.name} ruleset version {self.version}")
 
     @property
     @override
@@ -499,6 +502,6 @@ class ProcessingPurposesRuleset(Ruleset):
                     )
                 )
             self.rules = tuple(rules_list)
-            self.logger.debug(f"Generated {len(self.rules)} processing purpose rules")
+            logger.debug(f"Generated {len(self.rules)} processing purpose rules")
 
         return self.rules

--- a/tests/wct/test_logging.py
+++ b/tests/wct/test_logging.py
@@ -1,0 +1,400 @@
+"""Tests for WCT logging configuration and setup."""
+
+import importlib.util
+import logging
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from wct.logging import (
+    LoggingError,
+    create_log_directories,
+    get_config_path,
+    get_project_root,
+    load_config,
+    setup_logging,
+)
+
+
+class TestLoggingConfiguration:
+    """Test logging configuration functionality."""
+
+    def test_get_project_root_returns_correct_path(self):
+        """Test that get_project_root returns the correct project root."""
+        root = get_project_root()
+        assert root.is_dir()
+        assert (root / "config").exists()
+        assert (root / "src" / "wct").exists()
+
+    def test_get_project_root_finds_markers(self):
+        """Test that get_project_root correctly identifies project markers."""
+        root = get_project_root()
+
+        # Should have found one or more of these markers
+        markers = [
+            root / "pyproject.toml",
+            root / "setup.py",
+            root / ".git",
+            root / "src" / "wct",
+        ]
+
+        # At least one marker should exist
+        assert any(marker.exists() for marker in markers)
+
+        # Must have the config directory (our specific requirement)
+        assert (root / "config").is_dir()
+
+    def test_get_project_root_is_robust(self):
+        """Test that get_project_root works from different locations."""
+        # Should work consistently regardless of import location
+        root1 = get_project_root()
+
+        # Test again to ensure consistency
+        root2 = get_project_root()
+        assert root1 == root2
+
+        # Should be absolute path
+        assert root1.is_absolute()
+
+        # Should contain expected structure
+        assert (root1 / "config").is_dir()
+        assert (root1 / "src" / "wct").is_dir()
+
+    def test_get_project_root_uses_importlib(self):
+        """Test that get_project_root can use importlib.util.find_spec method."""
+        # Verify the package can be found via importlib
+        spec = importlib.util.find_spec("wct")
+        assert spec is not None
+        assert spec.origin is not None
+
+        # The function should work and find the correct root
+        root = get_project_root()
+
+        # Should contain the package source
+        assert (root / "src" / "wct").is_dir()
+        assert (root / "config").is_dir()
+
+        # The root should be consistent with the package location
+        package_path = Path(spec.origin).parent  # src/wct/__init__.py -> src/wct
+        expected_root = package_path.parent.parent  # src/wct -> src -> project_root
+        assert root == expected_root
+
+    def test_get_config_path_default_production(self):
+        """Test default config path selection for production."""
+        with patch.dict("os.environ", {}, clear=True):
+            config_path = get_config_path()
+            assert config_path.name == "logging.yaml"
+            assert config_path.exists()
+
+    def test_get_config_path_environment_specific(self):
+        """Test environment-specific config path selection."""
+        # Test dev environment
+        with patch.dict("os.environ", {"WCT_ENV": "dev"}):
+            config_path = get_config_path()
+            expected = get_project_root() / "config" / "logging-dev.yaml"
+            assert config_path == expected
+
+        # Test test environment
+        with patch.dict("os.environ", {"WCT_ENV": "test"}):
+            config_path = get_config_path()
+            expected = get_project_root() / "config" / "logging-test.yaml"
+            assert config_path == expected
+
+    def test_get_config_path_fallback_to_default(self):
+        """Test fallback to default config when environment-specific doesn't exist."""
+        with patch.dict("os.environ", {"WCT_ENV": "nonexistent"}):
+            config_path = get_config_path()
+            assert config_path.name == "logging.yaml"
+
+    def test_get_config_path_explicit_environment(self):
+        """Test explicit environment parameter overrides env var."""
+        with patch.dict("os.environ", {"WCT_ENV": "dev"}):
+            config_path = get_config_path(environment="test")
+            expected = get_project_root() / "config" / "logging-test.yaml"
+            assert config_path == expected
+
+    def test_get_config_path_nonexistent_raises_error(self):
+        """Test that nonexistent config files raise LoggingError."""
+        with patch("wct.logging.get_project_root") as mock_root:
+            mock_root.return_value = Path("/nonexistent")
+            with pytest.raises(LoggingError, match="No logging configuration found"):
+                get_config_path()
+
+    def test_load_config_valid_yaml(self):
+        """Test loading valid YAML configuration."""
+        config_path = get_project_root() / "config" / "logging.yaml"
+        config = load_config(config_path)
+
+        assert isinstance(config, dict)
+        assert "version" in config
+        assert "handlers" in config
+        assert "loggers" in config
+        assert config["version"] == 1
+
+    def test_load_config_invalid_yaml_raises_error(self):
+        """Test that invalid YAML raises LoggingError."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("invalid: yaml: content: [")
+            f.flush()
+
+            with pytest.raises(LoggingError, match="Failed to parse YAML config"):
+                load_config(Path(f.name))
+
+            Path(f.name).unlink()
+
+    def test_load_config_nonexistent_file_raises_error(self):
+        """Test that nonexistent file raises LoggingError."""
+        with pytest.raises(LoggingError, match="Failed to read config file"):
+            load_config(Path("/nonexistent/config.yaml"))
+
+    def test_create_log_directories_creates_missing_dirs(self):
+        """Test that log directories are created when missing."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            config = {
+                "handlers": {
+                    "file_handler": {"filename": str(temp_path / "logs" / "test.log")}
+                }
+            }
+
+            # Directory doesn't exist initially
+            log_dir = temp_path / "logs"
+            assert not log_dir.exists()
+
+            create_log_directories(config)
+
+            # Directory should now exist
+            assert log_dir.exists()
+            assert log_dir.is_dir()
+
+    def test_create_log_directories_handles_absolute_paths(self):
+        """Test that absolute log paths are handled correctly."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            abs_log_path = Path(temp_dir) / "absolute" / "test.log"
+            config = {"handlers": {"file_handler": {"filename": str(abs_log_path)}}}
+
+            create_log_directories(config)
+
+            assert abs_log_path.parent.exists()
+
+
+class TestLoggingSetup:
+    """Test logging setup and level override functionality."""
+
+    def test_setup_logging_default_configuration(self, caplog):
+        """Test default logging setup loads configuration."""
+        with caplog.at_level(logging.INFO):
+            setup_logging()
+
+        # Should have configured logging from default config
+        # Note: The message appears in stdout via Rich handler, not in caplog
+        # So we test that setup_logging completes without error
+        assert True  # If we get here, setup_logging() succeeded
+
+    def test_setup_logging_level_override_updates_loggers(self):
+        """Test that level override correctly updates logger levels."""
+        # Create a temporary config with known logger
+        config = {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "handlers": {
+                "console": {"class": "logging.StreamHandler", "level": "INFO"}
+            },
+            "loggers": {"test_logger": {"level": "INFO", "handlers": ["console"]}},
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            f.flush()
+
+            try:
+                # Setup with DEBUG override
+                setup_logging(config_path=f.name, level="DEBUG")
+
+                # Check that logger level was updated
+                test_logger = logging.getLogger("test_logger")
+                assert test_logger.level == logging.DEBUG
+
+            finally:
+                Path(f.name).unlink()
+
+    def test_setup_logging_handler_level_override(self):
+        """Test that handler levels are lowered when logger level is more verbose."""
+        config = {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "level": "INFO",  # Handler at INFO level
+                }
+            },
+            "loggers": {"test_logger": {"level": "INFO", "handlers": ["console"]}},
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            f.flush()
+
+            try:
+                # Setup with DEBUG override (more verbose than INFO)
+                setup_logging(config_path=f.name, level="DEBUG")
+
+                # Get the actual handler that was configured
+                test_logger = logging.getLogger("test_logger")
+                handler = test_logger.handlers[0] if test_logger.handlers else None
+
+                # Handler level should have been lowered to DEBUG
+                assert handler is not None
+                assert handler.level == logging.DEBUG
+
+            finally:
+                Path(f.name).unlink()
+
+    def test_setup_logging_handler_level_not_raised(self):
+        """Test that handler levels are not raised when logger level is less verbose."""
+        config = {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "level": "DEBUG",  # Handler at DEBUG level
+                }
+            },
+            "loggers": {"test_logger": {"level": "DEBUG", "handlers": ["console"]}},
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            f.flush()
+
+            try:
+                # Setup with WARNING override (less verbose than DEBUG)
+                setup_logging(config_path=f.name, level="WARNING")
+
+                # Get the actual handler that was configured
+                test_logger = logging.getLogger("test_logger")
+                handler = test_logger.handlers[0] if test_logger.handlers else None
+
+                # Handler level should remain at DEBUG (not raised to WARNING)
+                assert handler is not None
+                assert handler.level == logging.DEBUG
+
+            finally:
+                Path(f.name).unlink()
+
+    def test_setup_logging_invalid_level_falls_back(self, capsys):
+        """Test that invalid log levels fall back to basic logging."""
+        setup_logging(level="INVALID")
+
+        # Should have fallen back to basic logging - check output contains warning
+        # (Rich handler displays it in formatted output)
+        captured = capsys.readouterr()
+        assert "Failed to configure logging" in captured.out
+
+    def test_setup_logging_fallback_on_config_error(self, capsys):
+        """Test fallback to basic logging when config fails."""
+        # Try to setup with nonexistent config
+        setup_logging(config_path="/nonexistent/config.yaml", level="INFO")
+
+        # Should have fallen back to basic logging - check output contains warning
+        captured = capsys.readouterr()
+        output = (
+            (captured.out + captured.err).lower().replace(" ", "").replace("\n", "")
+        )
+        assert "consolelogging" in output
+
+    def test_setup_logging_force_basic_mode(self):
+        """Test force_basic parameter bypasses config loading."""
+        # Clear any existing handlers to avoid interference
+        root_logger = logging.getLogger()
+        original_handlers = root_logger.handlers[:]
+        root_logger.handlers.clear()
+
+        try:
+            setup_logging(force_basic=True, level="DEBUG")
+
+            # Should have working basic logging at DEBUG level
+            logger = logging.getLogger("test.basic")
+
+            # The basic logging should be configured
+            assert logger.isEnabledFor(logging.DEBUG)
+
+        finally:
+            # Restore original handlers
+            root_logger.handlers = original_handlers
+
+
+class TestEnvironmentIntegration:
+    """Test environment-specific logging behavior."""
+
+    def test_development_environment_uses_dev_config(self):
+        """Test that development environment uses logging-dev.yaml."""
+        with patch.dict("os.environ", {"WCT_ENV": "development"}):
+            config_path = get_config_path()
+            expected = get_project_root() / "config" / "logging-dev.yaml"
+            assert config_path == expected
+
+    def test_production_environment_uses_prod_config(self):
+        """Test that production environment uses logging-prod.yaml if available."""
+        with patch.dict("os.environ", {"WCT_ENV": "production"}):
+            config_path = get_config_path()
+            # Falls back to logging.yaml since logging-prod.yaml doesn't exist
+            expected = get_project_root() / "config" / "logging.yaml"
+            assert config_path == expected
+
+    def test_unknown_environment_uses_default_config(self):
+        """Test that unknown environments fall back to default config."""
+        with patch.dict("os.environ", {"WCT_ENV": "staging"}):
+            config_path = get_config_path()
+            expected = get_project_root() / "config" / "logging.yaml"
+            assert config_path == expected
+
+
+# Integration test that mimics the verbose flag functionality
+class TestVerboseFlagIntegration:
+    """Integration tests for verbose flag functionality."""
+
+    def test_verbose_flag_enables_debug_logging(self):
+        """Test that verbose flag (DEBUG level) enables debug messages."""
+        # Clear any existing handlers
+        root_logger = logging.getLogger()
+        original_handlers = root_logger.handlers[:]
+        original_level = root_logger.level
+        root_logger.handlers.clear()
+
+        try:
+            # Setup logging with DEBUG level (simulating --verbose)
+            setup_logging(level="DEBUG", force_basic=True)
+
+            # Check that root logger is set to DEBUG level
+            assert root_logger.level == logging.DEBUG
+
+        finally:
+            # Restore original state
+            root_logger.handlers = original_handlers
+            root_logger.level = original_level
+
+    def test_non_verbose_mode_filters_debug_messages(self):
+        """Test that non-verbose mode (INFO level) filters out debug messages."""
+        # Clear any existing handlers
+        root_logger = logging.getLogger()
+        original_handlers = root_logger.handlers[:]
+        root_logger.handlers.clear()
+
+        try:
+            # Setup logging with INFO level (simulating normal mode)
+            setup_logging(level="INFO", force_basic=True)
+
+            # Create a test logger and verify DEBUG is filtered out
+            test_logger = logging.getLogger("wct.test.normal")
+            assert not test_logger.isEnabledFor(logging.DEBUG)
+            assert test_logger.isEnabledFor(logging.INFO)
+
+        finally:
+            # Restore original handlers
+            root_logger.handlers = original_handlers


### PR DESCRIPTION
## Summary
This PR completely refactors WCT's logging system to use Python standard practices with `dictConfig()` and YAML configuration files. This migration addresses issue #38 by replacing custom logging functions with standard Python patterns and fixing the verbose flag functionality.

## Changes Made

### 🔄 **Core Logging System Migration**
- **Replaced custom logging functions** (`get_executor_logger`, `get_cli_logger`, etc.) with standard `logging.getLogger(__name__)` pattern
- **Implemented `dictConfig()`** with YAML configuration files for centralized logging setup
- **Added environment-specific configurations**: dev, test, and production logging configs
- **Fixed verbose flag functionality** that was broken during previous changes

### 📁 **Configuration System**
- **`config/logging.yaml`** - Production logging with Rich console output and rotating file logs
- **`config/logging-dev.yaml`** - Development config with debug level and enhanced Rich formatting  
- **`config/logging-test.yaml`** - Minimal test configuration showing warnings/errors only
- **`config/README.md`** - Comprehensive documentation for logging configuration system

### 🧪 **Testing & Validation**
- **`tests/wct/test_logging.py`** - Comprehensive test suite with 26 tests covering:
  - Project root discovery from different contexts (importlib + marker search)
  - Configuration loading and environment-specific selection
  - Level overrides and verbose flag functionality validation
  - Fallback mechanisms and error handling
  - Handler level management for proper message filtering

### 🔧 **Technical Implementation**
- **Robust project root discovery** using industry-standard 2-method approach (importlib + marker search)
- **Proper handler level management** to fix verbose flag issues where handlers filter messages
- **Automatic environment detection** via `WCT_ENV` variable with sensible fallbacks
- **Type safety** with proper annotations and cast usage for YAML data
- **Error handling** with fallback to basic logging when configuration fails

## Codebase Migration Details

**Updated Components:**
- `src/wct/logging.py` - Complete rewrite using Python-standard dictConfig()
- `src/wct/cli.py` - Migrated from custom to standard logging
- `src/wct/executor.py` - Updated to use standard logging patterns
- All connectors, analysers, and rulesets - Migrated to `logging.getLogger(__name__)`

**Key Technical Fixes:**
- **Verbose flag issue**: Fixed by updating both logger and handler levels when overriding
- **Project root detection**: Simplified from 3 methods to industry-standard 2 methods
- **Type checking**: All files pass strict type checking with zero errors

## Test Results
✅ **All 26 new logging tests pass**  
✅ **Verbose flag functionality verified working**  
✅ **Type checker passes with zero errors**  
✅ **Integration testing confirms proper debug output in verbose mode**  
✅ **Pre-commit hooks pass (formatting, linting, type checking)**

## Environment Usage Examples

**Development with debug logging:**
```bash
export WCT_ENV=dev
uv run wct run runbooks/samples/file_content_analysis.yaml -v
```

**Test environment (minimal output):**
```bash
export WCT_ENV=test  
uv run wct run runbooks/samples/file_content_analysis.yaml
```

**Production (default):**
```bash
uv run wct run runbooks/samples/file_content_analysis.yaml
```

## Breaking Changes
- **Removed custom logging functions** - Components now use standard `logging.getLogger(__name__)`
- **Configuration location** - Logging configs moved to `config/` directory
- **Log file location** - Logs now written to `logs/` directory

## Backwards Compatibility
- **CLI interface unchanged** - All commands work exactly as before
- **Environment variables** - Existing env vars continue to work
- **Fallback mechanisms** - System falls back to basic logging if configuration fails

Fixes #38

## Checklist
- [x] Migration from custom logging to Python-standard dictConfig()
- [x] Environment-specific YAML configuration files created
- [x] Verbose flag functionality restored and tested
- [x] Comprehensive test suite added (26 tests)
- [x] All components migrated to standard logging patterns
- [x] Type checking passes with strict mode
- [x] Documentation updated
- [x] Pre-commit hooks pass