### PR TITLE
refactor: use model_validate() for external data validation in rulesets

### DIFF
--- a/src/wct/rulesets/data_collection.py
+++ b/src/wct/rulesets/data_collection.py
@@ -63,7 +63,7 @@ class DataCollectionRuleset(Ruleset):
             with yaml_file.open("r", encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
-            ruleset_data = RulesetData(**data)
+            ruleset_data = RulesetData.model_validate(data)
             self.rules = ruleset_data.to_rules()
             logger.debug(f"Loaded {len(self.rules)} data collection ruleset data")
 

--- a/src/wct/rulesets/personal_data.py
+++ b/src/wct/rulesets/personal_data.py
@@ -66,7 +66,7 @@ class PersonalDataRuleset(Ruleset):
             with yaml_file.open("r", encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
-            ruleset_data = RulesetData(**data)
+            ruleset_data = RulesetData.model_validate(data)
             self.rules = ruleset_data.to_rules()
             logger.debug(f"Loaded {len(self.rules)} personal data ruleset data")
 

--- a/src/wct/rulesets/processing_purposes.py
+++ b/src/wct/rulesets/processing_purposes.py
@@ -73,7 +73,7 @@ class ProcessingPurposesRuleset(Ruleset):
             with ruleset_file.open("r", encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
-            ruleset_data = RulesetData(**data)
+            ruleset_data = RulesetData.model_validate(data)
             self.rules = ruleset_data.to_rules()
             logger.debug(f"Loaded {len(self.rules)} processing purpose patterns")
 

--- a/src/wct/rulesets/service_integrations.py
+++ b/src/wct/rulesets/service_integrations.py
@@ -74,7 +74,7 @@ class ServiceIntegrationsRuleset(Ruleset):
             with ruleset_file.open("r", encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
-            ruleset_data = RulesetData(**data)
+            ruleset_data = RulesetData.model_validate(data)
             self.rules = ruleset_data.to_rules()
             logger.debug(f"Loaded {len(self.rules)} service integration patterns")
 


### PR DESCRIPTION
## Summary
- Replace `RulesetData(**data)` with `RulesetData.model_validate(data)` across all rulesets
- Improves error clarity when YAML validation fails
- Follows best practices for external data parsing used elsewhere in codebase

## Test plan
- [x] All 492 tests pass
- [x] Dev checks (linting, type checking, formatting) pass
- [x] No breaking changes to existing functionality