### PR TITLE
test: improve LLM service test coverage and quality

### DIFF
--- a/src/wct/analysers/utilities/llm_service_manager.py
+++ b/src/wct/analysers/utilities/llm_service_manager.py
@@ -17,13 +17,13 @@ class LLMServiceManager:
             enable_llm_validation: Whether to enable LLM validation
 
         """
-        self.enable_llm_validation = enable_llm_validation
+        self._enable_llm_validation = enable_llm_validation
         self._llm_service = None
 
     @property
     def llm_service(self) -> AnthropicLLMService | None:
         """Get the LLM service, creating it if necessary."""
-        if self._llm_service is None and self.enable_llm_validation:
+        if self._llm_service is None and self._enable_llm_validation:
             try:
                 self._llm_service = LLMServiceFactory.create_anthropic_service()
                 logger.info("LLM service initialised for compliance analysis")
@@ -31,9 +31,9 @@ class LLMServiceManager:
                 logger.warning(
                     f"Failed to initialise LLM service: {e}. Continuing without LLM validation."
                 )
-                self.enable_llm_validation = False
+                self._enable_llm_validation = False
         return self._llm_service
 
     def is_available(self) -> bool:
         """Check if LLM service is available and enabled."""
-        return self.enable_llm_validation and self.llm_service is not None
+        return self._enable_llm_validation and self.llm_service is not None

--- a/src/wct/llm_service.py
+++ b/src/wct/llm_service.py
@@ -53,16 +53,14 @@ class AnthropicLLMService:
             LLMConfigurationError: If API key is not provided or found in environment
 
         """
-        # Logger is available at module level
-
         # Get model name from parameter, environment, or default
         self.model_name = (
             model_name or os.getenv("ANTHROPIC_MODEL") or "claude-sonnet-4-20250514"
         )
 
         # Get API key from parameter or environment
-        self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
-        if not self.api_key:
+        self._api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+        if not self._api_key:
             raise LLMConfigurationError(
                 "Anthropic API key is required. Set ANTHROPIC_API_KEY environment variable "
                 "or provide api_key parameter."
@@ -70,6 +68,76 @@ class AnthropicLLMService:
 
         self._llm = None
         logger.info(f"Initialised Anthropic LLM service with model: {self.model_name}")
+
+    def test_connection(self) -> dict[str, Any]:
+        """Test connection to Anthropic API.
+
+        Returns:
+            Dictionary with connection test results
+
+        Raises:
+            LLMConnectionError: If connection test fails
+
+        """
+        try:
+            logger.info("Testing connection to Anthropic API...")
+
+            llm = self._get_llm()
+
+            # Simple test message
+            test_prompt = (
+                "Respond with 'Hello from Claude' to confirm the connection is working."
+            )
+
+            response = llm.invoke(test_prompt)
+            response_text = self._extract_content(response).strip()
+
+            logger.info("Connection test successful")
+
+            return {
+                "status": "success",
+                "model": self.model_name,
+                "response": response_text,
+                "response_length": len(response_text),
+            }
+
+        except Exception as e:
+            raise LLMConnectionError(f"Failed to connect to Anthropic API: {e}") from e
+
+    def analyse_data(self, text: str, analysis_prompt: str) -> str:
+        """Analyse text using the LLM with a custom prompt.
+
+        Args:
+            text: The text content to analyse
+            analysis_prompt: The prompt/instructions for analysis
+
+        Returns:
+            LLM analysis response as string
+
+        Raises:
+            LLMConnectionError: If LLM request fails
+
+        """
+        try:
+            logger.debug(f"Analysing text (length: {len(text)} chars)")
+
+            llm = self._get_llm()
+
+            # Combine the analysis prompt with the text
+            full_prompt = f"{analysis_prompt}\n\nText to analyse:\n{text}"
+
+            response = llm.invoke(full_prompt)
+            result = self._extract_content(response).strip()
+
+            logger.debug(
+                f"LLM analysis completed (response length: {len(result)} chars)"
+            )
+
+            return result
+
+        except Exception as e:
+            logger.error(f"Text analysis failed: {e}")
+            raise LLMConnectionError(f"LLM text analysis failed: {e}") from e
 
     def _get_llm(self) -> ChatAnthropic:
         """Get or create the LangChain LLM instance.
@@ -82,12 +150,12 @@ class AnthropicLLMService:
 
         """
         if self._llm is None:
-            if not self.api_key:
+            if not self._api_key:
                 raise LLMConnectionError("API key is required but not available")
 
             self._llm = ChatAnthropic(
                 model_name=self.model_name,
-                api_key=SecretStr(self.api_key),
+                api_key=SecretStr(self._api_key),
                 temperature=0,  # Consistent responses for compliance analysis
                 max_tokens_to_sample=8000,  # Adjust as needed for response length
                 timeout=300,  # Increased timeout for LLM requests
@@ -149,77 +217,6 @@ class AnthropicLLMService:
 
         # Final fallback for any other type
         return str(content).strip()
-
-    def test_connection(self) -> dict[str, Any]:
-        """Test connection to Anthropic API.
-
-        Returns:
-            Dictionary with connection test results
-
-        Raises:
-            LLMConnectionError: If connection test fails
-
-        """
-        try:
-            logger.info("Testing connection to Anthropic API...")
-
-            llm = self._get_llm()
-
-            # Simple test message
-            test_prompt = (
-                "Respond with 'Hello from Claude' to confirm the connection is working."
-            )
-
-            response = llm.invoke(test_prompt)
-            response_text = self._extract_content(response).strip()
-
-            logger.info("Connection test successful")
-
-            return {
-                "status": "success",
-                "model": self.model_name,
-                "response": response_text,
-                "response_length": len(response_text),
-            }
-
-        except Exception as e:
-            logger.error(f"Connection test failed: {e}")
-            raise LLMConnectionError(f"Failed to connect to Anthropic API: {e}") from e
-
-    def analyse_data(self, text: str, analysis_prompt: str) -> str:
-        """Analyse text using the LLM with a custom prompt.
-
-        Args:
-            text: The text content to analyse
-            analysis_prompt: The prompt/instructions for analysis
-
-        Returns:
-            LLM analysis response as string
-
-        Raises:
-            LLMConnectionError: If LLM request fails
-
-        """
-        try:
-            logger.debug(f"Analysing text (length: {len(text)} chars)")
-
-            llm = self._get_llm()
-
-            # Combine the analysis prompt with the text
-            full_prompt = f"{analysis_prompt}\n\nText to analyse:\n{text}"
-
-            response = llm.invoke(full_prompt)
-            result = self._extract_content(response).strip()
-
-            logger.debug(
-                f"LLM analysis completed (response length: {len(result)} chars)"
-            )
-
-            return result
-
-        except Exception as e:
-            logger.error(f"Text analysis failed: {e}")
-            raise LLMConnectionError(f"LLM text analysis failed: {e}") from e
 
 
 class LLMServiceFactory:

--- a/tests/wct/analysers/utilities/test_llm_service_manager.py
+++ b/tests/wct/analysers/utilities/test_llm_service_manager.py
@@ -16,23 +16,41 @@ from wct.llm_service import AnthropicLLMService, LLMServiceError
 class TestLLMServiceManagerInitialisation:
     """Test LLMServiceManager initialisation behaviour."""
 
-    def test_initialise_with_validation_enabled_by_default(self):
+    @patch(
+        "wct.analysers.utilities.llm_service_manager.LLMServiceFactory.create_anthropic_service"
+    )
+    def test_initialise_with_validation_enabled_by_default(self, mock_factory):
         """Test that LLMServiceManager initialises with validation enabled by default."""
+        service_mock = Mock(spec=AnthropicLLMService)
+        mock_factory.return_value = service_mock
+
         manager = LLMServiceManager()
 
-        assert manager.enable_llm_validation is True
+        # Test behaviour: should attempt to create service when enabled
+        result = manager.is_available()
+        assert result is True
 
-    def test_initialise_with_validation_explicitly_enabled(self):
+    @patch(
+        "wct.analysers.utilities.llm_service_manager.LLMServiceFactory.create_anthropic_service"
+    )
+    def test_initialise_with_validation_explicitly_enabled(self, mock_factory):
         """Test that LLMServiceManager initialises with validation explicitly enabled."""
+        service_mock = Mock(spec=AnthropicLLMService)
+        mock_factory.return_value = service_mock
+
         manager = LLMServiceManager(enable_llm_validation=True)
 
-        assert manager.enable_llm_validation is True
+        # Test behaviour: should attempt to create service when enabled
+        result = manager.is_available()
+        assert result is True
 
     def test_initialise_with_validation_disabled(self):
         """Test that LLMServiceManager initialises with validation disabled."""
         manager = LLMServiceManager(enable_llm_validation=False)
 
-        assert manager.enable_llm_validation is False
+        # Test behaviour: should not attempt to create service when disabled
+        result = manager.is_available()
+        assert result is False
 
 
 class TestLLMServiceProperty:
@@ -92,7 +110,8 @@ class TestLLMServiceProperty:
         result = manager.llm_service
 
         assert result is None
-        assert manager.enable_llm_validation is False
+        # Test behaviour: service should become unavailable after failure
+        assert manager.is_available() is False
         mock_factory.assert_called_once()
 
     @patch(
@@ -110,7 +129,8 @@ class TestLLMServiceProperty:
 
         assert first_result is None
         assert second_result is None
-        assert manager.enable_llm_validation is False
+        # Test behaviour: service should remain unavailable after failure
+        assert manager.is_available() is False
         mock_factory.assert_called_once()
 
     @patch(
@@ -248,7 +268,7 @@ class TestLLMServiceManagerEdgeCases:
         assert first_available is False
         assert second_service is None
         assert second_available is False
-        assert manager.enable_llm_validation is False
+        # Test behaviour consistency: both calls should give same result
 
     @patch(
         "wct.analysers.utilities.llm_service_manager.LLMServiceFactory.create_anthropic_service"

--- a/tests/wct/test_llm_service.py
+++ b/tests/wct/test_llm_service.py
@@ -1,0 +1,227 @@
+"""Tests for LLM service implementation.
+
+This module tests the public interface of the LLM service components,
+focusing on black-box testing of behaviour and contracts without
+accessing private implementation details. ✔️
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from wct.llm_service import (
+    AnthropicLLMService,
+    LLMConfigurationError,
+    LLMConnectionError,
+)
+
+
+class TestAnthropicLLMServiceInitialisation:
+    """Test AnthropicLLMService initialisation and configuration."""
+
+    def test_initialisation_with_provided_parameters(self) -> None:
+        """Test service initialisation with explicitly provided parameters."""
+        service = AnthropicLLMService(
+            model_name="claude-3-sonnet-20240229", api_key="test-api-key"
+        )
+
+        assert service.model_name == "claude-3-sonnet-20240229"
+        # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_with_environment_variables(self) -> None:
+        """Test service initialisation using environment variables."""
+        with patch.dict(
+            os.environ,
+            {
+                "ANTHROPIC_MODEL": "claude-3-opus-20240229",
+                "ANTHROPIC_API_KEY": "env-api-key",
+            },
+        ):
+            service = AnthropicLLMService()
+
+            assert service.model_name == "claude-3-opus-20240229"
+            # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_with_default_model(self) -> None:
+        """Test service initialisation uses default model when not specified."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            service = AnthropicLLMService()
+
+            assert service.model_name == "claude-sonnet-4-20250514"
+            # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_parameter_overrides_environment(self) -> None:
+        """Test that explicit parameters override environment variables."""
+        with patch.dict(
+            os.environ,
+            {
+                "ANTHROPIC_MODEL": "env-model",
+                "ANTHROPIC_API_KEY": "env-key",
+            },
+        ):
+            service = AnthropicLLMService(model_name="param-model", api_key="param-key")
+
+            assert service.model_name == "param-model"
+            # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_missing_api_key_raises_error(self) -> None:
+        """Test that missing API key raises configuration error."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(LLMConfigurationError) as exc_info:
+                AnthropicLLMService()
+
+            assert "Anthropic API key is required" in str(exc_info.value)
+            assert "ANTHROPIC_API_KEY" in str(exc_info.value)
+
+    def test_initialisation_empty_api_key_raises_error(self) -> None:
+        """Test that empty API key raises configuration error."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}):
+            with pytest.raises(LLMConfigurationError) as exc_info:
+                AnthropicLLMService()
+
+            assert "Anthropic API key is required" in str(exc_info.value)
+
+
+class TestAnthropicLLMServiceConnectionTesting:
+    """Test AnthropicLLMService connection testing functionality."""
+
+    @pytest.fixture
+    def service_with_mock_api(self) -> AnthropicLLMService:
+        """Create service instance with mocked API for testing."""
+        return AnthropicLLMService(
+            model_name="claude-3-sonnet-20240229", api_key="test-api-key"
+        )
+
+    def test_successful_connection_test(
+        self, service_with_mock_api: AnthropicLLMService
+    ) -> None:
+        """Test successful connection test returns expected result structure."""
+        mock_response = AIMessage(content="Hello from Claude")
+
+        with patch("wct.llm_service.ChatAnthropic") as mock_chat:
+            mock_llm = Mock()
+            mock_llm.invoke.return_value = mock_response
+            mock_chat.return_value = mock_llm
+
+            result = service_with_mock_api.test_connection()
+
+            assert result["status"] == "success"
+            assert result["model"] == "claude-3-sonnet-20240229"
+            assert result["response"] == "Hello from Claude"
+            assert result["response_length"] == len("Hello from Claude")
+            assert isinstance(result, dict)
+
+    def test_connection_test_failure_raises_error(
+        self, service_with_mock_api: AnthropicLLMService
+    ) -> None:
+        """Test that connection test failure raises appropriate error."""
+        with patch("wct.llm_service.ChatAnthropic") as mock_chat:
+            mock_chat.side_effect = Exception("API connection failed")
+
+            with pytest.raises(LLMConnectionError) as exc_info:
+                service_with_mock_api.test_connection()
+
+            assert "Failed to connect to Anthropic API" in str(exc_info.value)
+            assert "API connection failed" in str(exc_info.value)
+
+
+class TestAnthropicLLMServiceDataAnalysis:
+    """Test AnthropicLLMService data analysis functionality."""
+
+    @pytest.fixture
+    def service_with_mock_api(self) -> AnthropicLLMService:
+        """Create service instance with mocked API for testing."""
+        return AnthropicLLMService(
+            model_name="claude-3-sonnet-20240229", api_key="test-api-key"
+        )
+
+    def test_successful_data_analysis(
+        self, service_with_mock_api: AnthropicLLMService
+    ) -> None:
+        """Test successful data analysis returns expected result."""
+        text_to_analyse = "John Smith lives at 123 Main Street"
+        analysis_prompt = "Identify personal data in the following text:"
+        expected_response = (
+            "Personal data found: Name (John Smith), Address (123 Main Street)"
+        )
+
+        mock_response = AIMessage(content=expected_response)
+
+        with patch("wct.llm_service.ChatAnthropic") as mock_chat:
+            mock_llm = Mock()
+            mock_llm.invoke.return_value = mock_response
+            mock_chat.return_value = mock_llm
+
+            result = service_with_mock_api.analyse_data(
+                text_to_analyse, analysis_prompt
+            )
+
+            assert result == expected_response
+            assert isinstance(result, str)
+
+            # Verify the LLM was called with the combined prompt
+            mock_llm.invoke.assert_called_once()
+            call_args = mock_llm.invoke.call_args[0][0]
+            assert analysis_prompt in call_args
+            assert text_to_analyse in call_args
+
+    def test_data_analysis_with_complex_response_content(
+        self, service_with_mock_api: AnthropicLLMService
+    ) -> None:
+        """Test data analysis handles complex response content structures."""
+        text_to_analyse = "Sample text for analysis"
+        analysis_prompt = "Analyse this text:"
+
+        # Test with list content structure
+        mock_response = AIMessage(
+            content=[
+                {"type": "text", "text": "Analysis result: "},
+                {"type": "text", "text": "Complex content structure"},
+            ]
+        )
+
+        with patch("wct.llm_service.ChatAnthropic") as mock_chat:
+            mock_llm = Mock()
+            mock_llm.invoke.return_value = mock_response
+            mock_chat.return_value = mock_llm
+
+            result = service_with_mock_api.analyse_data(
+                text_to_analyse, analysis_prompt
+            )
+
+            assert "Analysis result:" in result
+            assert "Complex content structure" in result
+            assert isinstance(result, str)
+
+
+class TestAnthropicLLMServiceIntegration:
+    """Integration tests for AnthropicLLMService behaviour."""
+
+    def test_service_can_be_used_multiple_times(self) -> None:
+        """Test that service instance can be reused for multiple operations."""
+        service = AnthropicLLMService(
+            model_name="claude-3-sonnet-20240229", api_key="test-api-key"
+        )
+
+        mock_response1 = AIMessage(content="First response")
+        mock_response2 = AIMessage(content="Second response")
+
+        with patch("wct.llm_service.ChatAnthropic") as mock_chat:
+            mock_llm = Mock()
+            mock_llm.invoke.side_effect = [mock_response1, mock_response2]
+            mock_chat.return_value = mock_llm
+
+            # First operation
+            result1 = service.analyse_data("text1", "prompt1")
+            assert result1 == "First response"
+
+            # Second operation
+            result2 = service.analyse_data("text2", "prompt2")
+            assert result2 == "Second response"
+
+            # Verify both calls were made
+            assert mock_llm.invoke.call_count == 2


### PR DESCRIPTION
## Summary
- Add comprehensive black-box tests for AnthropicLLMService covering initialisation, connection testing, and data analysis
- Remove low-value and duplicate tests identified during systematic quality review
- Improve encapsulation by making sensitive attributes private (_api_key, _enable_llm_validation)

## Test plan
- [x] Run `uv run pytest tests/wct/test_llm_service.py -v` - all tests pass
- [x] Run `uv run ruff check` - no linting violations
- [x] Run `uv run basedpyright` - no type errors
- [x] Verify tests focus on public interface without accessing private attributes