### PR TITLE
Convert ruleset categories to lowercase for consistency

### DIFF
--- a/src/wct/analysers/processing_purpose_analyser/README.md
+++ b/src/wct/analysers/processing_purpose_analyser/README.md
@@ -132,7 +132,7 @@ def _analyse_single_file(self, file_data: SourceCodeFileDataModel):
 ```json
 {
   "purpose": "payment_processing",
-  "purpose_category": "OPERATIONAL",
+  "purpose_category": "operational",
   "risk_level": "high",
   "compliance": [
     {

--- a/src/wct/analysers/processing_purpose_analyser/source_code_schema_input_handler.py
+++ b/src/wct/analysers/processing_purpose_analyser/source_code_schema_input_handler.py
@@ -278,7 +278,7 @@ class SourceCodeSchemaInputHandler:
 
         return ProcessingPurposeFindingModel(
             purpose=rule.name,
-            purpose_category="OPERATIONAL",  # DataCollectionRule doesn't have purpose_category
+            purpose_category="operational",  # DataCollectionRule doesn't have purpose_category
             risk_level=rule.risk_level,
             compliance=compliance_data,
             matched_pattern=matched_pattern,

--- a/src/wct/rulesets/data/processing_purposes/1.0.0/processing_purposes.yaml
+++ b/src/wct/rulesets/data/processing_purposes/1.0.0/processing_purposes.yaml
@@ -4,17 +4,17 @@ description: "Known processing purposes to search for during analysis. This rule
 
 # Master list of all valid purpose categories
 purpose_categories:
-  - "AI_AND_ML"
-  - "ANALYTICS"
-  - "MARKETING_AND_ADVERTISING"
-  - "OPERATIONAL"
-  - "SECURITY"
+  - "ai_and_ml"
+  - "analytics"
+  - "marketing_and_advertising"
+  - "operational"
+  - "security"
 
 # Subset of purpose_categories considered privacy-sensitive
 sensitive_categories:
-  - "AI_AND_ML"
-  - "ANALYTICS"
-  - "MARKETING_AND_ADVERTISING"
+  - "ai_and_ml"
+  - "analytics"
+  - "marketing_and_advertising"
 
 rules:
   # ===== AI AND ML PURPOSES =====
@@ -39,7 +39,7 @@ rules:
       - "snorkel ai"
       - "kubeflow"
       - "feast"
-    purpose_category: "AI_AND_ML"
+    purpose_category: "ai_and_ml"
     risk_level: "high"
     compliance:
       - regulation: "GDPR"
@@ -71,7 +71,7 @@ rules:
       - "credo ai"
       - "aws sagemaker clarify"
       - "parity ai"
-    purpose_category: "AI_AND_ML"
+    purpose_category: "ai_and_ml"
     risk_level: "high"
     compliance:
       - regulation: "GDPR"
@@ -102,7 +102,7 @@ rules:
       - "cohere"
       - "scale ai"
       - "labelbox"
-    purpose_category: "AI_AND_ML"
+    purpose_category: "ai_and_ml"
     risk_level: "medium"
     compliance:
       - regulation: "GDPR"
@@ -127,7 +127,7 @@ rules:
       - "helm"
       - "big-bench"
       - "decoding trust benchmark"
-    purpose_category: "AI_AND_ML"
+    purpose_category: "ai_and_ml"
     risk_level: "medium"
     compliance:
       - regulation: "GDPR"
@@ -156,7 +156,7 @@ rules:
       - "darktrace"
       - "synack"
       - "shellgpt"
-    purpose_category: "AI_AND_ML"
+    purpose_category: "ai_and_ml"
     risk_level: "low"
     compliance:
       - regulation: "GDPR"
@@ -194,7 +194,7 @@ rules:
       - "vanta"
       - "waivern"
       - "mineos"
-    purpose_category: "AI_AND_ML"
+    purpose_category: "ai_and_ml"
     risk_level: "low"
     compliance:
       - regulation: "GDPR"
@@ -220,7 +220,7 @@ rules:
       - "labrador"
       - "Stibo DX"
       - "Dr Publish"
-    purpose_category: "OPERATIONAL"
+    purpose_category: "operational"
     risk_level: "low"
     compliance:
       - regulation: "GDPR"
@@ -243,7 +243,7 @@ rules:
       - "salesforce servicecloud"
       - "helpscout"
       - "liveagent"
-    purpose_category: "OPERATIONAL"
+    purpose_category: "operational"
     risk_level: "low"
     compliance:
       - regulation: "GDPR"
@@ -259,7 +259,7 @@ rules:
       - "theme"
       - "ui"
       - "personalization"
-    purpose_category: "OPERATIONAL"
+    purpose_category: "operational"
     risk_level: "low"
     compliance:
       - regulation: "GDPR"
@@ -332,7 +332,7 @@ rules:
       - "vipps sign-in"
       - "microsoft active directory"
       - "forgerock"
-    purpose_category: "OPERATIONAL"
+    purpose_category: "operational"
     risk_level: "medium"
     compliance:
       - regulation: "GDPR"
@@ -377,7 +377,7 @@ rules:
       - "Chase Paymentech"
       - "Bank of America Merchant Services"
       - "Wells Fargo Merchant Services"
-    purpose_category: "OPERATIONAL"
+    purpose_category: "operational"
     risk_level: "medium"
     compliance:
       - regulation: "GDPR"
@@ -417,7 +417,7 @@ rules:
       - "Tableau"
       - "SAS Analytics"
       - "IBM Watson Analytics"
-    purpose_category: "ANALYTICS"
+    purpose_category: "analytics"
     risk_level: "high"
     compliance:
       - regulation: "GDPR"
@@ -451,7 +451,7 @@ rules:
       - "OneSignal"
       - "Leanplum"
       - "Clevertap"
-    purpose_category: "MARKETING_AND_ADVERTISING"
+    purpose_category: "marketing_and_advertising"
     risk_level: "high"
     compliance:
       - regulation: "GDPR"
@@ -475,7 +475,7 @@ rules:
       - "sendgrid"
       - "mailjet"
       - "onesignal"
-    purpose_category: "MARKETING_AND_ADVERTISING"
+    purpose_category: "marketing_and_advertising"
     risk_level: "medium"
     compliance:
       - regulation: "GDPR"
@@ -496,7 +496,7 @@ rules:
       - "tiktok"
       - "twitter"
       - "linkedin ads"
-    purpose_category: "MARKETING_AND_ADVERTISING"
+    purpose_category: "marketing_and_advertising"
     risk_level: "high"
     compliance:
       - regulation: "GDPR"
@@ -514,7 +514,7 @@ rules:
       - "google ads 360"
       - "tiktok"
       - "third-party advertisers"
-    purpose_category: "MARKETING_AND_ADVERTISING"
+    purpose_category: "marketing_and_advertising"
     risk_level: "high"
     compliance:
       - regulation: "GDPR"
@@ -538,7 +538,7 @@ rules:
       - "complyadvantage"
       - "veriff"
       - "feedzai"
-    purpose_category: "SECURITY"
+    purpose_category: "security"
     risk_level: "low"
     compliance:
       - regulation: "GDPR"

--- a/src/wct/rulesets/data/service_integrations/1.0.0/service_integrations.yaml
+++ b/src/wct/rulesets/data/service_integrations/1.0.0/service_integrations.yaml
@@ -13,9 +13,9 @@ service_categories:
 
 # Master list of valid purpose categories for service integrations (maps to processing purposes)
 purpose_categories:
-  - "OPERATIONAL"
-  - "ANALYTICS"
-  - "MARKETING_AND_ADVERTISING"
+  - "operational"
+  - "analytics"
+  - "marketing_and_advertising"
 
 rules:
   # ===== CLOUD INFRASTRUCTURE SERVICES =====
@@ -34,7 +34,7 @@ rules:
       - "storage"
       - "upload"
     service_category: "cloud_infrastructure"
-    purpose_category: "OPERATIONAL"
+    purpose_category: "operational"
     risk_level: "medium"
     compliance:
       - regulation: "GDPR"
@@ -56,7 +56,7 @@ rules:
       - "sms"
       - "notification"
     service_category: "communication"
-    purpose_category: "OPERATIONAL"
+    purpose_category: "operational"
     risk_level: "medium"
     compliance:
       - regulation: "GDPR"
@@ -77,7 +77,7 @@ rules:
       - "authorization"
       - "identity"
     service_category: "identity_management"
-    purpose_category: "OPERATIONAL"
+    purpose_category: "operational"
     risk_level: "high"
     compliance:
       - regulation: "GDPR"
@@ -98,7 +98,7 @@ rules:
       - "adyen"
       - "charge"
     service_category: "payment_processing"
-    purpose_category: "OPERATIONAL"
+    purpose_category: "operational"
     risk_level: "high"
     compliance:
       - regulation: "GDPR"
@@ -118,7 +118,7 @@ rules:
       - "fullstory"
       - "logrocket"
     service_category: "user_analytics"
-    purpose_category: "ANALYTICS"
+    purpose_category: "analytics"
     risk_level: "medium"
     compliance:
       - regulation: "GDPR"
@@ -138,7 +138,7 @@ rules:
       - "pinterest"
       - "social"
     service_category: "social_media"
-    purpose_category: "MARKETING_AND_ADVERTISING"
+    purpose_category: "marketing_and_advertising"
     risk_level: "medium"
     compliance:
       - regulation: "GDPR"

--- a/src/wct/schemas/json_schemas/processing_purpose_finding/1.0.0/processing_purpose_finding.sample.json
+++ b/src/wct/schemas/json_schemas/processing_purpose_finding/1.0.0/processing_purpose_finding.sample.json
@@ -2,7 +2,7 @@
   "findings": [
     {
       "purpose": "Artificial Intelligence Compliance Management",
-      "purpose_category": "AI_AND_ML",
+      "purpose_category": "ai_and_ml",
       "risk_level": "low",
       "compliance": [
         {
@@ -42,7 +42,7 @@
     },
     {
       "purpose": "User Identity and Login Management",
-      "purpose_category": "OPERATIONAL",
+      "purpose_category": "operational",
       "risk_level": "medium",
       "compliance": [
         {
@@ -74,7 +74,7 @@
     },
     {
       "purpose": "Behavioral Data Analysis for Product Improvement",
-      "purpose_category": "ANALYTICS",
+      "purpose_category": "analytics",
       "risk_level": "high",
       "compliance": [
         {
@@ -114,7 +114,7 @@
     },
     {
       "purpose": "Dynamic Personalization of Products and Services",
-      "purpose_category": "MARKETING_AND_ADVERTISING",
+      "purpose_category": "marketing_and_advertising",
       "risk_level": "high",
       "compliance": [
         {
@@ -154,7 +154,7 @@
     },
     {
       "purpose": "Security, Fraud Prevention, and Abuse Detection",
-      "purpose_category": "SECURITY",
+      "purpose_category": "security",
       "risk_level": "low",
       "compliance": [
         {
@@ -197,9 +197,9 @@
     "purposes_identified": 4,
     "high_risk_count": 0,
     "purpose_categories": {
-      "AI_AND_ML": 1,
-      "OPERATIONAL": 2,
-      "SECURITY_AND_FRAUD_PREVENTION": 1
+      "ai_and_ml": 1,
+      "operational": 2,
+      "security": 1
     },
     "risk_level_distribution": {
       "low": 1,

--- a/tests/wct/rulesets/test_types.py
+++ b/tests/wct/rulesets/test_types.py
@@ -119,12 +119,12 @@ class TestProcessingPurposeRule:
             name="analytics_rule",
             description="Analytics processing rule",
             patterns=("analytics", "tracking"),
-            purpose_category="ANALYTICS",
+            purpose_category="analytics",
             risk_level="medium",
         )
 
         assert rule.name == "analytics_rule"
-        assert rule.purpose_category == "ANALYTICS"
+        assert rule.purpose_category == "analytics"
         assert rule.risk_level == "medium"
 
 


### PR DESCRIPTION
## Summary
- Standardise all category lists and field values in rulesets to use lowercase naming
- Convert purpose_categories list from uppercase to lowercase in processing_purposes.yaml
- Update all individual purpose_category field values across all rulesets
- Fix hardcoded uppercase category references in source code and documentation

## Test plan
- [x] All 585 tests pass
- [x] All development checks pass (formatting, linting, type checking)
- [x] Schema validation works correctly with lowercase categories
- [x] Ruleset loading and validation maintains functionality