### PR TITLE
Rename Ruleset classes to clarify naming conventions

### DIFF
--- a/src/wct/rulesets/README.md
+++ b/src/wct/rulesets/README.md
@@ -77,7 +77,7 @@ rules:
 from pathlib import Path
 from typing import Final
 import yaml
-from wct.rulesets.base import Ruleset
+from wct.rulesets.base import AbstractRuleset
 from wct.rulesets.types import Rule, RulesetData
 
 _RULESET_DATA_VERSION: Final[str] = "1.0.0"

--- a/src/wct/rulesets/base.py
+++ b/src/wct/rulesets/base.py
@@ -9,7 +9,7 @@ from wct.rulesets.types import BaseRule
 logger = logging.getLogger(__name__)
 
 
-class Ruleset[RuleType: BaseRule](abc.ABC):
+class AbstractRuleset[RuleType: BaseRule](abc.ABC):
     """Base class for all rulesets with logging support.
 
     This provides a common interface for rulesets and automatic
@@ -70,7 +70,7 @@ class RulesetRegistry:
     """Type-aware singleton registry for ruleset classes with explicit registration."""
 
     _instance: "RulesetRegistry | None" = None
-    _registry: dict[str, type[Ruleset[Any]]]
+    _registry: dict[str, type[AbstractRuleset[Any]]]
     _type_mapping: dict[str, type[BaseRule]]
 
     def __new__(cls, *args: Any, **kwargs: Any) -> "RulesetRegistry":  # noqa: ANN401  # Singleton pattern requires flexible constructor arguments
@@ -90,7 +90,7 @@ class RulesetRegistry:
         return cls._instance
 
     def register[T: BaseRule](
-        self, name: str, ruleset_class: type[Ruleset[T]], rule_type: type[T]
+        self, name: str, ruleset_class: type[AbstractRuleset[T]], rule_type: type[T]
     ) -> None:
         """Register a ruleset class with its rule type.
 
@@ -112,7 +112,7 @@ class RulesetRegistry:
 
     def get_ruleset_class[T: BaseRule](
         self, name: str, expected_rule_type: type[T]
-    ) -> type[Ruleset[T]]:
+    ) -> type[AbstractRuleset[T]]:
         """Get a registered ruleset class with type validation.
 
         Args:

--- a/src/wct/rulesets/data_collection.py
+++ b/src/wct/rulesets/data_collection.py
@@ -11,7 +11,7 @@ from typing import Final, override
 
 import yaml
 
-from wct.rulesets.base import Ruleset
+from wct.rulesets.base import AbstractRuleset
 from wct.rulesets.types import DataCollectionRule, DataCollectionRulesetData
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ _RULESET_DATA_VERSION: Final[str] = "1.0.0"
 _RULESET_NAME: Final[str] = "data_collection"
 
 
-class DataCollectionRuleset(Ruleset[DataCollectionRule]):
+class DataCollectionRuleset(AbstractRuleset[DataCollectionRule]):
     """Ruleset for detecting data collection patterns in source code."""
 
     def __init__(self) -> None:

--- a/src/wct/rulesets/personal_data.py
+++ b/src/wct/rulesets/personal_data.py
@@ -10,7 +10,7 @@ from typing import Final, override
 
 import yaml
 
-from wct.rulesets.base import Ruleset
+from wct.rulesets.base import AbstractRuleset
 from wct.rulesets.types import PersonalDataRule, PersonalDataRulesetData
 
 logger = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ _RULESET_DATA_VERSION: Final[str] = "1.0.0"
 _RULESET_NAME: Final[str] = "personal_data"
 
 
-class PersonalDataRuleset(Ruleset[PersonalDataRule]):
+class PersonalDataRuleset(AbstractRuleset[PersonalDataRule]):
     """Class-based personal data detection ruleset with logging support.
 
     This class provides structured access to personal data patterns

--- a/src/wct/rulesets/processing_purposes.py
+++ b/src/wct/rulesets/processing_purposes.py
@@ -10,7 +10,7 @@ from typing import Final, override
 
 import yaml
 
-from wct.rulesets.base import Ruleset
+from wct.rulesets.base import AbstractRuleset
 from wct.rulesets.types import ProcessingPurposeRule, ProcessingPurposesRulesetData
 
 logger = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ _RULESET_DATA_VERSION: Final[str] = "1.0.0"
 _RULESET_NAME: Final[str] = "processing_purposes"
 
 
-class ProcessingPurposesRuleset(Ruleset[ProcessingPurposeRule]):
+class ProcessingPurposesRuleset(AbstractRuleset[ProcessingPurposeRule]):
     """Class-based processing purposes detection ruleset with logging support.
 
     This class provides structured access to processing purposes patterns

--- a/src/wct/rulesets/service_integrations.py
+++ b/src/wct/rulesets/service_integrations.py
@@ -12,7 +12,7 @@ from typing import Final, override
 
 import yaml
 
-from wct.rulesets.base import Ruleset
+from wct.rulesets.base import AbstractRuleset
 from wct.rulesets.types import ServiceIntegrationRule, ServiceIntegrationsRulesetData
 
 logger = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ _RULESET_DATA_VERSION: Final[str] = "1.0.0"
 _RULESET_NAME: Final[str] = "service_integrations"
 
 
-class ServiceIntegrationsRuleset(Ruleset[ServiceIntegrationRule]):
+class ServiceIntegrationsRuleset(AbstractRuleset[ServiceIntegrationRule]):
     """Ruleset for detecting third-party service integrations in source code.
 
     This ruleset focuses on identifying service integrations through:

--- a/src/wct/rulesets/types.py
+++ b/src/wct/rulesets/types.py
@@ -54,7 +54,7 @@ class BaseRule(BaseModel):
         return patterns
 
 
-class BaseRuleset[RuleType: BaseRule](BaseModel):
+class RulesetData[RuleType: BaseRule](BaseModel):
     """Base ruleset class with minimal guaranteed properties."""
 
     name: str = Field(min_length=1, description="Canonical name of the ruleset")
@@ -85,7 +85,7 @@ class ProcessingPurposeRule(BaseRule):
     purpose_category: str = Field(description="Category of this processing purpose")
 
 
-class ProcessingPurposesRulesetData(BaseRuleset[ProcessingPurposeRule]):
+class ProcessingPurposesRulesetData(RulesetData[ProcessingPurposeRule]):
     """Processing purposes ruleset data model with category management."""
 
     # Ruleset-specific properties
@@ -134,7 +134,7 @@ class PersonalDataRule(BaseRule):
     )
 
 
-class PersonalDataRulesetData(BaseRuleset[PersonalDataRule]):
+class PersonalDataRulesetData(RulesetData[PersonalDataRule]):
     """Personal data ruleset with GDPR Article 9 support."""
 
     # Ruleset-specific properties
@@ -181,7 +181,7 @@ class DataCollectionRule(BaseRule):
     data_source: str = Field(description="Source of the data")
 
 
-class DataCollectionRulesetData(BaseRuleset[DataCollectionRule]):
+class DataCollectionRulesetData(RulesetData[DataCollectionRule]):
     """Data collection ruleset data model."""
 
     # Ruleset-specific properties
@@ -217,7 +217,7 @@ class ServiceIntegrationRule(BaseRule):
     purpose_category: str = Field(description="Purpose category for compliance")
 
 
-class ServiceIntegrationsRulesetData(BaseRuleset[ServiceIntegrationRule]):
+class ServiceIntegrationsRulesetData(RulesetData[ServiceIntegrationRule]):
     """Service integrations ruleset data model."""
 
     # Ruleset-specific properties

--- a/tests/wct/rulesets/test_base.py
+++ b/tests/wct/rulesets/test_base.py
@@ -3,7 +3,7 @@
 import pytest
 
 from wct.rulesets.base import (
-    Ruleset,
+    AbstractRuleset,
     RulesetAlreadyRegisteredError,
     RulesetLoader,
     RulesetNotFoundError,
@@ -12,7 +12,7 @@ from wct.rulesets.base import (
 from wct.rulesets.types import ProcessingPurposeRule
 
 
-class ConcreteRuleset(Ruleset[ProcessingPurposeRule]):
+class ConcreteRuleset(AbstractRuleset[ProcessingPurposeRule]):
     """Concrete implementation of Ruleset for testing."""
 
     @property
@@ -44,7 +44,7 @@ class TestRulesetClass:
     def test_ruleset_get_rules_is_abstract(self):
         """Test that Ruleset.get_rules is an abstract method."""
         with pytest.raises(TypeError, match="Can't instantiate abstract class"):
-            Ruleset()  # type: ignore[abstract]
+            AbstractRuleset()  # type: ignore[abstract]
 
     def test_ruleset_initialisation_uses_name_property(self):
         """Test Ruleset initialisation uses name property."""
@@ -73,7 +73,7 @@ class TestRulesetClass:
     def test_ruleset_name_and_version_are_abstract(self):
         """Test that Ruleset.name and version are abstract properties."""
 
-        class IncompleteRuleset(Ruleset):
+        class IncompleteRuleset(AbstractRuleset):
             def get_rules(self) -> tuple[ProcessingPurposeRule, ...]:
                 return ()
 
@@ -168,7 +168,7 @@ class TestRulesetRegistry:
     def test_registry_prevents_duplicate_registration(self):
         """Test that registering the same name raises RulesetAlreadyRegisteredError."""
 
-        class AnotherRuleset(Ruleset[ProcessingPurposeRule]):
+        class AnotherRuleset(AbstractRuleset[ProcessingPurposeRule]):
             @property
             def name(self) -> str:
                 return "another_test"
@@ -230,7 +230,7 @@ class TestRulesetLoader:
     def test_load_ruleset_creates_instance_with_correct_name(self):
         """Test that load_ruleset creates ruleset instance with correct name."""
 
-        class NameTrackingRuleset(Ruleset[ProcessingPurposeRule]):
+        class NameTrackingRuleset(AbstractRuleset[ProcessingPurposeRule]):
             @property
             def name(self) -> str:
                 return "name_tracking"
@@ -288,7 +288,7 @@ class TestRulesetIntegration:
         """Test the complete workflow from registration to loading."""
 
         # Define a custom ruleset
-        class CustomRuleset(Ruleset[ProcessingPurposeRule]):
+        class CustomRuleset(AbstractRuleset[ProcessingPurposeRule]):
             @property
             def name(self) -> str:
                 return "custom_rules"
@@ -341,7 +341,7 @@ class TestRulesetIntegration:
     def test_ruleset_version_accessible_through_loader(self):
         """Test that ruleset version is accessible after loading."""
 
-        class VersionedRuleset(Ruleset[ProcessingPurposeRule]):
+        class VersionedRuleset(AbstractRuleset[ProcessingPurposeRule]):
             @property
             def name(self) -> str:
                 return "versioned_rules"


### PR DESCRIPTION
## Summary
- Rename `Ruleset` to `AbstractRuleset` to clearly indicate it's an abstract base class
- Rename `BaseRuleset` to `RulesetData` to clearly indicate it's a Pydantic data model for YAML validation
- Update all references across implementations, tests, and documentation

## Test plan
- [x] All existing tests pass (87/87)
- [x] Type checking passes with no errors
- [x] Linting passes
- [x] Pre-commit hooks pass