### PR TITLE
feat: add OpenAI LLM provider with lazy import and complete integration tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,9 @@ MYSQL_DATABASE=your_database_name
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 # Anthropic model name (optional)
 ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+
+# OpenAI Configuration (optional - requires: uv sync --group llm-openai)
+# OpenAI API key for LLM-powered analysis
+OPENAI_API_KEY=your_openai_api_key_here
+# OpenAI model name (optional, defaults to gpt-4o)
+OPENAI_MODEL=gpt-4o

--- a/docs/feature-plans/multi-provider-llm-support.md
+++ b/docs/feature-plans/multi-provider-llm-support.md
@@ -1,5 +1,19 @@
 # Multi-Provider LLM Support - Incremental TDD Implementation
 
+## Progress Tracker
+
+| Feature | Status | Branch | PR | Merged | Notes |
+|---------|--------|--------|----|----|-------|
+| Feature 1: Base LLM Service Abstraction | ✅ Complete | `refactor/base-llm-service-abstraction` | [#145](https://github.com/waivern-compliance/waivern-compliance/pull/145) | ⏳ Pending | 712 tests pass, zero behaviour change |
+| Feature 2: OpenAI Provider with Lazy Import | ✅ Complete | `feature/openai-provider-lazy-import` | - | - | 722 unit tests + 8 integration tests (4 Anthropic + 4 OpenAI) pass |
+| Feature 3: Environment-Based Provider Selection | 📋 Planned | - | - | - | - |
+| Feature 4: Add Google & Cohere Providers | 📋 Planned | - | - | - | - |
+| Feature 5: Per-Analyser LLM Configuration (Schema) | 📋 Planned | - | - | - | - |
+| Feature 6: Configuration Hierarchy Resolution | 📋 Planned | - | - | - | - |
+| Feature 7: Test-LLM CLI Command | 📋 Planned | - | - | - | - |
+| Feature 8: Multi-Provider Example Runbook | 📋 Planned | - | - | - | - |
+| Feature 9: Documentation & Migration Guide | 📋 Planned | - | - | - | - |
+
 ## Overview
 
 This document outlines the plan for adding multi-provider LLM support to WCT, broken down into small, independently mergeable features that can be implemented using TDD methodology.
@@ -40,41 +54,71 @@ This document outlines the plan for adding multi-provider LLM support to WCT, br
 
 ## Implementation Plan
 
-### Feature 1: Base LLM Service Abstraction
+### Feature 1: Base LLM Service Abstraction ✅ COMPLETE
 **Goal:** Extract interface, make current code inherit from it
 **Testing:** All existing tests pass unchanged
 **Mergeable:** ✅ Zero behaviour change, pure refactoring
+**Status:** ✅ Complete - PR #145 ready for merge
+**Actual effort:** ~1.5 hours
 
-**Changes:**
-- Create `BaseLLMService` ABC with `analyse_data()` method
-- Refactor `AnthropicLLMService` to inherit from base
-- Update `LLMServiceManager` type hint to `BaseLLMService | None`
-- Run existing tests to verify no regression
+**Changes Implemented:**
+- ✅ Create `BaseLLMService` ABC with `analyse_data()` abstract method
+- ✅ Refactor `AnthropicLLMService` to inherit from base with `@override` decorator
+- ✅ Update `LLMServiceManager` type hint to `BaseLLMService | None`
+- ✅ Update all validation strategies to accept `BaseLLMService`
+- ✅ Add test verifying `AnthropicLLMService` implements base interface
 
-**Test Strategy:**
-- Existing `test_llm_service.py` tests pass unchanged
-- Add test verifying `AnthropicLLMService` is instance of `BaseLLMService`
+**Test Results:**
+- ✅ All 712 tests pass
+- ✅ Type checking passes (basedpyright strict mode)
+- ✅ Linting passes (ruff)
+- ✅ All dev checks pass
 
-**Estimated effort:** 1-2 hours
+**Files Modified:**
+- `src/wct/llm_service.py` - Added `BaseLLMService` ABC
+- `src/wct/analysers/utilities/llm_service_manager.py` - Updated type hints
+- `src/wct/analysers/llm_validation/strategy.py` - Updated type hints
+- `src/wct/analysers/personal_data_analyser/llm_validation_strategy.py` - Updated type hints
+- `src/wct/analysers/processing_purpose_analyser/llm_validation_strategy.py` - Updated type hints
+- `tests/wct/test_llm_service.py` - Added interface verification test
 
 ---
 
-### Feature 2: OpenAI Provider with Lazy Import
+### Feature 2: OpenAI Provider with Lazy Import ✅ COMPLETE
 **Goal:** Add single alternative provider, prove the pattern works
-**Testing:** Unit tests for OpenAI service with mocks
+**Testing:** Unit tests for OpenAI service with mocks + real API integration tests
 **Mergeable:** ✅ Additive only, doesn't affect existing code
+**Status:** ✅ Complete - Ready for PR
+**Actual effort:** ~3 hours
 
-**Changes:**
-- Add `llm-openai = ["langchain-openai>=0.2.0"]` to dependency groups
-- Implement `OpenAILLMService` with lazy import + helpful error
-- Add `LLMServiceFactory.create_openai_service()` method
-- Document OpenAI setup in `.env.example`
+**Changes Implemented:**
+- ✅ Add `llm-openai = ["langchain-openai>=0.2.0"]` to dependency groups
+- ✅ Implement `OpenAILLMService` with lazy import + helpful error
+- ✅ Add `LLMServiceFactory.create_openai_service()` method
+- ✅ Document OpenAI setup in `.env.example`
+- ✅ Add pytest integration test markers and configuration
+- ✅ Implement 4 real API integration tests for Anthropic
+- ✅ Implement 4 real API integration tests for OpenAI
 
-**Test Strategy:**
-- Test `OpenAILLMService` with mocked `ChatOpenAI`
-- Test lazy import error message (without langchain-openai installed)
-- Test factory creates correct service type
-- All existing tests still pass (Anthropic unchanged)
+**Test Results:**
+- ✅ All 722 unit tests pass (including OpenAI mocked tests)
+- ✅ 4 Anthropic real API integration tests pass (8.12s)
+- ✅ 4 OpenAI real API integration tests pass (4.30s)
+- ✅ All 8 integration tests pass together (13.02s)
+- ✅ Type checking passes (basedpyright strict mode)
+- ✅ Linting passes (ruff)
+
+**Files Modified:**
+- `pyproject.toml` - Added llm-openai dependency group, pytest markers, default test exclusion
+- `src/wct/llm_service.py` - Added OpenAILLMService class
+- `.env.example` - Added OpenAI configuration
+- `tests/wct/test_llm_service.py` - Added unit tests + integration test classes
+
+**Integration Test Setup:**
+- pytest markers: `@pytest.mark.integration`
+- Default behavior: `uv run pytest` excludes integration tests (no API costs)
+- Run integration tests: `uv run pytest -m integration`
+- Integration tests skip gracefully when API keys not present
 
 **Estimated effort:** 2-3 hours
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ dev = [
     "mypy>=1.17.0",
 ]
 
+# LLM provider dependencies (optional)
+llm-openai = [
+    "langchain-openai>=0.2.0",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -51,6 +56,11 @@ addopts = [
     # with a `tests` directory.
     # See https://docs.pytest.org/en/stable/explanation/goodpractices.html#tests-outside-application-code
     "--import-mode=importlib",
+    # Exclude integration tests by default (they require API keys and make real API calls)
+    "-m", "not integration",
+]
+markers = [
+    "integration: marks tests as integration tests requiring real API calls (deselect with '-m \"not integration\"')",
 ]
 
 [tool.basedpyright]
@@ -92,6 +102,7 @@ ignore = [
     "B", # flake8-bugbear - less strict in tests
     "D", # Documentation
     "S101", # Use of assert detected
+    "PLC0415", # Import outside top-level - acceptable for checking optional dependencies
     "PLR2004", # Magic value used in comparison - acceptable in tests
 ]
 # Connector constructors need many database/filesystem parameters

--- a/src/wct/llm_service.py
+++ b/src/wct/llm_service.py
@@ -212,6 +212,170 @@ class AnthropicLLMService(BaseLLMService):
         return str(content).strip()
 
 
+class OpenAILLMService(BaseLLMService):
+    """Service for interacting with OpenAI's models via LangChain.
+
+    This service provides a unified interface for AI-powered compliance analysis
+    using OpenAI's models (GPT-4, GPT-3.5, etc.) through the LangChain framework.
+    """
+
+    def __init__(
+        self, model_name: str | None = None, api_key: str | None = None
+    ) -> None:
+        """Initialise the OpenAI LLM service.
+
+        Args:
+            model_name: The OpenAI model to use (will use OPENAI_MODEL env var)
+            api_key: OpenAI API key (will use OPENAI_API_KEY env var if not provided)
+
+        Raises:
+            LLMConfigurationError: If API key is not provided or found in environment
+
+        """
+        # Get model name from parameter, environment, or default
+        self.model_name = model_name or os.getenv("OPENAI_MODEL") or "gpt-4o"
+
+        # Get API key from parameter or environment
+        self._api_key = api_key or os.getenv("OPENAI_API_KEY")
+        if not self._api_key:
+            raise LLMConfigurationError(
+                "OpenAI API key is required. Set OPENAI_API_KEY environment variable "
+                "or provide api_key parameter."
+            )
+
+        self._llm = None
+        logger.info(f"Initialised OpenAI LLM service with model: {self.model_name}")
+
+    @override
+    def analyse_data(self, text: str, analysis_prompt: str) -> str:
+        """Analyse text using the LLM with a custom prompt.
+
+        Args:
+            text: The text content to analyse
+            analysis_prompt: The prompt/instructions for analysis
+
+        Returns:
+            LLM analysis response as string
+
+        Raises:
+            LLMConnectionError: If LLM request fails
+            LLMConfigurationError: If OpenAI provider is not installed
+
+        """
+        try:
+            logger.debug(f"Analysing text (length: {len(text)} chars)")
+
+            llm = self._get_llm()  # type: ignore[reportUnknownMemberType]
+
+            # Combine the analysis prompt with the text
+            full_prompt = f"{analysis_prompt}\n\nText to analyse:\n{text}"
+
+            response = llm.invoke(full_prompt)  # type: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            result = self._extract_content(response).strip()  # type: ignore[reportUnknownArgumentType]
+
+            logger.debug(
+                f"LLM analysis completed (response length: {len(result)} chars)"
+            )
+
+            return result
+
+        except Exception as e:
+            logger.error(f"Text analysis failed: {e}")
+            raise LLMConnectionError(f"LLM text analysis failed: {e}") from e
+
+    def _get_llm(self) -> ChatOpenAI:  # type: ignore[name-defined] # noqa: F821
+        """Get or create the LangChain LLM instance with lazy import.
+
+        NOTE: This method uses lazy imports and type ignores because langchain-openai
+        is an optional dependency. The type ignores are necessary due to:
+        1. ChatOpenAI not being available at type checking time (optional dependency)
+        2. Intentional lazy import pattern (PLC0415) for optional dependencies
+        This is the same pattern used throughout the codebase for optional dependencies.
+
+        Returns:
+            LangChain ChatOpenAI instance
+
+        Raises:
+            LLMConfigurationError: If langchain-openai is not installed
+            LLMConnectionError: If API key is not available
+
+        """
+        if self._llm is None:  # type: ignore[reportUnknownMemberType]
+            # Lazy import with helpful error message
+            try:
+                from langchain_openai import (  # noqa: PLC0415  # type: ignore[reportMissingImports]
+                    ChatOpenAI,  # type: ignore[reportUnknownVariableType]
+                )
+            except ImportError as e:
+                raise LLMConfigurationError(
+                    "OpenAI provider is not installed.\n"
+                    "Install it with: uv sync --group llm-openai\n"
+                    "Or install all providers: uv sync --group llm-all"
+                ) from e
+
+            if not self._api_key:
+                raise LLMConnectionError("API key is required but not available")
+
+            self._llm = ChatOpenAI(  # type: ignore[reportUnknownMemberType]
+                model=self.model_name,
+                api_key=SecretStr(self._api_key),
+                temperature=0,  # Consistent responses for compliance analysis
+                timeout=300,  # Increased timeout for LLM requests
+            )
+            logger.debug("Created LangChain ChatOpenAI instance")
+
+        return self._llm  # type: ignore[return-value]
+
+    def _extract_content(self, response: BaseMessage) -> str:
+        """Extract string content from LangChain response, handling all content types.
+
+        LangChain responses can contain various content types. This method safely
+        extracts text content regardless of the underlying structure.
+
+        NOTE: LangChain's type definitions use Unknown types which cause basedpyright
+        to report type errors. The logic below is sound and handles all possible
+        content types properly, but type ignores are needed due to LangChain's
+        incomplete type definitions.
+
+        Args:
+            response: LangChain BaseMessage response
+
+        Returns:
+            Extracted text content as string
+
+        """
+        content = response.content  # type: ignore[reportUnknownMemberType,reportUnknownVariableType]
+
+        # Handle string content (most common case)
+        if isinstance(content, str):
+            return content.strip()
+
+        # Handle list content (e.g., multiple text blocks)
+        if isinstance(content, list):  # type: ignore[reportUnnecessaryIsInstance]
+            text_parts: list[str] = []
+            for item in content:  # type: ignore[reportUnknownVariableType]
+                if isinstance(item, str):
+                    text_parts.append(item)  # type: ignore[reportUnknownMemberType]
+                elif isinstance(item, dict):  # type: ignore[reportUnnecessaryIsInstance]
+                    if "text" in item:
+                        text_parts.append(str(item["text"]))  # type: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+                    else:
+                        text_parts.append(str(item))  # type: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+                else:
+                    text_parts.append(str(item))  # type: ignore[reportUnknownMemberType]
+            return " ".join(text_parts).strip()  # type: ignore[reportUnknownArgumentType]
+
+        # Handle dict content
+        if isinstance(content, dict):  # type: ignore[reportUnnecessaryIsInstance]
+            if "text" in content:
+                return str(content["text"]).strip()  # type: ignore[reportUnknownArgumentType]
+            else:
+                return str(content).strip()
+
+        # Final fallback for any other type
+        return str(content).strip()
+
+
 class LLMServiceFactory:
     """Factory for creating LLM service instances."""
 
@@ -230,3 +394,19 @@ class LLMServiceFactory:
 
         """
         return AnthropicLLMService(model_name=model_name, api_key=api_key)
+
+    @staticmethod
+    def create_openai_service(
+        model_name: str | None = None, api_key: str | None = None
+    ) -> OpenAILLMService:
+        """Create an OpenAI LLM service instance.
+
+        Args:
+            model_name: The OpenAI model to use (uses OPENAI_MODEL env var or default if not provided)
+            api_key: Optional API key (uses OPENAI_API_KEY env var if not provided)
+
+        Returns:
+            Configured OpenAILLMService instance
+
+        """
+        return OpenAILLMService(model_name=model_name, api_key=api_key)

--- a/tests/wct/test_llm_service.py
+++ b/tests/wct/test_llm_service.py
@@ -17,6 +17,8 @@ from wct.llm_service import (
     AnthropicLLMService,
     BaseLLMService,
     LLMConfigurationError,
+    LLMServiceFactory,
+    OpenAILLMService,
 )
 
 
@@ -201,3 +203,411 @@ class TestAnthropicLLMServiceIntegration:
 
             # Verify both calls were made
             assert mock_llm.invoke.call_count == 2
+
+
+class TestOpenAILLMServiceInitialisation:
+    """Test OpenAILLMService initialisation and configuration."""
+
+    def test_initialisation_with_provided_parameters(self) -> None:
+        """Test service initialisation with explicitly provided parameters."""
+        service = OpenAILLMService(model_name="gpt-4", api_key="test-api-key")
+
+        assert service.model_name == "gpt-4"
+        # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_with_environment_variables(self) -> None:
+        """Test service initialisation using environment variables."""
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_MODEL": "gpt-3.5-turbo",
+                "OPENAI_API_KEY": "env-api-key",
+            },
+        ):
+            service = OpenAILLMService()
+
+            assert service.model_name == "gpt-3.5-turbo"
+            # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_with_default_model(self) -> None:
+        """Test service initialisation uses default model when not specified."""
+        with patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "test-key"},
+            clear=True,
+        ):
+            service = OpenAILLMService()
+
+            assert service.model_name == "gpt-4o"
+            # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_parameter_overrides_environment(self) -> None:
+        """Test that explicit parameters override environment variables."""
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_MODEL": "env-model",
+                "OPENAI_API_KEY": "env-key",
+            },
+        ):
+            service = OpenAILLMService(model_name="param-model", api_key="param-key")
+
+            assert service.model_name == "param-model"
+            # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_missing_api_key_raises_error(self) -> None:
+        """Test that missing API key raises configuration error."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(LLMConfigurationError) as exc_info:
+                OpenAILLMService()
+
+            assert "OpenAI API key is required" in str(exc_info.value)
+            assert "OPENAI_API_KEY" in str(exc_info.value)
+
+    def test_initialisation_empty_api_key_raises_error(self) -> None:
+        """Test that empty API key raises configuration error."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": ""}):
+            with pytest.raises(LLMConfigurationError) as exc_info:
+                OpenAILLMService()
+
+            assert "OpenAI API key is required" in str(exc_info.value)
+
+
+class TestOpenAILLMServiceDataAnalysis:
+    """Test OpenAILLMService data analysis functionality."""
+
+    @pytest.fixture
+    def service_with_mock_api(self) -> OpenAILLMService:
+        """Create service instance with mocked API for testing."""
+        return OpenAILLMService(model_name="gpt-4", api_key="test-api-key")
+
+    def test_successful_data_analysis(
+        self, service_with_mock_api: OpenAILLMService
+    ) -> None:
+        """Test successful data analysis returns expected result."""
+        text_to_analyse = "John Smith lives at 123 Main Street"
+        analysis_prompt = "Identify personal data in the following text:"
+        expected_response = (
+            "Personal data found: Name (John Smith), Address (123 Main Street)"
+        )
+
+        mock_response = AIMessage(content=expected_response)
+
+        # Create mock ChatOpenAI class
+        mock_chat_class = Mock()
+        mock_llm = Mock()
+        mock_llm.invoke.return_value = mock_response
+        mock_chat_class.return_value = mock_llm
+
+        # Mock the lazy import by patching __import__
+        with patch.dict(
+            "sys.modules", {"langchain_openai": Mock(ChatOpenAI=mock_chat_class)}
+        ):
+            result = service_with_mock_api.analyse_data(
+                text_to_analyse, analysis_prompt
+            )
+
+            assert result == expected_response
+            assert isinstance(result, str)
+
+            # Verify the LLM was called with the combined prompt
+            mock_llm.invoke.assert_called_once()
+            call_args = mock_llm.invoke.call_args[0][0]
+            assert analysis_prompt in call_args
+            assert text_to_analyse in call_args
+
+    def test_data_analysis_with_complex_response_content(
+        self, service_with_mock_api: OpenAILLMService
+    ) -> None:
+        """Test data analysis handles complex response content structures."""
+        text_to_analyse = "Sample text for analysis"
+        analysis_prompt = "Analyse this text:"
+
+        # Test with list content structure
+        mock_response = AIMessage(
+            content=[
+                {"type": "text", "text": "Analysis result: "},
+                {"type": "text", "text": "Complex content structure"},
+            ]
+        )
+
+        # Create mock ChatOpenAI class
+        mock_chat_class = Mock()
+        mock_llm = Mock()
+        mock_llm.invoke.return_value = mock_response
+        mock_chat_class.return_value = mock_llm
+
+        # Mock the lazy import by patching sys.modules
+        with patch.dict(
+            "sys.modules", {"langchain_openai": Mock(ChatOpenAI=mock_chat_class)}
+        ):
+            result = service_with_mock_api.analyse_data(
+                text_to_analyse, analysis_prompt
+            )
+
+            assert "Analysis result:" in result
+            assert "Complex content structure" in result
+            assert isinstance(result, str)
+
+
+class TestOpenAILLMServiceBasics:
+    """Test OpenAI LLM service basic functionality."""
+
+    def test_openai_service_implements_base_interface(self) -> None:
+        """Test that OpenAILLMService correctly implements BaseLLMService."""
+        service = OpenAILLMService(model_name="gpt-4", api_key="test-key")
+
+        assert isinstance(service, BaseLLMService)
+        assert hasattr(service, "analyse_data")
+        assert callable(service.analyse_data)
+
+
+class TestLLMServiceFactory:
+    """Test LLM service factory methods."""
+
+    def test_factory_can_create_openai_service(self) -> None:
+        """Test that factory can create OpenAI service instance."""
+        service = LLMServiceFactory.create_openai_service(
+            model_name="gpt-4", api_key="test-key"
+        )
+
+        assert isinstance(service, OpenAILLMService)
+        assert service.model_name == "gpt-4"
+
+
+class TestAnthropicLLMServiceRealApiIntegration:
+    """Integration tests with real Anthropic API (requires ANTHROPIC_API_KEY)."""
+
+    @pytest.mark.integration
+    def test_real_anthropic_api_simple_analysis(self) -> None:
+        """Test real Anthropic API with simple text analysis."""
+        # Skip if no API key
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            pytest.skip("ANTHROPIC_API_KEY not set - skipping real API test")
+
+        # Create real service (no mocks)
+        service = AnthropicLLMService(api_key=api_key)
+
+        # Simple test with clear expected content
+        text = "John Smith, email: john@example.com, phone: 555-1234"
+        prompt = "List any personal data found in this text in a single line."
+
+        # Make real API call
+        result = service.analyse_data(text, prompt)
+
+        # Verify response structure (don't assert exact content - LLM responses vary)
+        assert isinstance(result, str)
+        assert len(result) > 0
+        # Check that response mentions some of the personal data
+        assert "john" in result.lower() or "email" in result.lower()
+
+    @pytest.mark.integration
+    def test_real_anthropic_api_with_default_model(self) -> None:
+        """Test real Anthropic API uses default model from environment."""
+        # Skip if no API key
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            pytest.skip("ANTHROPIC_API_KEY not set - skipping real API test")
+
+        # Create service without specifying model (should use default or env var)
+        service = AnthropicLLMService(api_key=api_key)
+
+        # Verify model name is set (either default or from ANTHROPIC_MODEL env var)
+        expected_default = "claude-sonnet-4-5-20250929"
+        env_model = os.getenv("ANTHROPIC_MODEL")
+        expected_model = env_model if env_model else expected_default
+        assert service.model_name == expected_model
+
+        # Make a real API call to verify it works
+        text = "Test data"
+        prompt = "Reply with 'OK' if you can read this."
+
+        result = service.analyse_data(text, prompt)
+
+        # Verify we got a response
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.integration
+    def test_real_anthropic_api_with_custom_model(self) -> None:
+        """Test real Anthropic API with explicitly specified model."""
+        # Skip if no API key
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            pytest.skip("ANTHROPIC_API_KEY not set - skipping real API test")
+
+        # Create service with explicitly specified model
+        custom_model = "claude-3-5-sonnet-20241022"
+        service = AnthropicLLMService(model_name=custom_model, api_key=api_key)
+
+        # Verify the model name is set correctly
+        assert service.model_name == custom_model
+
+        # Make a real API call to verify it works with this model
+        text = "Hello"
+        prompt = "Reply with just the word 'Hi'"
+
+        result = service.analyse_data(text, prompt)
+
+        # Verify we got a response
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.integration
+    def test_real_anthropic_api_handles_empty_response(self) -> None:
+        """Test real Anthropic API handles edge cases gracefully."""
+        # Skip if no API key
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            pytest.skip("ANTHROPIC_API_KEY not set - skipping real API test")
+
+        # Create service
+        service = AnthropicLLMService(api_key=api_key)
+
+        # Test with minimal input that might produce a brief response
+        text = ""
+        prompt = "If the text is empty, respond with just 'EMPTY'"
+
+        result = service.analyse_data(text, prompt)
+
+        # Even with empty input, we should get a valid response
+        assert isinstance(result, str)
+        assert len(result) > 0
+        # LLM should recognize empty input
+        assert "empty" in result.lower()
+
+
+class TestOpenAILLMServiceRealApiIntegration:
+    """Integration tests with real OpenAI API (requires OPENAI_API_KEY and langchain-openai)."""
+
+    @pytest.mark.integration
+    def test_real_openai_api_simple_analysis(self) -> None:
+        """Test real OpenAI API with simple text analysis."""
+        # Skip if no API key
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            pytest.skip("OPENAI_API_KEY not set - skipping real API test")
+
+        # Skip if langchain-openai not installed
+        try:
+            from langchain_openai import ChatOpenAI  # noqa: F401
+        except ImportError:
+            pytest.skip(
+                "langchain-openai not installed - run: uv sync --group llm-openai"
+            )
+
+        # Create real service (no mocks)
+        service = OpenAILLMService(api_key=api_key)
+
+        # Simple test with clear expected content
+        text = "John Smith, email: john@example.com, phone: 555-1234"
+        prompt = "List any personal data found in this text in a single line."
+
+        # Make real API call
+        result = service.analyse_data(text, prompt)
+
+        # Verify response structure (don't assert exact content - LLM responses vary)
+        assert isinstance(result, str)
+        assert len(result) > 0
+        # Check that response mentions some of the personal data
+        assert "john" in result.lower() or "email" in result.lower()
+
+    @pytest.mark.integration
+    def test_real_openai_api_with_default_model(self) -> None:
+        """Test real OpenAI API uses default model from environment."""
+        # Skip if no API key
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            pytest.skip("OPENAI_API_KEY not set - skipping real API test")
+
+        # Skip if langchain-openai not installed
+        try:
+            from langchain_openai import ChatOpenAI  # noqa: F401
+        except ImportError:
+            pytest.skip(
+                "langchain-openai not installed - run: uv sync --group llm-openai"
+            )
+
+        # Create service without specifying model (should use default or env var)
+        service = OpenAILLMService(api_key=api_key)
+
+        # Verify model name is set (either default or from OPENAI_MODEL env var)
+        expected_default = "gpt-4o"
+        env_model = os.getenv("OPENAI_MODEL")
+        expected_model = env_model if env_model else expected_default
+        assert service.model_name == expected_model
+
+        # Make a real API call to verify it works
+        text = "Test data"
+        prompt = "Reply with 'OK' if you can read this."
+
+        result = service.analyse_data(text, prompt)
+
+        # Verify we got a response
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.integration
+    def test_real_openai_api_with_custom_model(self) -> None:
+        """Test real OpenAI API with explicitly specified model."""
+        # Skip if no API key
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            pytest.skip("OPENAI_API_KEY not set - skipping real API test")
+
+        # Skip if langchain-openai not installed
+        try:
+            from langchain_openai import ChatOpenAI  # noqa: F401
+        except ImportError:
+            pytest.skip(
+                "langchain-openai not installed - run: uv sync --group llm-openai"
+            )
+
+        # Create service with explicitly specified model
+        custom_model = "gpt-4o-mini"
+        service = OpenAILLMService(model_name=custom_model, api_key=api_key)
+
+        # Verify the model name is set correctly
+        assert service.model_name == custom_model
+
+        # Make a real API call to verify it works with this model
+        text = "Hello"
+        prompt = "Reply with just the word 'Hi'"
+
+        result = service.analyse_data(text, prompt)
+
+        # Verify we got a response
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.integration
+    def test_real_openai_api_handles_empty_response(self) -> None:
+        """Test real OpenAI API handles edge cases gracefully."""
+        # Skip if no API key
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            pytest.skip("OPENAI_API_KEY not set - skipping real API test")
+
+        # Skip if langchain-openai not installed
+        try:
+            from langchain_openai import ChatOpenAI  # noqa: F401
+        except ImportError:
+            pytest.skip(
+                "langchain-openai not installed - run: uv sync --group llm-openai"
+            )
+
+        # Create service
+        service = OpenAILLMService(api_key=api_key)
+
+        # Test with minimal input that might produce a brief response
+        text = ""
+        prompt = "If the text is empty, respond with just 'EMPTY'"
+
+        result = service.analyse_data(text, prompt)
+
+        # Even with empty input, we should get a valid response
+        assert isinstance(result, str)
+        assert len(result) > 0
+        # LLM should recognize empty input
+        assert "empty" in result.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -460,7 +460,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.72"
+version = "0.3.79"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -471,9 +471,23 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/49/7568baeb96a57d3218cb5f1f113b142063679088fd3a0d0cae1feb0b3d36/langchain_core-0.3.72.tar.gz", hash = "sha256:4de3828909b3d7910c313242ab07b241294650f5cb6eac17738dd3638b1cd7de", size = 567227, upload-time = "2025-07-24T00:40:08.5Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/99/f926495f467e0f43289f12e951655d267d1eddc1136c3cf4dd907794a9a7/langchain_core-0.3.79.tar.gz", hash = "sha256:024ba54a346dd9b13fb8b2342e0c83d0111e7f26fa01f545ada23ad772b55a60", size = 580895, upload-time = "2025-10-09T21:59:08.359Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/7d/9f75023c478e3b854d67da31d721e39f0eb30ae969ec6e755430cb1c0fb5/langchain_core-0.3.72-py3-none-any.whl", hash = "sha256:9fa15d390600eb6b6544397a7aa84be9564939b6adf7a2b091179ea30405b240", size = 442806, upload-time = "2025-07-24T00:40:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/71/46b0efaf3fc6ad2c2bd600aef500f1cb2b7038a4042f58905805630dd29d/langchain_core-0.3.79-py3-none-any.whl", hash = "sha256:92045bfda3e741f8018e1356f83be203ec601561c6a7becfefe85be5ddc58fdb", size = 449779, upload-time = "2025-10-09T21:59:06.493Z" },
+]
+
+[[package]]
+name = "langchain-openai"
+version = "0.3.35"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/96/06d0d25a37e05a0ff2d918f0a4b0bf0732aed6a43b472b0b68426ce04ef8/langchain_openai-0.3.35.tar.gz", hash = "sha256:fa985fd041c3809da256a040c98e8a43e91c6d165b96dcfeb770d8bd457bf76f", size = 786635, upload-time = "2025-10-06T15:09:28.463Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/d5/c90c5478215c20ee71d8feaf676f7ffd78d0568f8c98bd83f81ce7562ed7/langchain_openai-0.3.35-py3-none-any.whl", hash = "sha256:76d5707e6e81fd461d33964ad618bd326cb661a1975cef7c1cb0703576bdada5", size = 75952, upload-time = "2025-10-06T15:09:27.137Z" },
 ]
 
 [[package]]
@@ -585,6 +599,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/cd/e2b5083df581fc1d08eb93feb6f8fbd3d56b113cef9b59d8e0fb7d4dd4f3/nodejs_wheel_binaries-22.16.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7f526ca6a132b0caf633566a2a78c6985fe92857e7bfdb37380f76205a10b808", size = 60763005, upload-time = "2025-05-22T07:27:41.39Z" },
     { url = "https://files.pythonhosted.org/packages/71/8d/57112b49214e8bd636f3cc3386eba6be4d23552ec8a0f6efbe814013caa7/nodejs_wheel_binaries-22.16.0-py2.py3-none-win_amd64.whl", hash = "sha256:2fffb4bf1066fb5f660da20819d754f1b424bca1b234ba0f4fa901c52e3975fb", size = 41313324, upload-time = "2025-05-22T07:27:45.293Z" },
     { url = "https://files.pythonhosted.org/packages/91/03/a852711aec73dfb965844592dfe226024c0da28e37d1ee54083342e38f57/nodejs_wheel_binaries-22.16.0-py2.py3-none-win_arm64.whl", hash = "sha256:2728972d336d436d39ee45988978d8b5d963509e06f063e80fe41b203ee80b28", size = 38828154, upload-time = "2025-05-22T07:27:48.606Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/90/8f26554d24d63ed4f94d33c24271559863223a67e624f4d2e65ba8e48dca/openai-2.3.0.tar.gz", hash = "sha256:8d213ee5aaf91737faea2d7fc1cd608657a5367a18966372a3756ceaabfbd812", size = 589616, upload-time = "2025-10-10T01:12:50.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/5b/4be258ff072ed8ee15f6bfd8d5a1a4618aa4704b127c0c5959212ad177d6/openai-2.3.0-py3-none-any.whl", hash = "sha256:a7aa83be6f7b0ab2e4d4d7bcaf36e3d790874c0167380c5d0afd0ed99a86bd7b", size = 999768, upload-time = "2025-10-10T01:12:48.647Z" },
 ]
 
 [[package]]
@@ -850,6 +883,84 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2025.9.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/d3/eaa0d28aba6ad1827ad1e716d9a93e1ba963ada61887498297d3da715133/regex-2025.9.18.tar.gz", hash = "sha256:c5ba23274c61c6fef447ba6a39333297d0c247f53059dba0bca415cac511edc4", size = 400917, upload-time = "2025-09-19T00:38:35.79Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/99/05859d87a66ae7098222d65748f11ef7f2dff51bfd7482a4e2256c90d72b/regex-2025.9.18-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:436e1b31d7efd4dcd52091d076482031c611dde58bf9c46ca6d0a26e33053a7e", size = 486335, upload-time = "2025-09-19T00:36:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/97/7e/d43d4e8b978890932cf7b0957fce58c5b08c66f32698f695b0c2c24a48bf/regex-2025.9.18-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c190af81e5576b9c5fdc708f781a52ff20f8b96386c6e2e0557a78402b029f4a", size = 289720, upload-time = "2025-09-19T00:36:05.471Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3b/ff80886089eb5dcf7e0d2040d9aaed539e25a94300403814bb24cc775058/regex-2025.9.18-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e4121f1ce2b2b5eec4b397cc1b277686e577e658d8f5870b7eb2d726bd2300ab", size = 287257, upload-time = "2025-09-19T00:36:07.072Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/66/243edf49dd8720cba8d5245dd4d6adcb03a1defab7238598c0c97cf549b8/regex-2025.9.18-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:300e25dbbf8299d87205e821a201057f2ef9aa3deb29caa01cd2cac669e508d5", size = 797463, upload-time = "2025-09-19T00:36:08.399Z" },
+    { url = "https://files.pythonhosted.org/packages/df/71/c9d25a1142c70432e68bb03211d4a82299cd1c1fbc41db9409a394374ef5/regex-2025.9.18-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7b47fcf9f5316c0bdaf449e879407e1b9937a23c3b369135ca94ebc8d74b1742", size = 862670, upload-time = "2025-09-19T00:36:10.101Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8f/329b1efc3a64375a294e3a92d43372bf1a351aa418e83c21f2f01cf6ec41/regex-2025.9.18-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:57a161bd3acaa4b513220b49949b07e252165e6b6dc910ee7617a37ff4f5b425", size = 910881, upload-time = "2025-09-19T00:36:12.223Z" },
+    { url = "https://files.pythonhosted.org/packages/35/9e/a91b50332a9750519320ed30ec378b74c996f6befe282cfa6bb6cea7e9fd/regex-2025.9.18-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f130c3a7845ba42de42f380fff3c8aebe89a810747d91bcf56d40a069f15352", size = 802011, upload-time = "2025-09-19T00:36:13.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1d/6be3b8d7856b6e0d7ee7f942f437d0a76e0d5622983abbb6d21e21ab9a17/regex-2025.9.18-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5f96fa342b6f54dcba928dd452e8d8cb9f0d63e711d1721cd765bb9f73bb048d", size = 786668, upload-time = "2025-09-19T00:36:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ce/4a60e53df58bd157c5156a1736d3636f9910bdcc271d067b32b7fcd0c3a8/regex-2025.9.18-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:0f0d676522d68c207828dcd01fb6f214f63f238c283d9f01d85fc664c7c85b56", size = 856578, upload-time = "2025-09-19T00:36:16.845Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e8/162c91bfe7217253afccde112868afb239f94703de6580fb235058d506a6/regex-2025.9.18-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:40532bff8a1a0621e7903ae57fce88feb2e8a9a9116d341701302c9302aef06e", size = 849017, upload-time = "2025-09-19T00:36:18.597Z" },
+    { url = "https://files.pythonhosted.org/packages/35/34/42b165bc45289646ea0959a1bc7531733e90b47c56a72067adfe6b3251f6/regex-2025.9.18-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:039f11b618ce8d71a1c364fdee37da1012f5a3e79b1b2819a9f389cd82fd6282", size = 788150, upload-time = "2025-09-19T00:36:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/79/5d/cdd13b1f3c53afa7191593a7ad2ee24092a5a46417725ffff7f64be8342d/regex-2025.9.18-cp312-cp312-win32.whl", hash = "sha256:e1dd06f981eb226edf87c55d523131ade7285137fbde837c34dc9d1bf309f459", size = 264536, upload-time = "2025-09-19T00:36:21.922Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f5/4a7770c9a522e7d2dc1fa3ffc83ab2ab33b0b22b447e62cffef186805302/regex-2025.9.18-cp312-cp312-win_amd64.whl", hash = "sha256:3d86b5247bf25fa3715e385aa9ff272c307e0636ce0c9595f64568b41f0a9c77", size = 275501, upload-time = "2025-09-19T00:36:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/df/05/9ce3e110e70d225ecbed455b966003a3afda5e58e8aec2964042363a18f4/regex-2025.9.18-cp312-cp312-win_arm64.whl", hash = "sha256:032720248cbeeae6444c269b78cb15664458b7bb9ed02401d3da59fe4d68c3a5", size = 268601, upload-time = "2025-09-19T00:36:25.092Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c7/5c48206a60ce33711cf7dcaeaed10dd737733a3569dc7e1dce324dd48f30/regex-2025.9.18-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2a40f929cd907c7e8ac7566ac76225a77701a6221bca937bdb70d56cb61f57b2", size = 485955, upload-time = "2025-09-19T00:36:26.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/be/74fc6bb19a3c491ec1ace943e622b5a8539068771e8705e469b2da2306a7/regex-2025.9.18-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c90471671c2cdf914e58b6af62420ea9ecd06d1554d7474d50133ff26ae88feb", size = 289583, upload-time = "2025-09-19T00:36:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c4/9ceaa433cb5dc515765560f22a19578b95b92ff12526e5a259321c4fc1a0/regex-2025.9.18-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1a351aff9e07a2dabb5022ead6380cff17a4f10e4feb15f9100ee56c4d6d06af", size = 287000, upload-time = "2025-09-19T00:36:30.161Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/e6/68bc9393cb4dc68018456568c048ac035854b042bc7c33cb9b99b0680afa/regex-2025.9.18-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc4b8e9d16e20ddfe16430c23468a8707ccad3365b06d4536142e71823f3ca29", size = 797535, upload-time = "2025-09-19T00:36:31.876Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/ebae9032d34b78ecfe9bd4b5e6575b55351dc8513485bb92326613732b8c/regex-2025.9.18-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4b8cdbddf2db1c5e80338ba2daa3cfa3dec73a46fff2a7dda087c8efbf12d62f", size = 862603, upload-time = "2025-09-19T00:36:33.344Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/74/12332c54b3882557a4bcd2b99f8be581f5c6a43cf1660a85b460dd8ff468/regex-2025.9.18-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a276937d9d75085b2c91fb48244349c6954f05ee97bba0963ce24a9d915b8b68", size = 910829, upload-time = "2025-09-19T00:36:34.826Z" },
+    { url = "https://files.pythonhosted.org/packages/86/70/ba42d5ed606ee275f2465bfc0e2208755b06cdabd0f4c7c4b614d51b57ab/regex-2025.9.18-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92a8e375ccdc1256401c90e9dc02b8642894443d549ff5e25e36d7cf8a80c783", size = 802059, upload-time = "2025-09-19T00:36:36.664Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c5/fcb017e56396a7f2f8357412638d7e2963440b131a3ca549be25774b3641/regex-2025.9.18-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0dc6893b1f502d73037cf807a321cdc9be29ef3d6219f7970f842475873712ac", size = 786781, upload-time = "2025-09-19T00:36:38.168Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ee/21c4278b973f630adfb3bcb23d09d83625f3ab1ca6e40ebdffe69901c7a1/regex-2025.9.18-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a61e85bfc63d232ac14b015af1261f826260c8deb19401c0597dbb87a864361e", size = 856578, upload-time = "2025-09-19T00:36:40.129Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/de51550dc7274324435c8f1539373ac63019b0525ad720132866fff4a16a/regex-2025.9.18-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:1ef86a9ebc53f379d921fb9a7e42b92059ad3ee800fcd9e0fe6181090e9f6c23", size = 849119, upload-time = "2025-09-19T00:36:41.651Z" },
+    { url = "https://files.pythonhosted.org/packages/60/52/383d3044fc5154d9ffe4321696ee5b2ee4833a28c29b137c22c33f41885b/regex-2025.9.18-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d3bc882119764ba3a119fbf2bd4f1b47bc56c1da5d42df4ed54ae1e8e66fdf8f", size = 788219, upload-time = "2025-09-19T00:36:43.575Z" },
+    { url = "https://files.pythonhosted.org/packages/20/bd/2614fc302671b7359972ea212f0e3a92df4414aaeacab054a8ce80a86073/regex-2025.9.18-cp313-cp313-win32.whl", hash = "sha256:3810a65675845c3bdfa58c3c7d88624356dd6ee2fc186628295e0969005f928d", size = 264517, upload-time = "2025-09-19T00:36:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/07/0f/ab5c1581e6563a7bffdc1974fb2d25f05689b88e2d416525271f232b1946/regex-2025.9.18-cp313-cp313-win_amd64.whl", hash = "sha256:16eaf74b3c4180ede88f620f299e474913ab6924d5c4b89b3833bc2345d83b3d", size = 275481, upload-time = "2025-09-19T00:36:46.965Z" },
+    { url = "https://files.pythonhosted.org/packages/49/22/ee47672bc7958f8c5667a587c2600a4fba8b6bab6e86bd6d3e2b5f7cac42/regex-2025.9.18-cp313-cp313-win_arm64.whl", hash = "sha256:4dc98ba7dd66bd1261927a9f49bd5ee2bcb3660f7962f1ec02617280fc00f5eb", size = 268598, upload-time = "2025-09-19T00:36:48.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/83/6887e16a187c6226cb85d8301e47d3b73ecc4505a3a13d8da2096b44fd76/regex-2025.9.18-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fe5d50572bc885a0a799410a717c42b1a6b50e2f45872e2b40f4f288f9bce8a2", size = 489765, upload-time = "2025-09-19T00:36:49.996Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c5/e2f7325301ea2916ff301c8d963ba66b1b2c1b06694191df80a9c4fea5d0/regex-2025.9.18-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:1b9d9a2d6cda6621551ca8cf7a06f103adf72831153f3c0d982386110870c4d3", size = 291228, upload-time = "2025-09-19T00:36:51.654Z" },
+    { url = "https://files.pythonhosted.org/packages/91/60/7d229d2bc6961289e864a3a3cfebf7d0d250e2e65323a8952cbb7e22d824/regex-2025.9.18-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:13202e4c4ac0ef9a317fff817674b293c8f7e8c68d3190377d8d8b749f566e12", size = 289270, upload-time = "2025-09-19T00:36:53.118Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/b4f06868ee2958ff6430df89857fbf3d43014bbf35538b6ec96c2704e15d/regex-2025.9.18-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:874ff523b0fecffb090f80ae53dc93538f8db954c8bb5505f05b7787ab3402a0", size = 806326, upload-time = "2025-09-19T00:36:54.631Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e4/bca99034a8f1b9b62ccf337402a8e5b959dd5ba0e5e5b2ead70273df3277/regex-2025.9.18-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d13ab0490128f2bb45d596f754148cd750411afc97e813e4b3a61cf278a23bb6", size = 871556, upload-time = "2025-09-19T00:36:56.208Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/df/e06ffaf078a162f6dd6b101a5ea9b44696dca860a48136b3ae4a9caf25e2/regex-2025.9.18-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:05440bc172bc4b4b37fb9667e796597419404dbba62e171e1f826d7d2a9ebcef", size = 913817, upload-time = "2025-09-19T00:36:57.807Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/05/25b05480b63292fd8e84800b1648e160ca778127b8d2367a0a258fa2e225/regex-2025.9.18-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5514b8e4031fdfaa3d27e92c75719cbe7f379e28cacd939807289bce76d0e35a", size = 811055, upload-time = "2025-09-19T00:36:59.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/97/7bc7574655eb651ba3a916ed4b1be6798ae97af30104f655d8efd0cab24b/regex-2025.9.18-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:65d3c38c39efce73e0d9dc019697b39903ba25b1ad45ebbd730d2cf32741f40d", size = 794534, upload-time = "2025-09-19T00:37:01.405Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c2/d5da49166a52dda879855ecdba0117f073583db2b39bb47ce9a3378a8e9e/regex-2025.9.18-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:ae77e447ebc144d5a26d50055c6ddba1d6ad4a865a560ec7200b8b06bc529368", size = 866684, upload-time = "2025-09-19T00:37:03.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2d/0a5c4e6ec417de56b89ff4418ecc72f7e3feca806824c75ad0bbdae0516b/regex-2025.9.18-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e3ef8cf53dc8df49d7e28a356cf824e3623764e9833348b655cfed4524ab8a90", size = 853282, upload-time = "2025-09-19T00:37:04.985Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8e/d656af63e31a86572ec829665d6fa06eae7e144771e0330650a8bb865635/regex-2025.9.18-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:9feb29817df349c976da9a0debf775c5c33fc1c8ad7b9f025825da99374770b7", size = 797830, upload-time = "2025-09-19T00:37:06.697Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ce/06edc89df8f7b83ffd321b6071be4c54dc7332c0f77860edc40ce57d757b/regex-2025.9.18-cp313-cp313t-win32.whl", hash = "sha256:168be0d2f9b9d13076940b1ed774f98595b4e3c7fc54584bba81b3cc4181742e", size = 267281, upload-time = "2025-09-19T00:37:08.568Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9a/2b5d9c8b307a451fd17068719d971d3634ca29864b89ed5c18e499446d4a/regex-2025.9.18-cp313-cp313t-win_amd64.whl", hash = "sha256:d59ecf3bb549e491c8104fea7313f3563c7b048e01287db0a90485734a70a730", size = 278724, upload-time = "2025-09-19T00:37:10.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/70/177d31e8089a278a764f8ec9a3faac8d14a312d622a47385d4b43905806f/regex-2025.9.18-cp313-cp313t-win_arm64.whl", hash = "sha256:dbef80defe9fb21310948a2595420b36c6d641d9bea4c991175829b2cc4bc06a", size = 269771, upload-time = "2025-09-19T00:37:13.041Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b7/3b4663aa3b4af16819f2ab6a78c4111c7e9b066725d8107753c2257448a5/regex-2025.9.18-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c6db75b51acf277997f3adcd0ad89045d856190d13359f15ab5dda21581d9129", size = 486130, upload-time = "2025-09-19T00:37:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/80/5b/4533f5d7ac9c6a02a4725fe8883de2aebc713e67e842c04cf02626afb747/regex-2025.9.18-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8f9698b6f6895d6db810e0bda5364f9ceb9e5b11328700a90cae573574f61eea", size = 289539, upload-time = "2025-09-19T00:37:16.356Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8d/5ab6797c2750985f79e9995fad3254caa4520846580f266ae3b56d1cae58/regex-2025.9.18-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29cd86aa7cb13a37d0f0d7c21d8d949fe402ffa0ea697e635afedd97ab4b69f1", size = 287233, upload-time = "2025-09-19T00:37:18.025Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/95afcb02ba8d3a64e6ffeb801718ce73471ad6440c55d993f65a4a5e7a92/regex-2025.9.18-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c9f285a071ee55cd9583ba24dde006e53e17780bb309baa8e4289cd472bcc47", size = 797876, upload-time = "2025-09-19T00:37:19.609Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/fb/720b1f49cec1f3b5a9fea5b34cd22b88b5ebccc8c1b5de9cc6f65eed165a/regex-2025.9.18-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5adf266f730431e3be9021d3e5b8d5ee65e563fec2883ea8093944d21863b379", size = 863385, upload-time = "2025-09-19T00:37:21.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ca/e0d07ecf701e1616f015a720dc13b84c582024cbfbb3fc5394ae204adbd7/regex-2025.9.18-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1137cabc0f38807de79e28d3f6e3e3f2cc8cfb26bead754d02e6d1de5f679203", size = 910220, upload-time = "2025-09-19T00:37:23.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/45/bba86413b910b708eca705a5af62163d5d396d5f647ed9485580c7025209/regex-2025.9.18-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7cc9e5525cada99699ca9223cce2d52e88c52a3d2a0e842bd53de5497c604164", size = 801827, upload-time = "2025-09-19T00:37:25.684Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/740fbd9fcac31a1305a8eed30b44bf0f7f1e042342be0a4722c0365ecfca/regex-2025.9.18-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bbb9246568f72dce29bcd433517c2be22c7791784b223a810225af3b50d1aafb", size = 786843, upload-time = "2025-09-19T00:37:27.62Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a7/0579e8560682645906da640c9055506465d809cb0f5415d9976f417209a6/regex-2025.9.18-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6a52219a93dd3d92c675383efff6ae18c982e2d7651c792b1e6d121055808743", size = 857430, upload-time = "2025-09-19T00:37:29.362Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9b/4dc96b6c17b38900cc9fee254fc9271d0dde044e82c78c0811b58754fde5/regex-2025.9.18-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:ae9b3840c5bd456780e3ddf2f737ab55a79b790f6409182012718a35c6d43282", size = 848612, upload-time = "2025-09-19T00:37:31.42Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/6a/6f659f99bebb1775e5ac81a3fb837b85897c1a4ef5acffd0ff8ffe7e67fb/regex-2025.9.18-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d488c236ac497c46a5ac2005a952c1a0e22a07be9f10c3e735bc7d1209a34773", size = 787967, upload-time = "2025-09-19T00:37:34.019Z" },
+    { url = "https://files.pythonhosted.org/packages/61/35/9e35665f097c07cf384a6b90a1ac11b0b1693084a0b7a675b06f760496c6/regex-2025.9.18-cp314-cp314-win32.whl", hash = "sha256:0c3506682ea19beefe627a38872d8da65cc01ffa25ed3f2e422dffa1474f0788", size = 269847, upload-time = "2025-09-19T00:37:35.759Z" },
+    { url = "https://files.pythonhosted.org/packages/af/64/27594dbe0f1590b82de2821ebfe9a359b44dcb9b65524876cd12fabc447b/regex-2025.9.18-cp314-cp314-win_amd64.whl", hash = "sha256:57929d0f92bebb2d1a83af372cd0ffba2263f13f376e19b1e4fa32aec4efddc3", size = 278755, upload-time = "2025-09-19T00:37:37.367Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a3/0cd8d0d342886bd7d7f252d701b20ae1a3c72dc7f34ef4b2d17790280a09/regex-2025.9.18-cp314-cp314-win_arm64.whl", hash = "sha256:6a4b44df31d34fa51aa5c995d3aa3c999cec4d69b9bd414a8be51984d859f06d", size = 271873, upload-time = "2025-09-19T00:37:39.125Z" },
+    { url = "https://files.pythonhosted.org/packages/99/cb/8a1ab05ecf404e18b54348e293d9b7a60ec2bd7aa59e637020c5eea852e8/regex-2025.9.18-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:b176326bcd544b5e9b17d6943f807697c0cb7351f6cfb45bf5637c95ff7e6306", size = 489773, upload-time = "2025-09-19T00:37:40.968Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3b/6543c9b7f7e734d2404fa2863d0d710c907bef99d4598760ed4563d634c3/regex-2025.9.18-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:0ffd9e230b826b15b369391bec167baed57c7ce39efc35835448618860995946", size = 291221, upload-time = "2025-09-19T00:37:42.901Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/e9fdee6ad6bf708d98c5d17fded423dcb0661795a49cba1b4ffb8358377a/regex-2025.9.18-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec46332c41add73f2b57e2f5b642f991f6b15e50e9f86285e08ffe3a512ac39f", size = 289268, upload-time = "2025-09-19T00:37:44.823Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a6/bc3e8a918abe4741dadeaeb6c508e3a4ea847ff36030d820d89858f96a6c/regex-2025.9.18-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b80fa342ed1ea095168a3f116637bd1030d39c9ff38dc04e54ef7c521e01fc95", size = 806659, upload-time = "2025-09-19T00:37:46.684Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/71/ea62dbeb55d9e6905c7b5a49f75615ea1373afcad95830047e4e310db979/regex-2025.9.18-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f4d97071c0ba40f0cf2a93ed76e660654c399a0a04ab7d85472239460f3da84b", size = 871701, upload-time = "2025-09-19T00:37:48.882Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/90/fbe9dedb7dad24a3a4399c0bae64bfa932ec8922a0a9acf7bc88db30b161/regex-2025.9.18-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0ac936537ad87cef9e0e66c5144484206c1354224ee811ab1519a32373e411f3", size = 913742, upload-time = "2025-09-19T00:37:51.015Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/1c/47e4a8c0e73d41eb9eb9fdeba3b1b810110a5139a2526e82fd29c2d9f867/regex-2025.9.18-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dec57f96d4def58c422d212d414efe28218d58537b5445cf0c33afb1b4768571", size = 811117, upload-time = "2025-09-19T00:37:52.686Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/da/435f29fddfd015111523671e36d30af3342e8136a889159b05c1d9110480/regex-2025.9.18-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:48317233294648bf7cd068857f248e3a57222259a5304d32c7552e2284a1b2ad", size = 794647, upload-time = "2025-09-19T00:37:54.626Z" },
+    { url = "https://files.pythonhosted.org/packages/23/66/df5e6dcca25c8bc57ce404eebc7342310a0d218db739d7882c9a2b5974a3/regex-2025.9.18-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:274687e62ea3cf54846a9b25fc48a04459de50af30a7bd0b61a9e38015983494", size = 866747, upload-time = "2025-09-19T00:37:56.367Z" },
+    { url = "https://files.pythonhosted.org/packages/82/42/94392b39b531f2e469b2daa40acf454863733b674481fda17462a5ffadac/regex-2025.9.18-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a78722c86a3e7e6aadf9579e3b0ad78d955f2d1f1a8ca4f67d7ca258e8719d4b", size = 853434, upload-time = "2025-09-19T00:37:58.39Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f8/dcc64c7f7bbe58842a8f89622b50c58c3598fbbf4aad0a488d6df2c699f1/regex-2025.9.18-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:06104cd203cdef3ade989a1c45b6215bf42f8b9dd705ecc220c173233f7cba41", size = 798024, upload-time = "2025-09-19T00:38:00.397Z" },
+    { url = "https://files.pythonhosted.org/packages/20/8d/edf1c5d5aa98f99a692313db813ec487732946784f8f93145e0153d910e5/regex-2025.9.18-cp314-cp314t-win32.whl", hash = "sha256:2e1eddc06eeaffd249c0adb6fafc19e2118e6308c60df9db27919e96b5656096", size = 273029, upload-time = "2025-09-19T00:38:02.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/24/02d4e4f88466f17b145f7ea2b2c11af3a942db6222429c2c146accf16054/regex-2025.9.18-cp314-cp314t-win_amd64.whl", hash = "sha256:8620d247fb8c0683ade51217b459cb4a1081c0405a3072235ba43a40d355c09a", size = 282680, upload-time = "2025-09-19T00:38:04.102Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/a3/c64894858aaaa454caa7cc47e2f225b04d3ed08ad649eacf58d45817fad2/regex-2025.9.18-cp314-cp314t-win_arm64.whl", hash = "sha256:b7531a8ef61de2c647cdf68b3229b071e46ec326b3138b2180acb4275f470b01", size = 273034, upload-time = "2025-09-19T00:38:05.807Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1047,6 +1158,65 @@ wheels = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/85/be65d39d6b647c79800fd9d29241d081d4eeb06271f383bb87200d74cf76/tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8", size = 1050728, upload-time = "2025-10-06T20:21:52.756Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c5/ed88504d2f4a5fd6856990b230b56d85a777feab84e6129af0822f5d0f70/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37", size = 1129008, upload-time = "2025-10-06T20:21:54.832Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
+    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
+    { url = "https://files.pythonhosted.org/packages/72/05/3abc1db5d2c9aadc4d2c76fa5640134e475e58d9fbb82b5c535dc0de9b01/tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646", size = 1050188, upload-time = "2025-10-06T20:22:19.563Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7b/50c2f060412202d6c95f32b20755c7a6273543b125c0985d6fa9465105af/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88", size = 993978, upload-time = "2025-10-06T20:22:20.702Z" },
+    { url = "https://files.pythonhosted.org/packages/14/27/bf795595a2b897e271771cd31cb847d479073497344c637966bdf2853da1/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff", size = 1129271, upload-time = "2025-10-06T20:22:22.06Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/9341a6d7a8f1b448573bbf3425fa57669ac58258a667eb48a25dfe916d70/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830", size = 1151216, upload-time = "2025-10-06T20:22:23.085Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0d/881866647b8d1be4d67cb24e50d0c26f9f807f994aa1510cb9ba2fe5f612/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b", size = 1194860, upload-time = "2025-10-06T20:22:24.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/b651ec3059474dab649b8d5b69f5c65cd8fcd8918568c1935bd4136c9392/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b", size = 1254567, upload-time = "2025-10-06T20:22:25.671Z" },
+    { url = "https://files.pythonhosted.org/packages/80/57/ce64fd16ac390fafde001268c364d559447ba09b509181b2808622420eec/tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3", size = 921067, upload-time = "2025-10-06T20:22:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a4/72eed53e8976a099539cdd5eb36f241987212c29629d0a52c305173e0a68/tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365", size = 1050473, upload-time = "2025-10-06T20:22:27.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d7/0110b8f54c008466b19672c615f2168896b83706a6611ba6e47313dbc6e9/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e", size = 993855, upload-time = "2025-10-06T20:22:28.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/77/4f268c41a3957c418b084dd576ea2fad2e95da0d8e1ab705372892c2ca22/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63", size = 1129022, upload-time = "2025-10-06T20:22:29.981Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2b/fc46c90fe5028bd094cd6ee25a7db321cb91d45dc87531e2bdbb26b4867a/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0", size = 1150736, upload-time = "2025-10-06T20:22:30.996Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
 name = "tree-sitter"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1172,6 +1342,9 @@ dev = [
     { name = "pytest-mock" },
     { name = "ruff" },
 ]
+llm-openai = [
+    { name = "langchain-openai" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1200,6 +1373,7 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "ruff", specifier = ">=0.11.12" },
 ]
+llm-openai = [{ name = "langchain-openai", specifier = ">=0.2.0" }]
 
 [[package]]
 name = "zstandard"


### PR DESCRIPTION
## Summary
Add support for OpenAI as an alternative LLM provider alongside Anthropic, with optional dependency management and comprehensive real API integration testing.

This is **Feature 2** of the [multi-provider LLM support implementation plan](https://github.com/waivern-compliance/waivern-compliance/blob/main/docs/feature-plans/multi-provider-llm-support.md).

## Implementation

### Core Changes
- ✅ Add `OpenAILLMService` class with lazy import pattern
- ✅ Add `LLMServiceFactory.create_openai_service()` method
- ✅ Add optional dependency group: `llm-openai` (langchain-openai>=0.2.0)
- ✅ Document OpenAI configuration in `.env.example`

### Testing Infrastructure
- ✅ Add pytest integration test markers (`@pytest.mark.integration`)
- ✅ Configure pytest to exclude integration tests by default
- ✅ Integration tests skip gracefully when API keys not present

### Test Coverage
- ✅ 6 unit tests for OpenAI service (mocked) 
- ✅ 4 real API integration tests for Anthropic (all passing - 8.12s)
- ✅ 4 real API integration tests for OpenAI (all passing - 4.30s)
- ✅ **All 722 unit tests pass**
- ✅ **All 8 integration tests pass** (13.02s total)

## Configuration

### Integration Tests (opt-in)
```bash
# Run integration tests (requires API keys)
uv run pytest -m integration

# Default behavior excludes integration tests (no API costs)
uv run pytest
```

### Install OpenAI Support
```bash
# Add OpenAI provider
uv sync --group llm-openai
```

### Environment Variables
```bash
# .env file
OPENAI_API_KEY=your_openai_api_key_here
OPENAI_MODEL=gpt-4o  # optional, defaults to gpt-4o
```

## Files Changed
- `pyproject.toml`: Added llm-openai group, pytest markers, test exclusions
- `src/wct/llm_service.py`: Added OpenAILLMService class (180 lines)
- `tests/wct/test_llm_service.py`: Added 8 integration tests + 6 unit tests (410 lines)
- `.env.example`: Added OpenAI configuration variables
- `docs/feature-plans/`: Updated Feature 2 status to complete
- `uv.lock`: Added langchain-openai and dependencies

## Backward Compatibility
- ✅ Zero behaviour change for existing Anthropic users
- ✅ Fully backward compatible
- ✅ OpenAI support is opt-in (optional dependency)

## Test Plan
- [x] All 722 unit tests pass
- [x] All 8 integration tests pass with real API calls
- [x] Type checking passes (basedpyright strict mode)
- [x] Linting passes (ruff)
- [x] All dev checks pass
- [x] Pre-commit hooks pass
- [x] Integration tests skip gracefully without API keys
- [x] Integration tests excluded by default (no API costs in CI)

## What's Next
Feature 3: Environment-Based Provider Selection (global LLM_PROVIDER env var)