### PR TITLE
Modernise type annotations to Python 3.12+ syntax

### DIFF
--- a/src/wct/analysers/llm_validation/decision_engine.py
+++ b/src/wct/analysers/llm_validation/decision_engine.py
@@ -2,20 +2,17 @@
 
 import logging
 from collections.abc import Callable
-from typing import TypeVar
 
 from .models import LLMValidationResultModel
 
 logger = logging.getLogger(__name__)
-
-T = TypeVar("T")
 
 
 class ValidationDecisionEngine:
     """Validation decision engine."""
 
     @staticmethod
-    def should_keep_finding(
+    def should_keep_finding[T](
         result: LLMValidationResultModel,
         finding: T,
         get_identifier_func: Callable[[T], str],
@@ -62,7 +59,7 @@ class ValidationDecisionEngine:
         return True
 
     @staticmethod
-    def log_validation_decision(
+    def log_validation_decision[T](
         result: LLMValidationResultModel,
         finding: T,
         get_identifier_func: Callable[[T], str],

--- a/src/wct/analysers/llm_validation/strategy.py
+++ b/src/wct/analysers/llm_validation/strategy.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, TypeVar
+from typing import Any
 
 from wct.analysers.types import LLMValidationConfig
 from wct.llm_service import AnthropicLLMService
@@ -15,9 +15,6 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Generic type for finding models
-T = TypeVar("T")
 
 
 class LLMValidationStrategy[T](ABC):

--- a/src/wct/rulesets/base.py
+++ b/src/wct/rulesets/base.py
@@ -2,15 +2,9 @@
 
 import abc
 import logging
-from typing import Any, TypeVar
+from typing import Any
 
 from wct.rulesets.types import BaseRule
-
-# Generic type for rule implementations
-RuleType = TypeVar("RuleType", bound=BaseRule)
-
-# Generic type for RulesetLoader
-LoaderRuleType = TypeVar("LoaderRuleType", bound=BaseRule)
 
 logger = logging.getLogger(__name__)
 

--- a/src/wct/rulesets/types.py
+++ b/src/wct/rulesets/types.py
@@ -1,6 +1,6 @@
 """Pydantic-based types for structured rulesets with inheritance."""
 
-from typing import Literal, TypeVar
+from typing import Literal
 
 from pydantic import (
     BaseModel,
@@ -10,9 +10,6 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-
-# Generic type for BaseRuleset
-RulesetRuleType = TypeVar("RulesetRuleType", bound="BaseRule")
 
 
 class RuleComplianceData(BaseModel):
@@ -31,17 +28,16 @@ class BaseRule(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    name: str = Field(..., min_length=1, description="Unique name for this rule")
+    name: str = Field(min_length=1, description="Unique name for this rule")
     description: str = Field(
-        ...,
         min_length=1,
         description="Human-readable description of what this rule detects",
     )
     patterns: tuple[str, ...] = Field(
-        ..., min_length=1, description="Tuple of patterns to match"
+        min_length=1, description="Tuple of patterns to match"
     )
     risk_level: Literal["low", "medium", "high"] = Field(
-        ..., description="Risk level assessment"
+        description="Risk level assessment"
     )
     compliance: list[RuleComplianceData] = Field(
         default_factory=list, description="Compliance information"
@@ -58,25 +54,23 @@ class BaseRule(BaseModel):
         return patterns
 
 
-class BaseRuleset[RulesetRuleType: BaseRule](BaseModel):
+class BaseRuleset[RuleType: BaseRule](BaseModel):
     """Base ruleset class with minimal guaranteed properties."""
 
-    name: str = Field(..., min_length=1, description="Canonical name of the ruleset")
+    name: str = Field(min_length=1, description="Canonical name of the ruleset")
     version: str = Field(
-        ..., pattern=r"^\d+\.\d+\.\d+$", description='Semantic version (e.g., "1.0.0")'
+        pattern=r"^\d+\.\d+\.\d+$", description='Semantic version (e.g., "1.0.0")'
     )
     description: str = Field(
-        ..., min_length=1, description="Description of what this ruleset detects"
+        min_length=1, description="Description of what this ruleset detects"
     )
-    rules: list[RulesetRuleType] = Field(
-        ..., min_length=1, description="List of rules in this ruleset"
+    rules: list[RuleType] = Field(
+        min_length=1, description="List of rules in this ruleset"
     )
 
     @field_validator("rules")
     @classmethod
-    def validate_unique_rule_names(
-        cls, rules: list[RulesetRuleType]
-    ) -> list[RulesetRuleType]:
+    def validate_unique_rule_names(cls, rules: list[RuleType]) -> list[RuleType]:
         """Validate that rule names are unique within the ruleset."""
         names = [rule.name for rule in rules]
         duplicates = [name for name in names if names.count(name) > 1]
@@ -88,9 +82,7 @@ class BaseRuleset[RulesetRuleType: BaseRule](BaseModel):
 class ProcessingPurposeRule(BaseRule):
     """Processing purpose rule with category and risk information."""
 
-    purpose_category: str = Field(
-        ..., description="Category of this processing purpose"
-    )
+    purpose_category: str = Field(description="Category of this processing purpose")
 
 
 class ProcessingPurposesRulesetData(BaseRuleset[ProcessingPurposeRule]):
@@ -98,7 +90,7 @@ class ProcessingPurposesRulesetData(BaseRuleset[ProcessingPurposeRule]):
 
     # Ruleset-specific properties
     purpose_categories: list[str] = Field(
-        ..., min_length=1, description="Master list of valid purpose categories"
+        min_length=1, description="Master list of valid purpose categories"
     )
     sensitive_categories: list[str] = Field(
         default_factory=list,
@@ -157,8 +149,8 @@ class PersonalDataRulesetData(BaseRuleset[PersonalDataRule]):
 class DataCollectionRule(BaseRule):
     """Data collection rule with collection type and source."""
 
-    collection_type: str = Field(..., description="Type of data collection")
-    data_source: str = Field(..., description="Source of the data")
+    collection_type: str = Field(description="Type of data collection")
+    data_source: str = Field(description="Source of the data")
 
 
 class DataCollectionRulesetData(BaseRuleset[DataCollectionRule]):
@@ -168,8 +160,8 @@ class DataCollectionRulesetData(BaseRuleset[DataCollectionRule]):
 class ServiceIntegrationRule(BaseRule):
     """Service integration rule with service category and purpose."""
 
-    service_category: str = Field(..., description="Category of service integration")
-    purpose_category: str = Field(..., description="Purpose category for compliance")
+    service_category: str = Field(description="Category of service integration")
+    purpose_category: str = Field(description="Purpose category for compliance")
 
 
 class ServiceIntegrationsRulesetData(BaseRuleset[ServiceIntegrationRule]):

--- a/src/wct/schemas/validation.py
+++ b/src/wct/schemas/validation.py
@@ -6,12 +6,9 @@ abstracting the implementation details from the calling code.
 
 from __future__ import annotations
 
-from typing import Any, TypeVar
+from typing import Any
 
 from pydantic import BaseModel, ValidationError
-
-# Type variable for data model validation
-T = TypeVar("T", bound=BaseModel)
 
 
 class DataParsingError(Exception):


### PR DESCRIPTION
## Summary
- Remove deprecated TypeVar declarations and Field(...) ellipsis usage
- Update to use inline generic syntax and modern Field declarations
- Leverage Python 3.12+ type features for cleaner, more readable code

## Changes Made
- **Remove TypeVar imports**: Eliminated redundant TypeVar declarations across 5 files
- **Inline generic syntax**: Updated methods to use `def method[T](...)` syntax
- **Clean Field declarations**: Removed deprecated `Field(...)` ellipsis usage
- **Modern Pydantic patterns**: Follow current best practices for field definitions

## Test Plan
- [x] Type checker passes (basedpyright)
- [x] All tests pass (578 tests)
- [x] No functionality changes
- [x] Ruleset tests specifically validated (87 tests)