### PR TITLE
Fix runbook.json formatting inconsistency in linting

### DIFF
--- a/src/wct/schemas/json_schemas/runbook/1.0.0/runbook.json
+++ b/src/wct/schemas/json_schemas/runbook/1.0.0/runbook.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "version": "1.0.0",
   "$defs": {
     "AnalyserConfig": {
       "description": "Pydantic model for analyser configuration.",
@@ -201,7 +203,5 @@
     "execution"
   ],
   "title": "WCT Runbook",
-  "type": "object",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "version": "1.0.0"
+  "type": "object"
 }

--- a/src/wct/schemas/runbook.py
+++ b/src/wct/schemas/runbook.py
@@ -24,17 +24,20 @@ class RunbookSchemaGenerator:
         """
         schema = Runbook.model_json_schema()
 
-        # Add WCT-specific metadata
-        schema.update(
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "version": cls.SCHEMA_VERSION,
-                "title": "WCT Runbook",
-                "description": "Waivern Compliance Tool runbook configuration schema",
-            }
+        # Create new ordered dictionary with WCT-specific metadata at the beginning
+        ordered_schema = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "version": cls.SCHEMA_VERSION,
+            **schema,
+        }
+
+        # Update the title and description
+        ordered_schema["title"] = "WCT Runbook"
+        ordered_schema["description"] = (
+            "Waivern Compliance Tool runbook configuration schema"
         )
 
-        return schema
+        return ordered_schema
 
     @classmethod
     def save_schema(cls, output_path: Path) -> None:

--- a/tests/integration/test_schema_integration.py
+++ b/tests/integration/test_schema_integration.py
@@ -16,6 +16,7 @@ import json
 from pathlib import Path
 
 import jsonschema
+import pytest
 import yaml
 
 from wct.runbook import RunbookLoader
@@ -67,12 +68,15 @@ class TestSchemaIntegration:
 
     def test_bundled_schema_file_validates_samples(self) -> None:
         """Test that the bundled schema file validates sample runbooks."""
-        # Ensure bundled schema file exists
         bundled_path = RunbookSchemaGenerator.get_schema_path()
-        bundled_path.parent.mkdir(parents=True, exist_ok=True)
-        RunbookSchemaGenerator.save_schema(bundled_path)
 
-        # Load the bundled schema file
+        # Skip test if bundled schema doesn't exist
+        if not bundled_path.exists():
+            pytest.skip(
+                "Bundled schema file doesn't exist. Run 'wct generate-schema' first."
+            )
+
+        # Load the existing bundled schema file
         with open(bundled_path, encoding="utf-8") as f:
             bundled_schema = json.load(f)
 


### PR DESCRIPTION
## Summary

• Fixed issue where `runbook.json` was being reformatted on every linting run
• Resolved root cause: schema generation placing `$schema`/`version` properties inconsistently
• Updated integration test to stop unconditionally regenerating schema files during test runs

## Problem

The `end-of-file-fixer` pre-commit hook was alternating between adding/removing trailing newlines in `runbook.json` on consecutive runs, causing the file to be marked as modified after every `./scripts/dev-checks.sh` execution.

## Root Cause Analysis

1. **Schema Generation Issue**: `RunbookSchemaGenerator.generate_schema()` used `dict.update()` to add metadata properties, placing them at the end of the JSON object
2. **Test-Driven Regeneration**: Integration test `test_bundled_schema_file_validates_samples()` unconditionally called `RunbookSchemaGenerator.save_schema()` during every test run
3. **Property Order Inconsistency**: All other schema files had `$schema`/`version` at the beginning, but runbook.json had them at the end

## Solution

• **Schema Generation**: Modified to create ordered dictionary with metadata properties at the beginning, matching other schema files
• **Integration Test**: Changed to check file existence and skip test instead of regenerating schema file
• **Consistency**: Ensured all JSON schema files follow the same structure pattern

## Test Plan

- [x] Run `./scripts/dev-checks.sh` multiple times consecutively - no file modifications
- [x] Verify `runbook.json` has `$schema` and `version` at lines 2-3 (consistent with other schemas)
- [x] All existing tests pass including schema validation tests
- [x] Pre-commit hooks run cleanly without file modifications