### PR TITLE
refactor: replace EuUkRepresentativeConfig with Representatives list

### DIFF
--- a/config/organisation.yaml
+++ b/config/organisation.yaml
@@ -19,11 +19,13 @@ joint_controller:
   contact_email: "jean.dow@waivern.com"
   contact_address: "Solbakken Alle 24D, 1086, Oslo, Norway"
 
-# Optional
-eu_uk_representative:
-  company_name: "John Dow"
-  contact_email: "john.dow@waivern.com"
-  contact_address: "21 East Street, London, UK"
+# Optional - List of representatives for different jurisdictions
+representatives:
+  - company_name: "John Dow"
+    company_jurisdiction: "UK"  # This representative serves UK jurisdiction
+    contact_email: "john.dow@waivern.com"
+    contact_address: "21 East Street, London, UK"
+    representative_jurisdiction: "UK"  # Representative is located in UK
 
 dpo:
   name: "Vincent G Nunan"

--- a/tests/wct/test_organisation.py
+++ b/tests/wct/test_organisation.py
@@ -134,11 +134,15 @@ class TestOrganisationConfig:
                 "contact_email": "joint@partner.com",
                 "contact_address": "Joint Address",
             },
-            "eu_uk_representative": {
-                "company_name": "EU Rep Ltd",
-                "contact_email": "eurep@company.com",
-                "contact_address": "EU Rep Address",
-            },
+            "representatives": [
+                {
+                    "company_name": "EU Rep Ltd",
+                    "company_jurisdiction": "EU",
+                    "contact_email": "eurep@company.com",
+                    "contact_address": "EU Rep Address",
+                    "representative_jurisdiction": "EU",
+                }
+            ],
             "dpo": {
                 "name": "DPO Name",
                 "contact_email": "dpo@company.com",
@@ -157,7 +161,7 @@ class TestOrganisationConfig:
         # Verify all sections are present
         assert "data_controller" in export_data
         assert "joint_controller" in export_data
-        assert "eu_uk_representative" in export_data
+        assert "representatives" in export_data
         assert "dpo" in export_data
         assert "privacy_contact" in export_data
         assert "data_retention" in export_data
@@ -169,7 +173,10 @@ class TestOrganisationConfig:
 
         # Verify other sections have correct data
         assert export_data["joint_controller"]["name"] == "Joint Partner"
-        assert export_data["eu_uk_representative"]["company_name"] == "EU Rep Ltd"
+        assert len(export_data["representatives"]) == 1
+        assert export_data["representatives"][0]["company_name"] == "EU Rep Ltd"
+        assert export_data["representatives"][0]["company_jurisdiction"] == "EU"
+        assert export_data["representatives"][0]["representative_jurisdiction"] == "EU"
         assert export_data["dpo"]["name"] == "DPO Name"
         assert export_data["privacy_contact"]["email"] == "privacy@company.com"
         assert export_data["data_retention"]["general_rule"] == "24 months"


### PR DESCRIPTION
## Summary
- Replaced single `eu_uk_representative` field with `representatives` list structure
- Added `Representative` class with `company_jurisdiction` and `representative_jurisdiction` fields
- Resolves ambiguity between UK representative for EU firm vs EU representative for UK firm

## Breaking Changes
- `eu_uk_representative` field replaced with `representatives` list in configuration
- Export metadata now includes `representatives` array instead of `eu_uk_representative` object
- Each representative now explicitly specifies which jurisdiction they serve and where they're located

## Test Plan
- [x] All existing tests pass with updated structure
- [x] New test cases validate representative jurisdiction fields
- [x] Development checks pass (linting, type checking, formatting)
- [x] Configuration updated with clear jurisdiction mapping