### PR TITLE
Add timestamp collection to evidence items

### DIFF
--- a/src/wct/analysers/personal_data_analyser/analyser.py
+++ b/src/wct/analysers/personal_data_analyser/analyser.py
@@ -149,7 +149,7 @@ class PersonalDataAnalyser(Analyser):
         """
         # Convert models to dicts for final output
         validated_findings_dicts = [
-            finding.model_dump() for finding in validated_findings
+            finding.model_dump(mode="json") for finding in validated_findings
         ]
 
         result_data: dict[str, Any] = {

--- a/src/wct/analysers/personal_data_analyser/llm_validation_strategy.py
+++ b/src/wct/analysers/personal_data_analyser/llm_validation_strategy.py
@@ -212,7 +212,7 @@ def _convert_findings_for_prompt(
                 "risk_level": finding.risk_level,
                 "special_category": finding.special_category,
                 "matched_pattern": finding.matched_pattern,
-                "evidence": finding.evidence,
+                "evidence": [item.content for item in finding.evidence],
                 "metadata": finding.metadata,
             }
         )

--- a/src/wct/analysers/personal_data_analyser/types.py
+++ b/src/wct/analysers/personal_data_analyser/types.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import Self
 
 from wct.analysers.types import (
+    EvidenceItem,
     LLMValidationConfig,
     PatternMatchingConfig,
 )
@@ -62,9 +63,9 @@ class PersonalDataFindingModel(BaseModel):
     matched_pattern: str = Field(
         description="Specific pattern that matched in the content"
     )
-    evidence: list[str] | None = Field(
-        default=None,
-        description="Evidence snippets from content that matches this finding",
+    evidence: list[EvidenceItem] = Field(
+        min_length=1,
+        description="Evidence items with content and timestamps for this finding",
     )
     metadata: PersonalDataFindingMetadata | None = Field(
         default=None, description="Additional metadata from the original data source"

--- a/src/wct/analysers/processing_purpose_analyser/analyser.py
+++ b/src/wct/analysers/processing_purpose_analyser/analyser.py
@@ -174,7 +174,7 @@ class ProcessingPurposeAnalyser(Analyser):
 
         """
         # Convert models to dicts for JSON output
-        findings_dicts = [finding.model_dump() for finding in findings]
+        findings_dicts = [finding.model_dump(mode="json") for finding in findings]
 
         # Create result data with findings
         result_data: dict[str, Any] = {

--- a/src/wct/analysers/processing_purpose_analyser/source_code_schema_input_handler.py
+++ b/src/wct/analysers/processing_purpose_analyser/source_code_schema_input_handler.py
@@ -2,6 +2,7 @@
 
 from pydantic import BaseModel
 
+from wct.analysers.types import EvidenceItem
 from wct.rulesets import RulesetLoader
 from wct.rulesets.types import Rule
 from wct.schemas import (
@@ -205,8 +206,8 @@ class SourceCodeSchemaInputHandler:
         """
         # Create processing purpose finding evidence
         evidence = [
-            f"Line {line_num}: {rule.description} - {pattern}",
-            f"Code: {line.strip()}",
+            EvidenceItem(content=f"Line {line_num}: {rule.description} - {pattern}"),
+            EvidenceItem(content=f"Code: {line.strip()}"),
         ]
 
         # Create extra metadata fields
@@ -396,8 +397,8 @@ class SourceCodeSchemaInputHandler:
         # Extract matched text from evidence prefix (e.g., "Function: getUserByEmail" -> "getUserByEmail")
         matched_text = evidence_prefix.split(": ")[-1]
         evidence = [
-            f"{evidence_prefix}: {rule.description} - {pattern}",
-            f"Matched: {matched_text}",
+            EvidenceItem(content=f"{evidence_prefix}: {rule.description} - {pattern}"),
+            EvidenceItem(content=f"Matched: {matched_text}"),
         ]
 
         extra_metadata = {

--- a/src/wct/analysers/processing_purpose_analyser/types.py
+++ b/src/wct/analysers/processing_purpose_analyser/types.py
@@ -5,7 +5,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import Self
 
-from wct.analysers.types import LLMValidationConfig, PatternMatchingConfig
+from wct.analysers.types import EvidenceItem, LLMValidationConfig, PatternMatchingConfig
 
 
 class ProcessingPurposeAnalyserConfig(BaseModel):
@@ -59,8 +59,9 @@ class ProcessingPurposeFindingModel(BaseModel):
         description="Compliance frameworks this finding relates to",
     )
     matched_pattern: str = Field(description="Pattern that was matched")
-    evidence: list[str] = Field(
-        description="Evidence snippets that support the finding"
+    evidence: list[EvidenceItem] = Field(
+        min_length=1,
+        description="Evidence items with content and timestamps for this finding",
     )
     metadata: ProcessingPurposeFindingMetadata | None = Field(
         default=None, description="Additional metadata about the finding"

--- a/src/wct/analysers/types.py
+++ b/src/wct/analysers/types.py
@@ -1,8 +1,21 @@
 """Type definitions for analysers."""
 
+from datetime import datetime, timezone
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class EvidenceItem(BaseModel):
+    """Evidence item with content and collection timestamp."""
+
+    model_config = ConfigDict(ser_json_timedelta="iso8601")
+
+    content: str = Field(description="The evidence content snippet")
+    collection_timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="When the evidence was collected",
+    )
 
 
 class PatternMatchingConfig(BaseModel):

--- a/src/wct/schemas/json_schemas/personal_data_finding/1.0.0/personal_data_finding.json
+++ b/src/wct/schemas/json_schemas/personal_data_finding/1.0.0/personal_data_finding.json
@@ -28,11 +28,24 @@
             "description": "The specific pattern that was matched"
           },
           "evidence": {
-            "type": ["array", "null"],
+            "type": "array",
+            "minItems": 1,
             "items": {
-              "type": "string"
+              "type": "object",
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The evidence content snippet"
+                },
+                "collection_timestamp": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "ISO 8601 timestamp when the evidence was collected"
+                }
+              },
+              "required": ["content", "collection_timestamp"]
             },
-            "description": "Array of evidence snippets where the personal data was found"
+            "description": "Array of evidence objects with content and collection timestamps"
           },
           "metadata": {
             "type": "object",
@@ -47,7 +60,7 @@
             "required": ["source"]
           }
         },
-        "required": ["type", "risk_level", "special_category", "matched_pattern", "metadata"]
+        "required": ["type", "risk_level", "special_category", "matched_pattern", "evidence", "metadata"]
       }
     },
     "summary": {

--- a/src/wct/schemas/json_schemas/personal_data_finding/1.0.0/personal_data_finding.sample.json
+++ b/src/wct/schemas/json_schemas/personal_data_finding/1.0.0/personal_data_finding.sample.json
@@ -6,7 +6,12 @@
       "risk_level": "medium",
       "special_category": "N",
       "matched_pattern": "john.doe@company.com",
-      "evidence": ["the actual content of the email found in the employee data file"],
+      "evidence": [
+        {
+          "content": "the actual content of the email found in the employee data file",
+          "collection_timestamp": "2024-08-21T10:30:45.123Z"
+        }
+      ],
       "metadata": {
         "source": "employee_data.csv",
         "database": "hr_system",
@@ -20,7 +25,12 @@
       "risk_level": "low",
       "special_category": "N",
       "matched_pattern": "+1-555-123-4567",
-      "evidence": ["the actual content of the phone number found in the employee data file"],
+      "evidence": [
+        {
+          "content": "the actual content of the phone number found in the employee data file",
+          "collection_timestamp": "2024-08-21T10:31:22.456Z"
+        }
+      ],
       "metadata": {
         "source": "employee_data.csv",
         "file_path": "/data/employee_data.csv",
@@ -33,7 +43,12 @@
       "risk_level": "high",
       "special_category": "Y",
       "matched_pattern": "diabetes",
-      "evidence": ["the actual content of the health condition found in the medical records file"],
+      "evidence": [
+        {
+          "content": "the actual content of the health condition found in the medical records file",
+          "collection_timestamp": "2024-08-21T10:32:01.789Z"
+        }
+      ],
       "metadata": {
         "source": "medical_records.txt",
         "document_type": "medical_record",
@@ -46,7 +61,12 @@
       "risk_level": "high",
       "special_category": "Y",
       "matched_pattern": "ethnicity: Hispanic",
-      "evidence": ["the actual content of the ethnicity found in the HR forms file"],
+      "evidence": [
+        {
+          "content": "the actual content of the ethnicity found in the HR forms file",
+          "collection_timestamp": "2024-08-21T10:32:45.012Z"
+        }
+      ],
       "metadata": {
         "source": "hr_forms.pdf",
         "form_type": "employee_onboarding",
@@ -59,7 +79,12 @@
       "risk_level": "high",
       "special_category": "N",
       "matched_pattern": "123-45-6789",
-      "evidence": ["the actual content of the SSN found in the tax documents file"],
+      "evidence": [
+        {
+          "content": "the actual content of the SSN found in the tax documents file",
+          "collection_timestamp": "2024-08-21T10:33:18.345Z"
+        }
+      ],
       "metadata": {
         "source": "tax_documents.xlsx",
         "document_type": "tax_form",
@@ -72,7 +97,12 @@
       "risk_level": "medium",
       "special_category": "N",
       "matched_pattern": "4532-****-****-1234",
-      "evidence": ["the actual content of the credit card number found in the payment logs file"],
+      "evidence": [
+        {
+          "content": "the actual content of the credit card number found in the payment logs file",
+          "collection_timestamp": "2024-08-21T10:33:55.678Z"
+        }
+      ],
       "metadata": {
         "source": "payment_logs.txt",
         "system": "payment_processor",

--- a/src/wct/schemas/json_schemas/processing_purpose_finding/1.0.0/processing_purpose_finding.json
+++ b/src/wct/schemas/json_schemas/processing_purpose_finding/1.0.0/processing_purpose_finding.json
@@ -35,10 +35,23 @@
           },
           "evidence": {
             "type": "array",
+            "minItems": 1,
             "items": {
-              "type": "string"
+              "type": "object",
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The evidence content snippet"
+                },
+                "collection_timestamp": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "ISO 8601 timestamp when the evidence was collected"
+                }
+              },
+              "required": ["content", "collection_timestamp"]
             },
-            "description": "Evidence snippets that indicate this processing purpose"
+            "description": "Evidence objects with content and collection timestamps"
           },
           "metadata": {
             "type": "object",

--- a/src/wct/schemas/json_schemas/processing_purpose_finding/1.0.0/processing_purpose_finding.sample.json
+++ b/src/wct/schemas/json_schemas/processing_purpose_finding/1.0.0/processing_purpose_finding.sample.json
@@ -7,9 +7,18 @@
       "compliance_relevance": ["GDPR", "EU_AI_ACT", "NIST_AI_RMF"],
       "matched_pattern": "compliance",
       "evidence": [
-        "AI compliance framework implementation",
-        "regulatory compliance dashboard",
-        "ethics review process"
+        {
+          "content": "AI compliance framework implementation",
+          "collection_timestamp": "2024-08-21T10:35:15.123Z"
+        },
+        {
+          "content": "regulatory compliance dashboard",
+          "collection_timestamp": "2024-08-21T10:35:15.124Z"
+        },
+        {
+          "content": "ethics review process",
+          "collection_timestamp": "2024-08-21T10:35:15.125Z"
+        }
       ],
       "metadata": {
         "source": "source_code_analysis",
@@ -25,9 +34,18 @@
       "compliance_relevance": ["GDPR"],
       "matched_pattern": "authentication",
       "evidence": [
-        "login credentials validation",
-        "password hash storage",
-        "okta integration"
+        {
+          "content": "login credentials validation",
+          "collection_timestamp": "2024-08-21T10:36:22.456Z"
+        },
+        {
+          "content": "password hash storage",
+          "collection_timestamp": "2024-08-21T10:36:22.457Z"
+        },
+        {
+          "content": "okta integration",
+          "collection_timestamp": "2024-08-21T10:36:22.458Z"
+        }
       ],
       "metadata": {
         "source": "source_code_analysis",
@@ -43,9 +61,18 @@
       "compliance_relevance": ["GDPR", "CCPA", "CPRA"],
       "matched_pattern": "analytics",
       "evidence": [
-        "adobe analytics integration",
-        "user behavior tracking",
-        "product improvement metrics"
+        {
+          "content": "adobe analytics integration",
+          "collection_timestamp": "2024-08-21T10:37:05.789Z"
+        },
+        {
+          "content": "user behavior tracking",
+          "collection_timestamp": "2024-08-21T10:37:05.790Z"
+        },
+        {
+          "content": "product improvement metrics",
+          "collection_timestamp": "2024-08-21T10:37:05.791Z"
+        }
       ],
       "metadata": {
         "source": "third_party_integration",
@@ -61,9 +88,18 @@
       "compliance_relevance": ["GDPR", "CCPA", "CPRA"],
       "matched_pattern": "personalization",
       "evidence": [
-        "recommendation engine",
-        "user preferences tracking",
-        "dynamic yield optimisation"
+        {
+          "content": "recommendation engine",
+          "collection_timestamp": "2024-08-21T10:38:12.012Z"
+        },
+        {
+          "content": "user preferences tracking",
+          "collection_timestamp": "2024-08-21T10:38:12.013Z"
+        },
+        {
+          "content": "dynamic yield optimisation",
+          "collection_timestamp": "2024-08-21T10:38:12.014Z"
+        }
       ],
       "metadata": {
         "source": "feature_analysis",
@@ -79,9 +115,18 @@
       "compliance_relevance": ["GDPR", "ISO_27001", "SOC_2"],
       "matched_pattern": "fraud",
       "evidence": [
-        "transaction monitoring",
-        "scamalytics integration",
-        "abuse detection algorithms"
+        {
+          "content": "transaction monitoring",
+          "collection_timestamp": "2024-08-21T10:39:30.345Z"
+        },
+        {
+          "content": "scamalytics integration",
+          "collection_timestamp": "2024-08-21T10:39:30.346Z"
+        },
+        {
+          "content": "abuse detection algorithms",
+          "collection_timestamp": "2024-08-21T10:39:30.347Z"
+        }
       ],
       "metadata": {
         "source": "security_module",

--- a/tests/wct/analysers/personal_data_analyser/test_llm_validation_strategy.py
+++ b/tests/wct/analysers/personal_data_analyser/test_llm_validation_strategy.py
@@ -12,7 +12,7 @@ from wct.analysers.personal_data_analyser.types import (
     PersonalDataFindingMetadata,
     PersonalDataFindingModel,
 )
-from wct.analysers.types import LLMValidationConfig
+from wct.analysers.types import EvidenceItem, LLMValidationConfig
 from wct.llm_service import AnthropicLLMService
 
 
@@ -42,7 +42,7 @@ class TestPersonalDataValidationStrategy:
                 risk_level="medium",
                 special_category="N",
                 matched_pattern="test@example.com",
-                evidence=["Contact us at test@example.com"],
+                evidence=[EvidenceItem(content="Contact us at test@example.com")],
                 metadata=PersonalDataFindingMetadata(source="contact_form.php"),
             ),
             PersonalDataFindingModel(
@@ -50,7 +50,7 @@ class TestPersonalDataValidationStrategy:
                 risk_level="high",
                 special_category="N",
                 matched_pattern="123-456-7890",
-                evidence=["Call us at 123-456-7890"],
+                evidence=[EvidenceItem(content="Call us at 123-456-7890")],
                 metadata=PersonalDataFindingMetadata(source="customer_db"),
             ),
         ]
@@ -158,7 +158,7 @@ class TestPersonalDataValidationStrategy:
                 risk_level="low",
                 special_category="N",
                 matched_pattern="admin@domain.com",
-                evidence=["Email: admin@domain.com"],
+                evidence=[EvidenceItem(content="Email: admin@domain.com")],
                 metadata=PersonalDataFindingMetadata(source="config.txt"),
             ),
             PersonalDataFindingModel(
@@ -166,7 +166,7 @@ class TestPersonalDataValidationStrategy:
                 risk_level="high",
                 special_category="Y",
                 matched_pattern="123-45-6789",
-                evidence=["SSN: 123-45-6789"],
+                evidence=[EvidenceItem(content="SSN: 123-45-6789")],
                 metadata=PersonalDataFindingMetadata(source="employee_records"),
             ),
             PersonalDataFindingModel(
@@ -174,7 +174,7 @@ class TestPersonalDataValidationStrategy:
                 risk_level="medium",
                 special_category="N",
                 matched_pattern="user@test.com",
-                evidence=["Example: user@test.com"],
+                evidence=[EvidenceItem(content="Example: user@test.com")],
                 metadata=PersonalDataFindingMetadata(source="documentation.md"),
             ),
         ]
@@ -231,7 +231,7 @@ class TestPersonalDataValidationStrategy:
                 risk_level="medium",
                 special_category="N",
                 matched_pattern=f"user{i}@example.com",
-                evidence=[f"Email: user{i}@example.com"],
+                evidence=[EvidenceItem(content=f"Email: user{i}@example.com")],
                 metadata=PersonalDataFindingMetadata(source="database"),
             )
             for i in range(5)  # Create 5 findings
@@ -418,7 +418,8 @@ class TestPersonalDataValidationStrategy:
         assert result[1] is sample_findings[1]
         # Verify all properties are unchanged
         assert result[0].type == "email"
-        assert result[0].evidence == ["Contact us at test@example.com"]
+        assert len(result[0].evidence) == 1
+        assert result[0].evidence[0].content == "Contact us at test@example.com"
         assert result[1].type == "phone"
         assert result[1].metadata.source == "customer_db"
 
@@ -465,7 +466,7 @@ class TestPersonalDataValidationStrategy:
                 risk_level="medium",
                 special_category="N",
                 matched_pattern=f"test{i}@example.com",
-                evidence=[f"Email {i}"],
+                evidence=[EvidenceItem(content=f"Email {i}")],
                 metadata=PersonalDataFindingMetadata(source="test"),
             )
             for i in range(3)
@@ -521,7 +522,7 @@ class TestPersonalDataValidationStrategy:
                 risk_level="high",
                 special_category="N",
                 matched_pattern="4111-1111-1111-1111",
-                evidence=["Card: 4111-1111-1111-1111"],
+                evidence=[EvidenceItem(content="Card: 4111-1111-1111-1111")],
                 metadata=PersonalDataFindingMetadata(source="payment_form"),
             )
         ]
@@ -558,7 +559,7 @@ class TestPersonalDataValidationStrategy:
                 risk_level="medium",
                 special_category="N",
                 matched_pattern="+44 20 7946 0958",
-                evidence=["Contact: +44 20 7946 0958"],
+                evidence=[EvidenceItem(content="Contact: +44 20 7946 0958")],
                 metadata=PersonalDataFindingMetadata(source="customer_database"),
             )
         ]
@@ -611,7 +612,7 @@ class TestPersonalDataValidationStrategy:
                 risk_level="medium",
                 special_category="N",
                 matched_pattern=f"user{i}@test.com",
-                evidence=[f"Email: user{i}@test.com"],
+                evidence=[EvidenceItem(content=f"Email: user{i}@test.com")],
                 metadata=PersonalDataFindingMetadata(source="test"),
             )
             for i in range(3)


### PR DESCRIPTION
## Summary
- Replace evidence string arrays with EvidenceItem objects containing content and UTC timestamps
- Evidence is now mandatory with minimum 1 item requirement  
- Automatic timestamp generation via Pydantic default_factory
- Comprehensive test coverage for timestamp validation

## Changes Made
- **EvidenceItem Model**: New Pydantic model with auto-generated UTC timestamps
- **Schema Updates**: JSON schemas updated to require evidence objects with timestamps
- **Evidence Collection**: Refactored EvidenceExtractor and analyser evidence creation
- **Test Updates**: Updated 117 tests + added timestamp validation to 13 key tests
- **Sample Files**: Updated with new evidence structure and realistic timestamps

## Test Plan
- [x] All 117 existing tests pass
- [x] Evidence timestamps are automatically generated
- [x] Timestamps are in UTC timezone  
- [x] JSON serialization produces proper ISO 8601 format
- [x] Schema validation enforces new evidence structure