### PR TITLE
Add GDPR Article 30(1)(a) organisation metadata to analysis exports

### DIFF
--- a/config/organisation.yaml
+++ b/config/organisation.yaml
@@ -1,0 +1,39 @@
+# Organisation Configuration
+# This file contains metadata about your organisation for privacy document generation.
+# Non-technical users can easily edit this file to update organisation information.
+
+data_controller:
+  name: "Waivern Ltd"
+  company_nr: "16345663802"
+  address: "Solbakken Alle 24D, 1086, Oslo, Norway"
+  contact_email: "info@waivern.com"
+  trading_name: ""  # Leave empty if same as company name
+  jurisdictions:
+    - "EU"
+    - "UK"
+
+# Optional
+joint_controller:
+  name: "Jean Dow"
+  processing_purposes: "Personal Data Collection"
+  contact_email: "jean.dow@waivern.com"
+  contact_address: "Solbakken Alle 24D, 1086, Oslo, Norway"
+
+# Optional
+eu_uk_representative:
+  company_name: "John Dow"
+  contact_email: "john.dow@waivern.com"
+  contact_address: "21 East Street, London, UK"
+
+dpo:
+  name: "Vincent G Nunan"
+  contact_email: "vincent.nunan@waivern.com"
+  contact_address: "Solbakken Alle 24D, 1086, Oslo"
+
+privacy_contact:
+  email: "info@waivern.com"
+
+data_retention:
+  general_rule: "18 months from creation"
+  exceptions:
+    financial_records: "6 years (legal obligation)"

--- a/src/wct/organisation.py
+++ b/src/wct/organisation.py
@@ -1,0 +1,247 @@
+"""Organisation configuration loading for GDPR Article 30(1)(a) compliance.
+
+This module handles loading organisation metadata from config/organisation.yaml
+to include data controller information in WCT analysis exports as required
+by GDPR Article 30(1)(a) for records of processing activities.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Final
+
+import yaml
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
+
+from wct.utils import get_project_root
+
+logger = logging.getLogger(__name__)
+
+# Default organisation config file location
+ORGANISATION_CONFIG_PATH: Final[Path] = Path("config") / "organisation.yaml"
+
+
+class DataControllerConfig(BaseModel):
+    """Data controller information for GDPR compliance."""
+
+    name: str = Field(description="Legal name of the data controller organisation")
+    company_nr: str | None = Field(
+        default=None, description="Company registration number"
+    )
+    address: str = Field(description="Registered address of the data controller")
+    contact_email: str = Field(description="Contact email for data protection queries")
+    trading_name: str | None = Field(
+        default=None, description="Trading name if different from legal name"
+    )
+    jurisdictions: list[str] = Field(
+        default_factory=list,
+        description="List of jurisdictions where the controller operates",
+    )
+
+
+class JointControllerConfig(BaseModel):
+    """Joint controller information if applicable."""
+
+    name: str = Field(description="Name of the joint controller")
+    processing_purposes: str = Field(
+        description="Description of joint processing purposes"
+    )
+    contact_email: str = Field(description="Contact email for the joint controller")
+    contact_address: str = Field(description="Contact address for the joint controller")
+
+
+class EuUkRepresentativeConfig(BaseModel):
+    """EU/UK representative information for non-EU controllers."""
+
+    company_name: str = Field(description="Name of the EU/UK representative")
+    contact_email: str = Field(description="Contact email for the representative")
+    contact_address: str = Field(description="Contact address for the representative")
+
+
+class DpoConfig(BaseModel):
+    """Data Protection Officer information."""
+
+    name: str = Field(description="Name of the Data Protection Officer")
+    contact_email: str = Field(description="DPO contact email")
+    contact_address: str = Field(description="DPO contact address")
+
+
+class PrivacyContactConfig(BaseModel):
+    """Privacy contact information for data subjects."""
+
+    email: str = Field(
+        description="Email for privacy-related queries from data subjects"
+    )
+
+
+class DataRetentionConfig(BaseModel):
+    """Data retention policy information."""
+
+    general_rule: str = Field(description="General data retention rule")
+    exceptions: dict[str, str] = Field(
+        default_factory=dict,
+        description="Specific retention exceptions for different data categories",
+    )
+
+
+class OrganisationConfig(BaseModel):
+    """Complete organisation configuration for GDPR compliance.
+
+    This model represents the organisation metadata required for GDPR
+    Article 30(1)(a) compliance in WCT analysis exports.
+    """
+
+    data_controller: DataControllerConfig = Field(
+        description="Data controller information (required for GDPR Article 30(1)(a))"
+    )
+    joint_controller: JointControllerConfig | None = Field(
+        default=None, description="Joint controller information if applicable"
+    )
+    eu_uk_representative: EuUkRepresentativeConfig | None = Field(
+        default=None,
+        description="EU/UK representative for controllers outside EU/UK jurisdiction",
+    )
+    dpo: DpoConfig | None = Field(
+        default=None, description="Data Protection Officer information"
+    )
+    privacy_contact: PrivacyContactConfig | None = Field(
+        default=None, description="Privacy contact for data subjects"
+    )
+    data_retention: DataRetentionConfig | None = Field(
+        default=None, description="Data retention policy information"
+    )
+
+    @model_validator(mode="after")
+    def validate_controller_requirements(self) -> Self:
+        """Validate GDPR Article 30(1)(a) requirements."""
+        # Ensure data controller has minimum required information
+        if not self.data_controller.name.strip():
+            raise ValueError("Data controller name is required for GDPR compliance")
+        if not self.data_controller.address.strip():
+            raise ValueError("Data controller address is required for GDPR compliance")
+        if not self.data_controller.contact_email.strip():
+            raise ValueError(
+                "Data controller contact email is required for GDPR compliance"
+            )
+
+        return self
+
+    def to_export_metadata(self) -> dict[str, Any]:
+        """Convert to dictionary format suitable for analysis export metadata.
+
+        Returns:
+            Dictionary containing organisation information formatted for JSON export
+
+        """
+        export_data: dict[str, Any] = {
+            "data_controller": {
+                "name": self.data_controller.name,
+                "address": self.data_controller.address,
+                "contact_email": self.data_controller.contact_email,
+            }
+        }
+
+        # Add optional data controller fields
+        if self.data_controller.company_nr:
+            export_data["data_controller"]["company_nr"] = (
+                self.data_controller.company_nr
+            )
+        if self.data_controller.trading_name:
+            export_data["data_controller"]["trading_name"] = (
+                self.data_controller.trading_name
+            )
+        if self.data_controller.jurisdictions:
+            export_data["data_controller"]["jurisdictions"] = (
+                self.data_controller.jurisdictions
+            )
+
+        # Add joint controller if present
+        if self.joint_controller:
+            export_data["joint_controller"] = {
+                "name": self.joint_controller.name,
+                "processing_purposes": self.joint_controller.processing_purposes,
+                "contact_email": self.joint_controller.contact_email,
+                "contact_address": self.joint_controller.contact_address,
+            }
+
+        # Add EU/UK representative if present
+        if self.eu_uk_representative:
+            export_data["eu_uk_representative"] = {
+                "company_name": self.eu_uk_representative.company_name,
+                "contact_email": self.eu_uk_representative.contact_email,
+                "contact_address": self.eu_uk_representative.contact_address,
+            }
+
+        # Add DPO if present
+        if self.dpo:
+            export_data["dpo"] = {
+                "name": self.dpo.name,
+                "contact_email": self.dpo.contact_email,
+                "contact_address": self.dpo.contact_address,
+            }
+
+        # Add privacy contact if present
+        if self.privacy_contact:
+            export_data["privacy_contact"] = {"email": self.privacy_contact.email}
+
+        # Add data retention if present
+        if self.data_retention:
+            export_data["data_retention"] = {
+                "general_rule": self.data_retention.general_rule,
+                "exceptions": self.data_retention.exceptions,
+            }
+
+        return export_data
+
+
+class OrganisationLoader:
+    """Loads organisation configuration from YAML files."""
+
+    @classmethod
+    def load(cls) -> OrganisationConfig | None:
+        """Load organisation config from the project root directory.
+
+        Searches for config/organisation.yaml relative to the project root.
+
+        Returns:
+            OrganisationConfig instance if found and valid, None otherwise
+
+        """
+        config_path = None
+        try:
+            project_root = get_project_root()
+            config_path = project_root / ORGANISATION_CONFIG_PATH
+
+            if not config_path.exists():
+                logger.info(
+                    f"Organisation config not found at {config_path}. "
+                    "Analysis exports will not include organisation metadata."
+                )
+                return None
+
+            with config_path.open("r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+
+            # Pydantic will handle validation and provide clear error messages
+            org_config = OrganisationConfig.model_validate(data)
+            logger.info(
+                f"Loaded organisation config for: {org_config.data_controller.name}"
+            )
+            return org_config
+
+        except yaml.YAMLError as e:
+            logger.warning(f"Failed to parse YAML in {config_path}: {e}")
+            return None
+        except Exception as e:
+            logger.warning(
+                f"Could not determine project root or load organisation config: {e}"
+            )
+            return None
+
+
+class OrganisationConfigError(Exception):
+    """Exception raised for organisation configuration errors."""
+
+    pass

--- a/src/wct/utils.py
+++ b/src/wct/utils.py
@@ -1,0 +1,79 @@
+"""Utility functions for WCT project operations.
+
+This module provides common utility functions used across the WCT codebase,
+including project root discovery and other shared functionality.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+class ProjectUtilsError(Exception):
+    """Exception raised for project utility errors."""
+
+    pass
+
+
+def get_project_root() -> Path:
+    """Get the project root directory using robust discovery methods.
+
+    This function follows industry-standard approaches used by tools like pytest,
+    black, and setuptools to find the project root:
+    1. Package location via importlib (handles installed packages)
+    2. Upward search for project markers (handles development)
+
+    Returns:
+        Path to the project root directory
+
+    Raises:
+        ProjectUtilsError: If project root cannot be determined
+
+    """
+    # Method 1: Use package location if installed (preferred)
+    try:
+        spec = importlib.util.find_spec("wct")
+        if spec and spec.origin:
+            package_path = Path(spec.origin).parent
+
+            # For development installs, the package might be a symlink to src/wct
+            if package_path.is_symlink():
+                real_package = package_path.resolve()
+                if real_package.name == "wct" and real_package.parent.name == "src":
+                    potential_root = real_package.parent.parent
+                    if (potential_root / "src" / "wct" / "config").is_dir():
+                        return potential_root
+
+            # For regular installs, search upward from package location
+            for path in [package_path, *package_path.parents]:
+                if (path / "src" / "wct" / "config").is_dir():
+                    return path
+    except (ImportError, AttributeError):
+        # Package not found via importlib, continue to marker-based discovery
+        pass
+
+    # Method 2: Search upward from current file for project markers (development)
+    current_path = Path(__file__).parent.resolve()
+
+    for path in [current_path, *current_path.parents]:
+        # Look for common project root markers
+        markers = [
+            path / "pyproject.toml",  # Modern Python project file
+            path / "setup.py",  # Legacy setup file
+            path / ".git",  # Git repository root
+            path / "src" / "wct",  # Our package structure
+        ]
+
+        if any(marker.exists() for marker in markers):
+            # Verify this looks like our project by checking for src/wct/config/
+            if (path / "src" / "wct" / "config").is_dir():
+                return path
+
+    # If both methods fail, provide clear error message
+    raise ProjectUtilsError(
+        f"Could not determine project root. Searched:\n"
+        f"1. Package location via importlib.util.find_spec('wct')\n"
+        f"2. Upward from {current_path} for project markers\n"
+        f"Expected to find a directory containing 'src/wct/config/' subdirectory."
+    )

--- a/tests/wct/test_logging.py
+++ b/tests/wct/test_logging.py
@@ -13,10 +13,10 @@ from wct.logging import (
     LoggingError,
     create_log_directories,
     get_config_path,
-    get_project_root,
     load_config,
     setup_logging,
 )
+from wct.utils import get_project_root
 
 
 class TestLoggingConfiguration:

--- a/tests/wct/test_organisation.py
+++ b/tests/wct/test_organisation.py
@@ -1,0 +1,224 @@
+"""Tests for WCT organisation configuration functionality."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from wct.organisation import (
+    OrganisationConfig,
+    OrganisationLoader,
+)
+
+
+class TestOrganisationConfig:
+    """Test OrganisationConfig Pydantic model validation."""
+
+    def test_valid_organisation_config(self):
+        """Test that valid organisation config passes validation."""
+        config_data = {
+            "data_controller": {
+                "name": "Test Company Ltd",
+                "address": "123 Test Street, Test City, TC1 2AB",
+                "contact_email": "privacy@testcompany.com",
+                "company_nr": "12345678",
+                "jurisdictions": ["EU", "UK"],
+            },
+            "dpo": {
+                "name": "Jane Smith",
+                "contact_email": "dpo@testcompany.com",
+                "contact_address": "123 Test Street, Test City, TC1 2AB",
+            },
+        }
+
+        config = OrganisationConfig.model_validate(config_data)
+
+        assert config.data_controller.name == "Test Company Ltd"
+        assert config.data_controller.contact_email == "privacy@testcompany.com"
+        assert config.dpo is not None
+        assert config.dpo.name == "Jane Smith"
+
+    def test_minimal_valid_organisation_config(self):
+        """Test organisation config with only required fields."""
+        config_data = {
+            "data_controller": {
+                "name": "Minimal Company",
+                "address": "456 Minimal Ave",
+                "contact_email": "contact@minimal.com",
+            }
+        }
+
+        config = OrganisationConfig.model_validate(config_data)
+
+        assert config.data_controller.name == "Minimal Company"
+        assert config.joint_controller is None
+        assert config.dpo is None
+
+    def test_missing_required_fields_raises_validation_error(self):
+        """Test that missing required fields raise validation errors."""
+        config_data = {
+            "data_controller": {
+                "name": "Incomplete Company",
+                # Missing address and contact_email
+            }
+        }
+
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            OrganisationConfig.model_validate(config_data)
+
+    def test_empty_required_fields_raise_validation_error(self):
+        """Test that empty required fields raise validation errors."""
+        config_data = {
+            "data_controller": {
+                "name": "",  # Empty required field
+                "address": "123 Test Street",
+                "contact_email": "test@example.com",
+            }
+        }
+
+        with pytest.raises(ValueError, match="Data controller name is required"):
+            OrganisationConfig.model_validate(config_data)
+
+    def test_to_export_metadata_includes_all_sections(self):
+        """Test that to_export_metadata includes all configured sections."""
+        config_data = {
+            "data_controller": {
+                "name": "Full Company Ltd",
+                "address": "789 Full Street",
+                "contact_email": "full@company.com",
+                "company_nr": "987654321",
+                "jurisdictions": ["EU"],
+            },
+            "joint_controller": {
+                "name": "Joint Partner",
+                "processing_purposes": "Shared analytics",
+                "contact_email": "joint@partner.com",
+                "contact_address": "Joint Address",
+            },
+            "dpo": {
+                "name": "Data Officer",
+                "contact_email": "dpo@company.com",
+                "contact_address": "DPO Address",
+            },
+        }
+
+        config = OrganisationConfig.model_validate(config_data)
+        export_data = config.to_export_metadata()
+
+        assert "data_controller" in export_data
+        assert export_data["data_controller"]["name"] == "Full Company Ltd"
+        assert export_data["data_controller"]["company_nr"] == "987654321"
+
+        assert "joint_controller" in export_data
+        assert export_data["joint_controller"]["name"] == "Joint Partner"
+
+        assert "dpo" in export_data
+        assert export_data["dpo"]["name"] == "Data Officer"
+
+    def test_to_export_metadata_with_all_optional_sections(self):
+        """Test that to_export_metadata handles all optional organisation sections correctly."""
+        config_data = {
+            "data_controller": {
+                "name": "Complete Company Ltd",
+                "address": "Complete Address",
+                "contact_email": "complete@company.com",
+                "company_nr": "12345",
+                "trading_name": "Complete Corp",
+                "jurisdictions": ["EU", "UK"],
+            },
+            "joint_controller": {
+                "name": "Joint Partner",
+                "processing_purposes": "Joint processing",
+                "contact_email": "joint@partner.com",
+                "contact_address": "Joint Address",
+            },
+            "eu_uk_representative": {
+                "company_name": "EU Rep Ltd",
+                "contact_email": "eurep@company.com",
+                "contact_address": "EU Rep Address",
+            },
+            "dpo": {
+                "name": "DPO Name",
+                "contact_email": "dpo@company.com",
+                "contact_address": "DPO Address",
+            },
+            "privacy_contact": {"email": "privacy@company.com"},
+            "data_retention": {
+                "general_rule": "24 months",
+                "exceptions": {"financial": "7 years"},
+            },
+        }
+
+        config = OrganisationConfig.model_validate(config_data)
+        export_data = config.to_export_metadata()
+
+        # Verify all sections are present
+        assert "data_controller" in export_data
+        assert "joint_controller" in export_data
+        assert "eu_uk_representative" in export_data
+        assert "dpo" in export_data
+        assert "privacy_contact" in export_data
+        assert "data_retention" in export_data
+
+        # Verify data controller optional fields
+        assert export_data["data_controller"]["company_nr"] == "12345"
+        assert export_data["data_controller"]["trading_name"] == "Complete Corp"
+        assert export_data["data_controller"]["jurisdictions"] == ["EU", "UK"]
+
+        # Verify other sections have correct data
+        assert export_data["joint_controller"]["name"] == "Joint Partner"
+        assert export_data["eu_uk_representative"]["company_name"] == "EU Rep Ltd"
+        assert export_data["dpo"]["name"] == "DPO Name"
+        assert export_data["privacy_contact"]["email"] == "privacy@company.com"
+        assert export_data["data_retention"]["general_rule"] == "24 months"
+        assert export_data["data_retention"]["exceptions"]["financial"] == "7 years"
+
+
+class TestOrganisationLoader:
+    """Test OrganisationLoader functionality."""
+
+    @patch("wct.organisation.get_project_root")
+    def test_load_success(self, mock_get_root):
+        """Test successful loading from project root."""
+        # Create a temporary config file
+        config_data = {
+            "data_controller": {
+                "name": "Project Company",
+                "address": "Project Address",
+                "contact_email": "project@company.com",
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            config_dir = temp_path / "config"
+            config_dir.mkdir()
+
+            config_file = config_dir / "organisation.yaml"
+            with config_file.open("w") as f:
+                yaml.dump(config_data, f)
+
+            # Mock project root to return our temp directory
+            mock_get_root.return_value = temp_path
+
+            config = OrganisationLoader.load()
+            assert config is not None
+            assert config.data_controller.name == "Project Company"
+
+    @patch("wct.organisation.get_project_root")
+    def test_load_no_config_returns_none(self, mock_get_root):
+        """Test that load returns None when no config exists."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            mock_get_root.return_value = Path(temp_dir)
+            config = OrganisationLoader.load()
+            assert config is None
+
+    @patch("wct.organisation.get_project_root")
+    def test_load_handles_project_root_error(self, mock_get_root):
+        """Test that load handles project root discovery errors."""
+        mock_get_root.side_effect = Exception("Cannot find project root")
+
+        config = OrganisationLoader.load()
+        assert config is None


### PR DESCRIPTION
## Summary
- Implements organisation configuration system for GDPR Article 30(1)(a) compliance
- Adds organisation metadata to JSON analysis exports including data controller information
- Provides automatic config loading from `config/organisation.yaml`

## Changes
- New `OrganisationConfig` Pydantic model with comprehensive GDPR data controller fields
- `OrganisationLoader` with simplified API for loading configuration from project root
- Integration with `AnalysisResultsExporter` to include organisation metadata in exports
- Comprehensive test coverage with proper separation of concerns

## Testing
- 12 tests covering organisation functionality and analysis integration
- All existing tests pass with new functionality