### PR TITLE
refactor: remove redundant is_available method from LLMServiceManager

### DIFF
--- a/src/wct/analysers/personal_data_analyser/analyser.py
+++ b/src/wct/analysers/personal_data_analyser/analyser.py
@@ -202,7 +202,7 @@ class PersonalDataAnalyser(Analyser):
         if not findings:
             return findings
 
-        if not self.llm_service_manager.is_available():
+        if self.llm_service_manager.llm_service is None:
             logger.warning("LLM service not available, skipping validation")
             return findings
 
@@ -210,10 +210,6 @@ class PersonalDataAnalyser(Analyser):
             logger.info(f"Starting LLM validation of {len(findings)} findings")
 
             llm_service = self.llm_service_manager.llm_service
-            if llm_service is None:
-                logger.warning("LLM service is None, returning unvalidated findings")
-                return findings
-
             validated_findings = personal_data_validation_strategy(
                 findings, self.config.llm_validation, llm_service
             )

--- a/src/wct/analysers/utilities/llm_service_manager.py
+++ b/src/wct/analysers/utilities/llm_service_manager.py
@@ -33,7 +33,3 @@ class LLMServiceManager:
                 )
                 self._enable_llm_validation = False
         return self._llm_service
-
-    def is_available(self) -> bool:
-        """Check if LLM service is available and enabled."""
-        return self._enable_llm_validation and self.llm_service is not None

--- a/tests/wct/analysers/personal_data_analyser/test_analyser.py
+++ b/tests/wct/analysers/personal_data_analyser/test_analyser.py
@@ -232,7 +232,7 @@ class TestPersonalDataAnalyser:
         ]
 
         # Mock LLM service manager
-        mock_llm_service_manager.is_available.return_value = True
+        mock_llm_service_manager.llm_service = Mock()
         with patch(
             "wct.analysers.personal_data_analyser.analyser.personal_data_validation_strategy",
             return_value=sample_findings,
@@ -285,7 +285,7 @@ class TestPersonalDataAnalyser:
         ]
 
         # Mock LLM service manager
-        mock_llm_service_manager.is_available.return_value = True
+        mock_llm_service_manager.llm_service = Mock()
         filtered_findings = [sample_findings[0]]  # Remove one finding
         with patch(
             "wct.analysers.personal_data_analyser.analyser.personal_data_validation_strategy",
@@ -330,7 +330,7 @@ class TestPersonalDataAnalyser:
         )
 
         mock_pattern_matcher.find_patterns.return_value = sample_findings
-        mock_llm_service_manager.is_available.return_value = False
+        mock_llm_service_manager.llm_service = None
 
         input_schema = StandardInputSchema()
         output_schema = PersonalDataFindingSchema()
@@ -359,7 +359,7 @@ class TestPersonalDataAnalyser:
 
         # Mock pattern matcher to return no findings
         mock_pattern_matcher.find_patterns.return_value = []
-        mock_llm_service_manager.is_available.return_value = True
+        mock_llm_service_manager.llm_service = Mock()
 
         input_schema = StandardInputSchema()
         output_schema = PersonalDataFindingSchema()
@@ -399,7 +399,7 @@ class TestPersonalDataAnalyser:
 
         # Mock pattern matcher to not be called for empty data
         mock_pattern_matcher.find_patterns.return_value = []
-        mock_llm_service_manager.is_available.return_value = True
+        mock_llm_service_manager.llm_service = Mock()
 
         input_schema = StandardInputSchema()
         output_schema = PersonalDataFindingSchema()
@@ -434,7 +434,7 @@ class TestPersonalDataAnalyser:
         )
 
         mock_pattern_matcher.find_patterns.return_value = []
-        mock_llm_service_manager.is_available.return_value = False
+        mock_llm_service_manager.llm_service = None
 
         input_schema = StandardInputSchema()
         output_schema = PersonalDataFindingSchema()


### PR DESCRIPTION
## Summary

- Removed redundant `is_available()` method from `LLMServiceManager` class
- Replaced all `is_available()` calls with direct `llm_service is not None` checks
- Updated test mocks to work with the new approach
- Eliminated unnecessary abstraction layer while maintaining all functionality

## Changes Made

- **`LLMServiceManager`**: Removed `is_available()` method entirely
- **`PersonalDataAnalyser`**: Updated LLM availability check and removed redundant null check
- **Tests**: Updated all mock configurations and assertions to use property directly

## Test Plan

- [x] All existing tests pass (380 tests)
- [x] Type checking passes with no errors
- [x] Linting passes
- [x] Pre-commit hooks pass
- [x] No breaking changes to public API functionality

## Breaking Changes

None - the `is_available()` method was not part of the public API used by external consumers.