### PR TITLE
docs: fix README example runbook configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,19 +132,18 @@ connectors:
 analysers:
   - name: "content_analyser"
     type: "personal_data_analyser"
-    metadata:
-      priority: "high"
-      compliance_frameworks: ["GDPR", "CCPA"]
+    properties:
+      pattern_matching:
+        ruleset: "personal_data"
+        evidence_context_size: "medium"
+      llm_validation:
+        enable_llm_validation: true
 
 execution:
   - connector: "filesystem_reader"
     analyser: "content_analyser"
     input_schema: "standard_input"
     output_schema: "personal_data_finding"
-    context:
-      description: "Analyse file content for personal data"
-      priority: "high"
-      compliance_frameworks: ["GDPR", "CCPA"]
 ```
 
 **Key Features**:


### PR DESCRIPTION
## Summary
- Updates the README example runbook to use correct analyser configuration
- Removes outdated `compliance_frameworks` property that is no longer supported
- Replaces `metadata` with `properties` section using actual configuration structure  
- Removes deprecated `context` section from execution steps

## Test plan
- [x] Verified the example now shows actual `personal_data_analyser` configuration options
- [x] Confirmed all development checks pass
- [x] Example aligns with current codebase implementation