### PR TITLE
fix: align data subject ruleset schema with YAML structure

### DIFF
--- a/src/wct/analysers/data_subject_analyser/pattern_matcher.py
+++ b/src/wct/analysers/data_subject_analyser/pattern_matcher.py
@@ -156,7 +156,7 @@ class DataSubjectPatternMatcher:
                         )
                     ],  # TODO: Add proper compliance framework mappings for data subject categories
                     evidence=evidence,
-                    modifiers=[],  # TODO: Implement modifier detection logic with LLM validation (e.g., "minor" for age <18, "eu_resident" for EU location)
+                    modifiers=[],  # TODO: Implement modifier detection logic using ruleset.risk_increasing_modifiers and ruleset.risk_decreasing_modifiers with LLM validation
                     matched_patterns=matched_patterns,
                     metadata=finding_metadata,
                 )

--- a/src/wct/rulesets/data/data_subjects/1.0.0/data_subjects.yaml
+++ b/src/wct/rulesets/data/data_subjects/1.0.0/data_subjects.yaml
@@ -28,9 +28,14 @@ applicable_contexts:
   - "filesystem"
   - "source_code"
 
-modifiers:
+risk_increasing_modifiers:
   - "minor"
-  - "eu_resident"
+  - "child"
+  - "under 13 years of age"
+  - "vulnerable group"
+
+risk_decreasing_modifiers:
+  - "non-EU-resident"
 
 rules:
   # ===== EMPLOYEE CATEGORY =====

--- a/src/wct/rulesets/data/personal_data/1.0.0/personal_data.yaml
+++ b/src/wct/rulesets/data/personal_data/1.0.0/personal_data.yaml
@@ -277,12 +277,12 @@ rules:
       - "profiling"
       - "machine_learning"
     special_category: false
-    risk_level: "medium"
+    risk_level: "high"
     compliance:
       - regulation: "GDPR"
-        relevance: "Automated profiling and inferences under Article 22, right to explanation"
+        relevance: "Automated profiling and inferences under Articles 14 (transparency), 15 (right of access), 16 (right of rectification), 17 (right of erasure), 18-23, including right of reservation/objection and right to explanation"
       - regulation: "EU_AI_ACT"
-        relevance: "AI-generated profiles and inferences subject to high-risk AI system requirements"
+        relevance: "ML/AI-generated profiles and inferences subject to high-risk AI system requirements"
 
   - name: "User-Declared Preferences and Interests"
     description: "User-declared preferences and interests"
@@ -405,6 +405,11 @@ rules:
       - "political"
       - "trade_union"
       - "affiliation"
+      - "conservative"
+      - "liberal"
+      - "labour"
+      - "socialist"
+      - "activist"
     special_category: true
     risk_level: "high"
     compliance:
@@ -433,6 +438,7 @@ rules:
       - "belief"
       - "philosophy"
       - "faith"
+      - "creed"
     special_category: true
     risk_level: "high"
     compliance:

--- a/src/wct/rulesets/data_subjects.py
+++ b/src/wct/rulesets/data_subjects.py
@@ -53,8 +53,12 @@ class DataSubjectRulesetData(RulesetData[DataSubjectRule]):
     applicable_contexts: list[str] = Field(
         min_length=1, description="Master list of valid applicable contexts"
     )
-    modifiers: list[str] = Field(
-        min_length=1, description="Master list of valid cross-category modifiers"
+    risk_increasing_modifiers: list[str] = Field(
+        min_length=1,
+        description="Risk-increasing modifiers (e.g., minor, vulnerable group)",
+    )
+    risk_decreasing_modifiers: list[str] = Field(
+        min_length=1, description="Risk-decreasing modifiers (e.g., non-EU-resident)"
     )
 
     @model_validator(mode="after")

--- a/tests/wct/rulesets/test_data_subject.py
+++ b/tests/wct/rulesets/test_data_subject.py
@@ -124,13 +124,15 @@ class TestDataSubjectRulesetData:
             description="Data subject classification ruleset",
             subject_categories=["employee", "customer", "prospect"],
             applicable_contexts=["database", "filesystem", "source_code"],
-            modifiers=["minor", "eu_resident"],
+            risk_increasing_modifiers=["minor", "vulnerable group"],
+            risk_decreasing_modifiers=["non-EU-resident"],
             rules=[rule],
         )
 
         assert len(ruleset.rules) == 1
         assert "employee" in ruleset.subject_categories
-        assert "minor" in ruleset.modifiers
+        assert "minor" in ruleset.risk_increasing_modifiers
+        assert "non-EU-resident" in ruleset.risk_decreasing_modifiers
 
     def test_data_subject_ruleset_invalid_subject_category(self):
         """Test DataSubjectRulesetData rejects rules with invalid subject categories."""
@@ -152,7 +154,8 @@ class TestDataSubjectRulesetData:
                 description="Data subject classification ruleset",
                 subject_categories=["employee", "customer"],
                 applicable_contexts=["database", "filesystem", "source_code"],
-                modifiers=["minor", "eu_resident"],
+                risk_increasing_modifiers=["minor", "vulnerable group"],
+                risk_decreasing_modifiers=["non-EU-resident"],
                 rules=[rule],
             )
 
@@ -177,11 +180,13 @@ class TestDataSubjectRulesetData:
             description="Test ruleset",
             subject_categories=["employee"],
             applicable_contexts=["database", "filesystem", "source_code"],
-            modifiers=["minor", "eu_resident"],
+            risk_increasing_modifiers=["minor", "vulnerable group"],
+            risk_decreasing_modifiers=["non-EU-resident"],
             rules=[rule],
         )
-        assert "minor" in ruleset.modifiers
-        assert "eu_resident" in ruleset.modifiers
+        assert "minor" in ruleset.risk_increasing_modifiers
+        assert "vulnerable group" in ruleset.risk_increasing_modifiers
+        assert "non-EU-resident" in ruleset.risk_decreasing_modifiers
 
     def test_data_subject_ruleset_duplicate_rule_names(self):
         """Test DataSubjectRulesetData rejects duplicate rule names."""
@@ -214,7 +219,8 @@ class TestDataSubjectRulesetData:
                 description="Test ruleset",
                 subject_categories=["employee", "customer"],
                 applicable_contexts=["database", "filesystem", "source_code"],
-                modifiers=["minor", "eu_resident"],
+                risk_increasing_modifiers=["minor", "vulnerable group"],
+                risk_decreasing_modifiers=["non-EU-resident"],
                 rules=[rule1, rule2],
             )
 
@@ -238,7 +244,8 @@ class TestDataSubjectRulesetData:
                 description="Data subject classification ruleset",
                 subject_categories=["employee", "customer"],
                 applicable_contexts=["database", "filesystem", "source_code"],
-                modifiers=["minor", "eu_resident"],
+                risk_increasing_modifiers=["minor", "vulnerable group"],
+                risk_decreasing_modifiers=["non-EU-resident"],
                 rules=[rule],
             )
 


### PR DESCRIPTION
## Summary
• Fix data subject ruleset schema alignment with updated YAML structure
• Replace single `modifiers` field with separate risk modifier categories

Closes #139

## Test Plan
- [x] All 711 tests pass
- [x] YAML loads correctly (25 rules loaded successfully)
- [x] Dev checks pass (formatting, linting, type checking)
- [x] Schema validation works with new modifier structure
- [x] Backward compatibility maintained in analyser output