### PR TITLE
Simplify dependency structure by removing optional groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,15 +48,9 @@ This is a Python project using `uv` for dependency management. Key commands:
 - `uv run wct generate-schema` - Generate JSON Schema for IDE support and validation
 - `uv run wct test-llm` - Test LLM connectivity and configuration
 
-**Dependency Groups:**
-WCT uses optional dependency groups for specific features:
-- `uv sync --group mysql` - Install MySQL connector dependencies (pymysql, cryptography)
-- `uv sync --group source-code` - Install source code analysis dependencies (tree-sitter, tree-sitter-php)
-- `uv sync --group dev` - Install development tools
-- `uv sync --group mysql --group source-code --group dev` - Install multiple groups
-
-**Core Dependencies:**
-LLM functionality (langchain, langchain-anthropic) is now included as core dependencies and available by default for AI-powered compliance analysis and validation.
+**Dependencies:**
+- All connector and analyser dependencies are included by default
+- `uv sync --group dev` - Install development tools only when needed for contributing
 
 **Logging Options:**
 All WCT commands support logging configuration:
@@ -127,7 +121,7 @@ execution:
 - **Quick start**: Begin with `uv run wct run runbooks/samples/file_content_analysis.yaml -v`
 
 ## Project Structure Notes
-- Uses `uv` for dependency management with optional dependency groups
+- Uses `uv` for dependency management with all dependencies included by default
 - **Core Dependencies:** `jsonschema` for comprehensive JSON schema validation, `langchain` and `langchain-anthropic` for AI-powered compliance analysis
 - Type annotations are enforced with `basedpyright` (schema system is fully type-safe)
 - Main package is `wct` located in `src/wct/`

--- a/README.md
+++ b/README.md
@@ -21,38 +21,24 @@ The system is designed to be extensible and configurable through YAML runbook fi
 
 ### Installation
 
-This project uses `uv` for dependency management with optional dependency groups for specific connectors and analysers:
+This project uses `uv` for dependency management:
 
 ```bash
-# Install core dependencies only
+# Install all dependencies
 uv sync
 
-# Install with specific connector/analyser dependencies
-uv sync --group mysql      # MySQL connector support
-uv sync --group source-code # Source code analysis support
-uv sync --group dev        # Development tools
-
-# Install multiple groups
-uv sync --group mysql --group source-code --group dev
+# Install with development tools
+uv sync --group dev
 
 # Install pre-commit hooks (recommended)
 uv run pre-commit install
 ```
 
-**Available Dependency Groups**:
-- `mysql` - MySQL connector dependencies (pymysql, cryptography)
-- `source-code` - Source code analysis dependencies (tree-sitter, tree-sitter-php)
-- `dev` - Development tools (pytest, ruff, basedpyright, etc.)
+**Dependencies**:
+- All connector and analyser dependencies are included by default
 
-**Core Dependencies**:
-- `jsonschema` - Data validation for component interoperability
-- `langchain` and `langchain-anthropic` - AI-powered compliance analysis and validation
-
-Some connectors and analysers require additional dependencies that are not installed by default. Check the connector/analyser documentation or error messages for specific dependency group requirements.
-
-**Notable Connectors**:
-- MySQL connector requires `uv sync --group mysql`
-- Source code connector requires `uv sync --group source-code`
+**Development Dependencies** (`--group dev`):
+- Testing and code quality tools
 
 ### Basic Usage
 
@@ -140,7 +126,7 @@ execution:
 - **Explicit connector-analyser mapping**: Clear data flow specification in execution steps
 - **Dynamic schema loading**: Flexible schema file discovery with multiple search paths
 - **End-to-end validation**: Full pipeline validation from runbook loading to analysis results
-- **Optional dependencies**: MySQL connector requires `uv sync --group mysql`, source code connector requires `uv sync --group source-code`
+- **All-inclusive dependencies**: All connector and analyser dependencies included by default
 
 ## IDE Support
 
@@ -202,7 +188,7 @@ Key features:
 ### Modular Architecture Benefits
 
 - **Schema Contracts**: Clear input/output schema declarations for all components
-- **Dependency Isolation**: Optional dependencies grouped by component (`uv sync --group mysql`)
+- **Complete Dependencies**: All connector and analyser dependencies included for immediate use
 - **Independent Testing**: Each module tested in isolation with comprehensive coverage
 - **Declarative Configuration**: YAML runbooks with comprehensive validation eliminate manual validation
 - **Type Safety**: Strongly typed interfaces with comprehensive error reporting
@@ -365,7 +351,7 @@ src/wct/
 ├── connectors/          # Data source extractors
 │   ├── base.py         # Abstract connector interface
 │   ├── filesystem/     # File content extraction
-│   └── mysql/          # Database analysis (requires --group mysql)
+│   └── mysql/          # Database analysis
 ├── analysers/          # Compliance analysis engines
 │   ├── base.py         # Abstract analyser interface
 │   └── personal_data_analyser/ # Personal data detection with LLM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ dependencies = [
     "typing-extensions>=4.14.0",
     "langchain>=0.3.0",
     "langchain-anthropic>=0.2.0",
+    "cryptography>=45.0.5",
+    "pymysql>=1.1.1",
+    "tree-sitter>=0.21.0",
+    "tree-sitter-php>=0.22.0",
 ]
 
 [project.scripts]
@@ -30,8 +34,6 @@ dev = [
     "pre-commit>=4.0.0",
     "mypy>=1.17.0",
 ]
-mysql = ["cryptography>=45.0.5", "pymysql>=1.1.1"]
-source-code = ["tree-sitter>=0.21.0", "tree-sitter-php>=0.22.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -1148,13 +1148,17 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },
+    { name = "cryptography" },
     { name = "jsonschema" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "pydantic" },
+    { name = "pymysql" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-php" },
     { name = "typer" },
     { name = "typing-extensions" },
 ]
@@ -1168,25 +1172,21 @@ dev = [
     { name = "pytest-mock" },
     { name = "ruff" },
 ]
-mysql = [
-    { name = "cryptography" },
-    { name = "pymysql" },
-]
-source-code = [
-    { name = "tree-sitter" },
-    { name = "tree-sitter-php" },
-]
 
 [package.metadata]
 requires-dist = [
     { name = "annotated-types", specifier = ">=0.7.0" },
+    { name = "cryptography", specifier = ">=45.0.5" },
     { name = "jsonschema", specifier = ">=4.25.0" },
     { name = "langchain", specifier = ">=0.3.0" },
     { name = "langchain-anthropic", specifier = ">=0.2.0" },
     { name = "pydantic", specifier = ">=2.11.5" },
+    { name = "pymysql", specifier = ">=1.1.1" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "tree-sitter", specifier = ">=0.21.0" },
+    { name = "tree-sitter-php", specifier = ">=0.22.0" },
     { name = "typer", specifier = ">=0.16.0" },
     { name = "typing-extensions", specifier = ">=4.14.0" },
 ]
@@ -1199,14 +1199,6 @@ dev = [
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "ruff", specifier = ">=0.11.12" },
-]
-mysql = [
-    { name = "cryptography", specifier = ">=45.0.5" },
-    { name = "pymysql", specifier = ">=1.1.1" },
-]
-source-code = [
-    { name = "tree-sitter", specifier = ">=0.21.0" },
-    { name = "tree-sitter-php", specifier = ">=0.22.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Move MySQL and source code dependencies from optional groups to core dependencies
- Remove mysql and source-code dependency groups, keeping only dev group  
- Update documentation to reflect simplified installation process

## Test plan
- [x] All tests pass
- [x] Development checks pass
- [x] Installation works with just uv sync