### PR TITLE
feat: add Google LLM provider with lazy import and integration tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,9 @@ ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
 OPENAI_API_KEY=your_openai_api_key_here
 # OpenAI model name (optional, defaults to gpt-4o)
 OPENAI_MODEL=gpt-4o
+
+# Google Configuration (optional - requires: uv sync --group llm-google)
+# Google API key for LLM-powered analysis
+GOOGLE_API_KEY=your_google_api_key_here
+# Google model name (optional, defaults to gemini-2.5-flash)
+GOOGLE_MODEL=gemini-2.5-flash

--- a/docs/feature-plans/multi-provider-llm-support.md
+++ b/docs/feature-plans/multi-provider-llm-support.md
@@ -7,7 +7,7 @@
 | Feature 1: Base LLM Service Abstraction | ✅ Complete | `refactor/base-llm-service-abstraction` | [#145](https://github.com/waivern-compliance/waivern-compliance/pull/145) | ⏳ Pending | 712 tests pass, zero behaviour change |
 | Feature 2: OpenAI Provider with Lazy Import | ✅ Complete | `feature/openai-provider-lazy-import` | - | - | 722 unit tests + 8 integration tests (4 Anthropic + 4 OpenAI) pass |
 | Feature 3: Environment-Based Provider Selection | ✅ Complete | `feature/environment-based-provider-selection` | - | - | 726 unit tests + 8 integration tests pass |
-| Feature 4: Add Google & Cohere Providers | 📋 Planned | - | - | - | - |
+| Feature 4: Add Google Provider | ✅ Complete | `feature/google-llm-provider` | - | - | 737 unit tests + 12 integration tests (4 Anthropic + 4 OpenAI + 4 Google) pass; Cohere deferred |
 | Feature 5: Per-Analyser LLM Configuration (Schema) | 📋 Planned | - | - | - | - |
 | Feature 6: Configuration Hierarchy Resolution | 📋 Planned | - | - | - | - |
 | Feature 7: Test-LLM CLI Command | 📋 Planned | - | - | - | - |
@@ -162,25 +162,49 @@ This document outlines the plan for adding multi-provider LLM support to WCT, br
 
 ---
 
-### Feature 4: Add Google & Cohere Providers
-**Goal:** Expand provider options, validate pattern scales
-**Testing:** Unit tests for each provider
+### Feature 4: Add Google Provider ✅ COMPLETE
+**Goal:** Expand provider options, validate pattern scales (Cohere deferred)
+**Testing:** Unit tests + real API integration tests
 **Mergeable:** ✅ Additive, follows established pattern
+**Status:** ✅ Complete - Ready for PR
+**Actual effort:** ~2.5 hours
 
-**Changes:**
-- Add dependency groups: `llm-google`, `llm-cohere`, `llm-all`
-- Implement `GoogleLLMService` and `CohereLLMService`
-- Add factory methods for both providers
-- Update factory's `create_service()` to support all providers
-- Document in `.env.example`
+**Changes Implemented:**
+- ✅ Add dependency groups: `llm-google = ["langchain-google-genai>=2.0.0"]`, `llm-all` (includes OpenAI + Google)
+- ✅ Implement `GoogleLLMService` with lazy import + helpful error
+- ✅ Add `LLMServiceFactory.create_google_service()` method
+- ✅ Update `create_service()` to support "google" provider
+- ✅ Document Google configuration in `.env.example`
+- ✅ Add 4 real API integration tests for Google
+- ✅ Refactor: Extract duplicate `_extract_content()` to base class
 
-**Test Strategy:**
-- Test each service with mocked LangChain clients
-- Test lazy import errors for each
-- Test provider selection includes new options
-- Verify existing providers still work
+**Test Results:**
+- ✅ All 737 unit tests pass (11 new Google tests)
+- ✅ 4 Google real API integration tests pass
+- ✅ All 12 integration tests pass (4 Anthropic + 4 OpenAI + 4 Google)
+- ✅ Type checking passes (basedpyright strict mode)
+- ✅ Linting passes (ruff)
 
-**Estimated effort:** 2-3 hours
+**Files Modified:**
+- `pyproject.toml` - Added llm-google and llm-all dependency groups
+- `src/wct/llm_service.py` - Added GoogleLLMService class + base class refactoring
+- `.env.example` - Added Google configuration
+- `tests/wct/llm_service/test_google_service.py` (NEW) - Google service tests (2 classes, 9 tests)
+- `tests/wct/llm_service/test_factory.py` - Added Google factory tests (2 tests)
+- `tests/wct/llm_service/test_integration.py` - Added Google integration tests (1 class, 4 tests)
+
+**Implementation Details:**
+- Default model: `gemini-2.5-flash`
+- Environment variables: `GOOGLE_API_KEY`, `GOOGLE_MODEL`
+- Follows exact same pattern as OpenAI implementation
+- Integration tests skip gracefully when API key not present or package not installed
+
+**Refactoring:**
+- Extracted duplicate `_extract_content()` method from all three service classes to `BaseLLMService`
+- Eliminated ~150 lines of code duplication
+- All tests continue passing after refactoring
+
+**Note:** Cohere provider deferred per user request to focus on the three major providers (Anthropic, OpenAI, Google)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,12 @@ dev = [
 llm-openai = [
     "langchain-openai>=0.2.0",
 ]
+llm-google = [
+    "langchain-google-genai>=2.0.0",
+]
+llm-all = [
+    "waivern-compliance-tool[llm-openai,llm-google]",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/wct/llm_service/test_factory.py
+++ b/tests/wct/llm_service/test_factory.py
@@ -9,6 +9,7 @@ import pytest
 
 from wct.llm_service import (
     AnthropicLLMService,
+    GoogleLLMService,
     LLMConfigurationError,
     LLMServiceFactory,
     OpenAILLMService,
@@ -26,6 +27,15 @@ class TestLLMServiceFactory:
 
         assert isinstance(service, OpenAILLMService)
         assert service.model_name == "gpt-4"
+
+    def test_factory_can_create_google_service(self) -> None:
+        """Test that factory can create Google service instance."""
+        service = LLMServiceFactory.create_google_service(
+            model_name="gemini-1.5-pro", api_key="test-key"
+        )
+
+        assert isinstance(service, GoogleLLMService)
+        assert service.model_name == "gemini-1.5-pro"
 
 
 class TestLLMServiceFactoryProviderSelection:
@@ -57,6 +67,19 @@ class TestLLMServiceFactoryProviderSelection:
 
             assert isinstance(service, OpenAILLMService)
 
+    def test_create_service_with_google_provider(self) -> None:
+        """Test create_service() creates Google service when LLM_PROVIDER=google."""
+        with patch.dict(
+            os.environ,
+            {
+                "LLM_PROVIDER": "google",
+                "GOOGLE_API_KEY": "test-key",
+            },
+        ):
+            service = LLMServiceFactory.create_service()
+
+            assert isinstance(service, GoogleLLMService)
+
     def test_create_service_defaults_to_anthropic_when_no_provider_set(self) -> None:
         """Test create_service() defaults to Anthropic when LLM_PROVIDER not set."""
         with patch.dict(
@@ -80,3 +103,4 @@ class TestLLMServiceFactoryProviderSelection:
             assert "invalid-provider" in str(exc_info.value).lower()
             assert "anthropic" in str(exc_info.value).lower()
             assert "openai" in str(exc_info.value).lower()
+            assert "google" in str(exc_info.value).lower()

--- a/tests/wct/llm_service/test_google_service.py
+++ b/tests/wct/llm_service/test_google_service.py
@@ -1,0 +1,166 @@
+"""Tests for Google LLM service implementation."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from wct.llm_service import BaseLLMService, GoogleLLMService, LLMConfigurationError
+
+
+class TestGoogleLLMServiceInitialisation:
+    """Test GoogleLLMService initialisation and configuration."""
+
+    def test_initialisation_with_provided_parameters(self) -> None:
+        """Test service initialisation with explicitly provided parameters."""
+        service = GoogleLLMService(model_name="gemini-1.5-pro", api_key="test-api-key")
+
+        assert service.model_name == "gemini-1.5-pro"
+        # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_with_environment_variables(self) -> None:
+        """Test service initialisation using environment variables."""
+        with patch.dict(
+            os.environ,
+            {
+                "GOOGLE_MODEL": "gemini-1.5-flash",
+                "GOOGLE_API_KEY": "env-api-key",
+            },
+        ):
+            service = GoogleLLMService()
+
+            assert service.model_name == "gemini-1.5-flash"
+            # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_with_default_model(self) -> None:
+        """Test service initialisation uses default model when not specified."""
+        with patch.dict(
+            os.environ,
+            {"GOOGLE_API_KEY": "test-key"},
+            clear=True,
+        ):
+            service = GoogleLLMService()
+
+            assert service.model_name == "gemini-2.5-flash"
+            # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_parameter_overrides_environment(self) -> None:
+        """Test that explicit parameters override environment variables."""
+        with patch.dict(
+            os.environ,
+            {
+                "GOOGLE_MODEL": "env-model",
+                "GOOGLE_API_KEY": "env-key",
+            },
+        ):
+            service = GoogleLLMService(model_name="param-model", api_key="param-key")
+
+            assert service.model_name == "param-model"
+            # API key is private - service creation without error indicates it was set
+
+    def test_initialisation_missing_api_key_raises_error(self) -> None:
+        """Test that missing API key raises configuration error."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(LLMConfigurationError) as exc_info:
+                GoogleLLMService()
+
+            assert "Google API key is required" in str(exc_info.value)
+            assert "GOOGLE_API_KEY" in str(exc_info.value)
+
+    def test_initialisation_empty_api_key_raises_error(self) -> None:
+        """Test that empty API key raises configuration error."""
+        with patch.dict(os.environ, {"GOOGLE_API_KEY": ""}):
+            with pytest.raises(LLMConfigurationError) as exc_info:
+                GoogleLLMService()
+
+            assert "Google API key is required" in str(exc_info.value)
+
+    def test_google_service_implements_base_interface(self) -> None:
+        """Test that GoogleLLMService correctly implements BaseLLMService."""
+        service = GoogleLLMService(model_name="gemini-1.5-pro", api_key="test-key")
+
+        assert isinstance(service, BaseLLMService)
+        assert hasattr(service, "analyse_data")
+        assert callable(service.analyse_data)
+
+
+class TestGoogleLLMServiceDataAnalysis:
+    """Test GoogleLLMService data analysis functionality."""
+
+    @pytest.fixture
+    def service_with_mock_api(self) -> GoogleLLMService:
+        """Create service instance with mocked API for testing."""
+        return GoogleLLMService(model_name="gemini-1.5-pro", api_key="test-api-key")
+
+    def test_successful_data_analysis(
+        self, service_with_mock_api: GoogleLLMService
+    ) -> None:
+        """Test successful data analysis returns expected result."""
+        text_to_analyse = "John Smith lives at 123 Main Street"
+        analysis_prompt = "Identify personal data in the following text:"
+        expected_response = (
+            "Personal data found: Name (John Smith), Address (123 Main Street)"
+        )
+
+        mock_response = AIMessage(content=expected_response)
+
+        # Create mock ChatGoogleGenerativeAI class
+        mock_chat_class = Mock()
+        mock_llm = Mock()
+        mock_llm.invoke.return_value = mock_response
+        mock_chat_class.return_value = mock_llm
+
+        # Mock the lazy import by patching sys.modules
+        with patch.dict(
+            "sys.modules",
+            {"langchain_google_genai": Mock(ChatGoogleGenerativeAI=mock_chat_class)},
+        ):
+            result = service_with_mock_api.analyse_data(
+                text_to_analyse, analysis_prompt
+            )
+
+            assert result == expected_response
+            assert isinstance(result, str)
+
+            # Verify the LLM was called with the combined prompt
+            mock_llm.invoke.assert_called_once()
+            call_args = mock_llm.invoke.call_args[0][0]
+            assert analysis_prompt in call_args
+            assert text_to_analyse in call_args
+
+    def test_data_analysis_with_complex_response_content(
+        self, service_with_mock_api: GoogleLLMService
+    ) -> None:
+        """Test data analysis handles complex response content structures."""
+        text_to_analyse = "Sample text for analysis"
+        analysis_prompt = "Analyse this text:"
+
+        # Test with list content structure
+        mock_response = AIMessage(
+            content=[
+                {"type": "text", "text": "Analysis result: "},
+                {"type": "text", "text": "Complex content structure"},
+            ]
+        )
+
+        # Create mock ChatGoogleGenerativeAI class
+        mock_chat_class = Mock()
+        mock_llm = Mock()
+        mock_llm.invoke.return_value = mock_response
+        mock_chat_class.return_value = mock_llm
+
+        # Mock the lazy import by patching sys.modules
+        with patch.dict(
+            "sys.modules",
+            {"langchain_google_genai": Mock(ChatGoogleGenerativeAI=mock_chat_class)},
+        ):
+            result = service_with_mock_api.analyse_data(
+                text_to_analyse, analysis_prompt
+            )
+
+            assert "Analysis result:" in result
+            assert "Complex content structure" in result
+            assert isinstance(result, str)

--- a/tests/wct/llm_service/test_integration.py
+++ b/tests/wct/llm_service/test_integration.py
@@ -10,7 +10,7 @@ import os
 
 import pytest
 
-from wct.llm_service import AnthropicLLMService, OpenAILLMService
+from wct.llm_service import AnthropicLLMService, GoogleLLMService, OpenAILLMService
 
 
 class TestAnthropicLLMServiceRealApiIntegration:
@@ -237,6 +237,141 @@ class TestOpenAILLMServiceRealApiIntegration:
 
         # Create service
         service = OpenAILLMService(api_key=api_key)
+
+        # Test with minimal input that might produce a brief response
+        text = ""
+        prompt = "If the text is empty, respond with just 'EMPTY'"
+
+        result = service.analyse_data(text, prompt)
+
+        # Even with empty input, we should get a valid response
+        assert isinstance(result, str)
+        assert len(result) > 0
+        # LLM should recognize empty input
+        assert "empty" in result.lower()
+
+
+class TestGoogleLLMServiceRealApiIntegration:
+    """Integration tests with real Google API (requires GOOGLE_API_KEY and langchain-google-genai)."""
+
+    @pytest.mark.integration
+    def test_real_google_api_simple_analysis(self) -> None:
+        """Test real Google API with simple text analysis."""
+        # Skip if no API key
+        api_key = os.getenv("GOOGLE_API_KEY")
+        if not api_key:
+            pytest.skip("GOOGLE_API_KEY not set - skipping real API test")
+
+        # Skip if langchain-google-genai not installed
+        try:
+            from langchain_google_genai import ChatGoogleGenerativeAI  # noqa: F401
+        except ImportError:
+            pytest.skip(
+                "langchain-google-genai not installed - run: uv sync --group llm-google"
+            )
+
+        # Create real service (no mocks)
+        service = GoogleLLMService(api_key=api_key)
+
+        # Simple test with clear expected content
+        text = "John Smith, email: john@example.com, phone: 555-1234"
+        prompt = "List any personal data found in this text in a single line."
+
+        # Make real API call
+        result = service.analyse_data(text, prompt)
+
+        # Verify response structure (don't assert exact content - LLM responses vary)
+        assert isinstance(result, str)
+        assert len(result) > 0
+        # Check that response mentions some of the personal data
+        assert "john" in result.lower() or "email" in result.lower()
+
+    @pytest.mark.integration
+    def test_real_google_api_with_default_model(self) -> None:
+        """Test real Google API uses default model from environment."""
+        # Skip if no API key
+        api_key = os.getenv("GOOGLE_API_KEY")
+        if not api_key:
+            pytest.skip("GOOGLE_API_KEY not set - skipping real API test")
+
+        # Skip if langchain-google-genai not installed
+        try:
+            from langchain_google_genai import ChatGoogleGenerativeAI  # noqa: F401
+        except ImportError:
+            pytest.skip(
+                "langchain-google-genai not installed - run: uv sync --group llm-google"
+            )
+
+        # Create service without specifying model (should use default or env var)
+        service = GoogleLLMService(api_key=api_key)
+
+        # Verify model name is set (either default or from GOOGLE_MODEL env var)
+        expected_default = "gemini-2.5-flash"
+        env_model = os.getenv("GOOGLE_MODEL")
+        expected_model = env_model if env_model else expected_default
+        assert service.model_name == expected_model
+
+        # Make a real API call to verify it works
+        text = "Test data"
+        prompt = "Reply with 'OK' if you can read this."
+
+        result = service.analyse_data(text, prompt)
+
+        # Verify we got a response
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.integration
+    def test_real_google_api_with_custom_model(self) -> None:
+        """Test real Google API with explicitly specified model."""
+        # Skip if no API key
+        api_key = os.getenv("GOOGLE_API_KEY")
+        if not api_key:
+            pytest.skip("GOOGLE_API_KEY not set - skipping real API test")
+
+        # Skip if langchain-google-genai not installed
+        try:
+            from langchain_google_genai import ChatGoogleGenerativeAI  # noqa: F401
+        except ImportError:
+            pytest.skip(
+                "langchain-google-genai not installed - run: uv sync --group llm-google"
+            )
+
+        # Create service with explicitly specified model
+        custom_model = "gemini-2.5-flash-lite"
+        service = GoogleLLMService(model_name=custom_model, api_key=api_key)
+
+        # Verify the model name is set correctly
+        assert service.model_name == custom_model
+
+        # Make a real API call to verify it works with this model
+        text = "Hello"
+        prompt = "Reply with just the word 'Hi'"
+
+        result = service.analyse_data(text, prompt)
+
+        # Verify we got a response
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.integration
+    def test_real_google_api_handles_empty_response(self) -> None:
+        """Test real Google API handles edge cases gracefully."""
+        # Skip if no API key
+        api_key = os.getenv("GOOGLE_API_KEY")
+        if not api_key:
+            pytest.skip("GOOGLE_API_KEY not set - skipping real API test")
+
+        # Skip if langchain-google-genai not installed
+        try:
+            from langchain_google_genai import ChatGoogleGenerativeAI  # noqa: F401
+        except ImportError:
+            pytest.skip(
+                "langchain-google-genai not installed - run: uv sync --group llm-google"
+            )
+
+        # Create service
+        service = GoogleLLMService(api_key=api_key)
 
         # Test with minimal input that might produce a brief response
         text = ""

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -62,6 +67,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/80/fb/bd92196a07e3b4ccee4ff2761a26a05bff77d4da089b67b4b1a547868099/basedpyright-1.29.4.tar.gz", hash = "sha256:2df1976f8591eedf4b4ce8f9d123f43e810cc8cb7cc83c53eec0e2f8044073d0", size = 21961481, upload-time = "2025-06-11T22:25:55.173Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/dc/180fe721a2574fb3aad4051adcca196ac2d18adaf75122f5eeb47436cca2/basedpyright-1.29.4-py3-none-any.whl", hash = "sha256:e087513979972f83010639c6c1a1c13dd3b1d24ee45f8ecff747962cc2063d6f", size = 11476859, upload-time = "2025-06-11T22:25:52.01Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/7e/b975b5814bd36faf009faebe22c1072a1fa1168db34d285ef0ba071ad78c/cachetools-6.2.1.tar.gz", hash = "sha256:3f391e4bd8f8bf0931169baf7456cc822705f4e2a31f840d218f445b9a854201", size = 31325, upload-time = "2025-10-12T14:55:30.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl", hash = "sha256:09868944b6dde876dfd44e1d47e18484541eaf12f26f29b7af91b26cc892d701", size = 11280, upload-time = "2025-10-12T14:55:28.382Z" },
 ]
 
 [[package]]
@@ -234,6 +248,78 @@ wheels = [
 ]
 
 [[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
+name = "google-ai-generativelanguage"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/35/af6c759bfde70386c741309df0cba6a1cb09b8bbd1d02c841df51f4c672d/google_ai_generativelanguage-0.7.0.tar.gz", hash = "sha256:207fed3089949e2e99f7cbd513e2d0ea5f2babdfa5a8f2f239c3ddffe6bd4297", size = 1475859, upload-time = "2025-09-02T15:39:53.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/e7/b670b2d5b53f18ae51d331283278595fea93a156ea79baf59d4098effaec/google_ai_generativelanguage-0.7.0-py3-none-any.whl", hash = "sha256:3241215c16e669f37054f6111c84cca50fdb7a8e10a62933b9e68086ce71eefe", size = 1394333, upload-time = "2025-09-02T15:39:06.14Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ea/e7b6ac3c7b557b728c2d0181010548cbbdd338e9002513420c5a354fa8df/google_api_core-2.26.0.tar.gz", hash = "sha256:e6e6d78bd6cf757f4aee41dcc85b07f485fbb069d5daa3afb126defba1e91a62", size = 166369, upload-time = "2025-10-08T21:37:38.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/ad/f73cf9fe9bd95918502b270e3ddb8764e4c900b3bbd7782b90c56fac14bb/google_api_core-2.26.0-py3-none-any.whl", hash = "sha256:2b204bd0da2c81f918e3582c48458e24c11771f987f6258e6e227212af78f3ed", size = 162505, upload-time = "2025-10-08T21:37:36.651Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/af/5129ce5b2f9688d2fa49b463e544972a7c82b0fdb50980dafee92e121d9f/google_auth-2.41.1.tar.gz", hash = "sha256:b76b7b1f9e61f0cb7e88870d14f6a94aeef248959ef6992670efee37709cbfd2", size = 292284, upload-time = "2025-09-30T22:51:26.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/a4/7319a2a8add4cc352be9e3efeff5e2aacee917c85ca2fa1647e29089983c/google_auth-2.41.1-py2.py3-none-any.whl", hash = "sha256:754843be95575b9a19c604a848a41be03f7f2afd8c019f716dc1f51ee41c639d", size = 221302, upload-time = "2025-09-30T22:51:24.212Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea27c9955e6713140fedd51e8b141b5ce5260897020f1a/googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257", size = 145903, upload-time = "2025-04-14T10:17:02.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/f1/62a193f0227cf15a920390abe675f386dec35f7ae3ffe6da582d3ade42c7/googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8", size = 294530, upload-time = "2025-04-14T10:17:01.271Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -264,6 +350,61 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/67/10/b2a4b63d3f08362662e89c103f7fe28894a51ae0bc890fabf37d1d780e52/greenlet-3.2.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b0df6f63cd15012bed5401b47829cfd2e97052dc89da3cfaf2c779124eb892", size = 692995, upload-time = "2025-06-05T16:13:07.972Z" },
     { url = "https://files.pythonhosted.org/packages/5a/c6/ad82f148a4e3ce9564056453a71529732baf5448ad53fc323e37efe34f66/greenlet-3.2.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c2d68e87107c1792e2e8d5399acec2487a4e993ab76c792408e59394d52141", size = 655320, upload-time = "2025-06-05T16:12:53.453Z" },
     { url = "https://files.pythonhosted.org/packages/5c/4f/aab73ecaa6b3086a4c89863d94cf26fa84cbff63f52ce9bc4342b3087a06/greenlet-3.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c47aae8fbbfcf82cc13327ae802ba13c9c36753b67e760023fd116bc124a62a", size = 301236, upload-time = "2025-06-05T16:15:20.111Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.75.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/f7/8963848164c7604efb3a3e6ee457fdb3a469653e19002bd24742473254f8/grpcio-1.75.1.tar.gz", hash = "sha256:3e81d89ece99b9ace23a6916880baca613c03a799925afb2857887efa8b1b3d2", size = 12731327, upload-time = "2025-09-26T09:03:36.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/81/42be79e73a50aaa20af66731c2defeb0e8c9008d9935a64dd8ea8e8c44eb/grpcio-1.75.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:7b888b33cd14085d86176b1628ad2fcbff94cfbbe7809465097aa0132e58b018", size = 5668314, upload-time = "2025-09-26T09:01:55.424Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/3686ed15822fedc58c22f82b3a7403d9faf38d7c33de46d4de6f06e49426/grpcio-1.75.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8775036efe4ad2085975531d221535329f5dac99b6c2a854a995456098f99546", size = 11476125, upload-time = "2025-09-26T09:01:57.927Z" },
+    { url = "https://files.pythonhosted.org/packages/14/85/21c71d674f03345ab183c634ecd889d3330177e27baea8d5d247a89b6442/grpcio-1.75.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bb658f703468d7fbb5dcc4037c65391b7dc34f808ac46ed9136c24fc5eeb041d", size = 6246335, upload-time = "2025-09-26T09:02:00.76Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/db/3beb661bc56a385ae4fa6b0e70f6b91ac99d47afb726fe76aaff87ebb116/grpcio-1.75.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4b7177a1cdb3c51b02b0c0a256b0a72fdab719600a693e0e9037949efffb200b", size = 6916309, upload-time = "2025-09-26T09:02:02.894Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/9c/eda9fe57f2b84343d44c1b66cf3831c973ba29b078b16a27d4587a1fdd47/grpcio-1.75.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d4fa6ccc3ec2e68a04f7b883d354d7fea22a34c44ce535a2f0c0049cf626ddf", size = 6435419, upload-time = "2025-09-26T09:02:05.055Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b8/090c98983e0a9d602e3f919a6e2d4e470a8b489452905f9a0fa472cac059/grpcio-1.75.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3d86880ecaeb5b2f0a8afa63824de93adb8ebe4e49d0e51442532f4e08add7d6", size = 7064893, upload-time = "2025-09-26T09:02:07.275Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c0/6d53d4dbbd00f8bd81571f5478d8a95528b716e0eddb4217cc7cb45aae5f/grpcio-1.75.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a8041d2f9e8a742aeae96f4b047ee44e73619f4f9d24565e84d5446c623673b6", size = 8011922, upload-time = "2025-09-26T09:02:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7c/48455b2d0c5949678d6982c3e31ea4d89df4e16131b03f7d5c590811cbe9/grpcio-1.75.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3652516048bf4c314ce12be37423c79829f46efffb390ad64149a10c6071e8de", size = 7466181, upload-time = "2025-09-26T09:02:12.279Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/12/04a0e79081e3170b6124f8cba9b6275871276be06c156ef981033f691880/grpcio-1.75.1-cp312-cp312-win32.whl", hash = "sha256:44b62345d8403975513af88da2f3d5cc76f73ca538ba46596f92a127c2aea945", size = 3938543, upload-time = "2025-09-26T09:02:14.77Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/11350d9d7fb5adc73d2b0ebf6ac1cc70135577701e607407fe6739a90021/grpcio-1.75.1-cp312-cp312-win_amd64.whl", hash = "sha256:b1e191c5c465fa777d4cafbaacf0c01e0d5278022082c0abbd2ee1d6454ed94d", size = 4641938, upload-time = "2025-09-26T09:02:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/46/74/bac4ab9f7722164afdf263ae31ba97b8174c667153510322a5eba4194c32/grpcio-1.75.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:3bed22e750d91d53d9e31e0af35a7b0b51367e974e14a4ff229db5b207647884", size = 5672779, upload-time = "2025-09-26T09:02:19.11Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/52/d0483cfa667cddaa294e3ab88fd2c2a6e9dc1a1928c0e5911e2e54bd5b50/grpcio-1.75.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5b8f381eadcd6ecaa143a21e9e80a26424c76a0a9b3d546febe6648f3a36a5ac", size = 11470623, upload-time = "2025-09-26T09:02:22.117Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e4/d1954dce2972e32384db6a30273275e8c8ea5a44b80347f9055589333b3f/grpcio-1.75.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5bf4001d3293e3414d0cf99ff9b1139106e57c3a66dfff0c5f60b2a6286ec133", size = 6248838, upload-time = "2025-09-26T09:02:26.426Z" },
+    { url = "https://files.pythonhosted.org/packages/06/43/073363bf63826ba8077c335d797a8d026f129dc0912b69c42feaf8f0cd26/grpcio-1.75.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:9f82ff474103e26351dacfe8d50214e7c9322960d8d07ba7fa1d05ff981c8b2d", size = 6922663, upload-time = "2025-09-26T09:02:28.724Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/6f/076ac0df6c359117676cacfa8a377e2abcecec6a6599a15a672d331f6680/grpcio-1.75.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0ee119f4f88d9f75414217823d21d75bfe0e6ed40135b0cbbfc6376bc9f7757d", size = 6436149, upload-time = "2025-09-26T09:02:30.971Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/27/1d08824f1d573fcb1fa35ede40d6020e68a04391709939e1c6f4193b445f/grpcio-1.75.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:664eecc3abe6d916fa6cf8dd6b778e62fb264a70f3430a3180995bf2da935446", size = 7067989, upload-time = "2025-09-26T09:02:33.233Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/98/98594cf97b8713feb06a8cb04eeef60b4757e3e2fb91aa0d9161da769843/grpcio-1.75.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c32193fa08b2fbebf08fe08e84f8a0aad32d87c3ad42999c65e9449871b1c66e", size = 8010717, upload-time = "2025-09-26T09:02:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/7e/bb80b1bba03c12158f9254762cdf5cced4a9bc2e8ed51ed335915a5a06ef/grpcio-1.75.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5cebe13088b9254f6e615bcf1da9131d46cfa4e88039454aca9cb65f639bd3bc", size = 7463822, upload-time = "2025-09-26T09:02:38.26Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1c/1ea57fdc06927eb5640f6750c697f596f26183573069189eeaf6ef86ba2d/grpcio-1.75.1-cp313-cp313-win32.whl", hash = "sha256:4b4c678e7ed50f8ae8b8dbad15a865ee73ce12668b6aaf411bf3258b5bc3f970", size = 3938490, upload-time = "2025-09-26T09:02:40.268Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/24/fbb8ff1ccadfbf78ad2401c41aceaf02b0d782c084530d8871ddd69a2d49/grpcio-1.75.1-cp313-cp313-win_amd64.whl", hash = "sha256:5573f51e3f296a1bcf71e7a690c092845fb223072120f4bdb7a5b48e111def66", size = 4642538, upload-time = "2025-09-26T09:02:42.519Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/1b/9a0a5cecd24302b9fdbcd55d15ed6267e5f3d5b898ff9ac8cbe17ee76129/grpcio-1.75.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:c05da79068dd96723793bffc8d0e64c45f316248417515f28d22204d9dae51c7", size = 5673319, upload-time = "2025-09-26T09:02:44.742Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ec/9d6959429a83fbf5df8549c591a8a52bb313976f6646b79852c4884e3225/grpcio-1.75.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:06373a94fd16ec287116a825161dca179a0402d0c60674ceeec8c9fba344fe66", size = 11480347, upload-time = "2025-09-26T09:02:47.539Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7a/26da709e42c4565c3d7bf999a9569da96243ce34a8271a968dee810a7cf1/grpcio-1.75.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4484f4b7287bdaa7a5b3980f3c7224c3c622669405d20f69549f5fb956ad0421", size = 6254706, upload-time = "2025-09-26T09:02:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/08/dcb26a319d3725f199c97e671d904d84ee5680de57d74c566a991cfab632/grpcio-1.75.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2720c239c1180eee69f7883c1d4c83fc1a495a2535b5fa322887c70bf02b16e8", size = 6922501, upload-time = "2025-09-26T09:02:52.711Z" },
+    { url = "https://files.pythonhosted.org/packages/78/66/044d412c98408a5e23cb348845979a2d17a2e2b6c3c34c1ec91b920f49d0/grpcio-1.75.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:07a554fa31c668cf0e7a188678ceeca3cb8fead29bbe455352e712ec33ca701c", size = 6437492, upload-time = "2025-09-26T09:02:55.542Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9d/5e3e362815152aa1afd8b26ea613effa005962f9da0eec6e0e4527e7a7d1/grpcio-1.75.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3e71a2105210366bfc398eef7f57a664df99194f3520edb88b9c3a7e46ee0d64", size = 7081061, upload-time = "2025-09-26T09:02:58.261Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/1a/46615682a19e100f46e31ddba9ebc297c5a5ab9ddb47b35443ffadb8776c/grpcio-1.75.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:8679aa8a5b67976776d3c6b0521e99d1c34db8a312a12bcfd78a7085cb9b604e", size = 8010849, upload-time = "2025-09-26T09:03:00.548Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8e/3204b94ac30b0f675ab1c06540ab5578660dc8b690db71854d3116f20d00/grpcio-1.75.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aad1c774f4ebf0696a7f148a56d39a3432550612597331792528895258966dc0", size = 7464478, upload-time = "2025-09-26T09:03:03.096Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/2d90652b213863b2cf466d9c1260ca7e7b67a16780431b3eb1d0420e3d5b/grpcio-1.75.1-cp314-cp314-win32.whl", hash = "sha256:62ce42d9994446b307649cb2a23335fa8e927f7ab2cbf5fcb844d6acb4d85f9c", size = 4012672, upload-time = "2025-09-26T09:03:05.477Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/e2e6e9fc1c985cd1a59e6996a05647c720fe8a03b92f5ec2d60d366c531e/grpcio-1.75.1-cp314-cp314-win_amd64.whl", hash = "sha256:f86e92275710bea3000cb79feca1762dc0ad3b27830dd1a74e82ab321d4ee464", size = 4772475, upload-time = "2025-09-26T09:03:07.661Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.75.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/5b/1ce0e3eedcdc08b4739b3da5836f31142ec8bee1a9ae0ad8dc0dc39a14bf/grpcio_status-1.75.1.tar.gz", hash = "sha256:8162afa21833a2085c91089cc395ad880fac1378a1d60233d976649ed724cbf8", size = 13671, upload-time = "2025-09-26T09:13:16.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/ad/6f414bb0b36eee20d93af6907256f208ffcda992ae6d3d7b6a778afe31e6/grpcio_status-1.75.1-py3-none-any.whl", hash = "sha256:f681b301be26dcf7abf5c765d4a22e4098765e1a65cbdfa3efca384edf8e4e3c", size = 14428, upload-time = "2025-09-26T09:12:55.516Z" },
 ]
 
 [[package]]
@@ -474,6 +615,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c8/99/f926495f467e0f43289f12e951655d267d1eddc1136c3cf4dd907794a9a7/langchain_core-0.3.79.tar.gz", hash = "sha256:024ba54a346dd9b13fb8b2342e0c83d0111e7f26fa01f545ada23ad772b55a60", size = 580895, upload-time = "2025-10-09T21:59:08.359Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/71/46b0efaf3fc6ad2c2bd600aef500f1cb2b7038a4042f58905805630dd29d/langchain_core-0.3.79-py3-none-any.whl", hash = "sha256:92045bfda3e741f8018e1356f83be203ec601561c6a7becfefe85be5ddc58fdb", size = 449779, upload-time = "2025-10-09T21:59:06.493Z" },
+]
+
+[[package]]
+name = "langchain-google-genai"
+version = "2.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filetype" },
+    { name = "google-ai-generativelanguage" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/38/8b3a71c729bd03e9eb0fd8bdb19e06a074c35bc2eaa61b1b9edfa863f38d/langchain_google_genai-2.1.12.tar.gz", hash = "sha256:4a98371e545eb97fcdf483086a4aebbb8eceeb9597ca5a9c4c35e92f4fbbd271", size = 77566, upload-time = "2025-09-17T01:27:11.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/8d/9dd9653e5414e73cae3480e5947bbbbd94ba7fa824efdf46e7ff2c0faef2/langchain_google_genai-2.1.12-py3-none-any.whl", hash = "sha256:4c07630419a8fbe7a2ec512c6dea68289663bfe7d5fae0ba431d2cd59a0d0880", size = 50746, upload-time = "2025-09-17T01:27:10.653Z" },
 ]
 
 [[package]]
@@ -719,6 +875,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424, upload-time = "2025-03-18T21:35:20.987Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707, upload-time = "2025-03-18T21:35:19.343Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142, upload-time = "2025-03-10T15:54:38.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/6d/280c4c2ce28b1593a19ad5239c8b826871fc6ec275c21afc8e1820108039/proto_plus-1.26.1-py3-none-any.whl", hash = "sha256:13285478c2dcf2abb829db158e1047e2f1e8d63a077d94263c2b88b043c75a66", size = 50163, upload-time = "2025-03-10T15:54:37.335Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.32.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/a4/cc17347aa2897568beece2e674674359f911d6fe21b0b8d6268cd42727ac/protobuf-6.32.1.tar.gz", hash = "sha256:ee2469e4a021474ab9baafea6cd070e5bf27c7d29433504ddea1a4ee5850f68d", size = 440635, upload-time = "2025-09-11T21:38:42.935Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/98/645183ea03ab3995d29086b8bf4f7562ebd3d10c9a4b14ee3f20d47cfe50/protobuf-6.32.1-cp310-abi3-win32.whl", hash = "sha256:a8a32a84bc9f2aad712041b8b366190f71dde248926da517bde9e832e4412085", size = 424411, upload-time = "2025-09-11T21:38:27.427Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f3/6f58f841f6ebafe076cebeae33fc336e900619d34b1c93e4b5c97a81fdfa/protobuf-6.32.1-cp310-abi3-win_amd64.whl", hash = "sha256:b00a7d8c25fa471f16bc8153d0e53d6c9e827f0953f3c09aaa4331c718cae5e1", size = 435738, upload-time = "2025-09-11T21:38:30.959Z" },
+    { url = "https://files.pythonhosted.org/packages/10/56/a8a3f4e7190837139e68c7002ec749190a163af3e330f65d90309145a210/protobuf-6.32.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8c7e6eb619ffdf105ee4ab76af5a68b60a9d0f66da3ea12d1640e6d8dab7281", size = 426454, upload-time = "2025-09-11T21:38:34.076Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/be/8dd0a927c559b37d7a6c8ab79034fd167dcc1f851595f2e641ad62be8643/protobuf-6.32.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:2f5b80a49e1eb7b86d85fcd23fe92df154b9730a725c3b38c4e43b9d77018bf4", size = 322874, upload-time = "2025-09-11T21:38:35.509Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/f6/88d77011b605ef979aace37b7703e4eefad066f7e84d935e5a696515c2dd/protobuf-6.32.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:b1864818300c297265c83a4982fd3169f97122c299f56a56e2445c3698d34710", size = 322013, upload-time = "2025-09-11T21:38:37.017Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b7/15cc7d93443d6c6a84626ae3258a91f4c6ac8c0edd5df35ea7658f71b79c/protobuf-6.32.1-py3-none-any.whl", hash = "sha256:2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346", size = 169289, upload-time = "2025-09-11T21:38:41.234Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1077,6 +1280,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1342,6 +1557,12 @@ dev = [
     { name = "pytest-mock" },
     { name = "ruff" },
 ]
+llm-all = [
+    { name = "waivern-compliance-tool" },
+]
+llm-google = [
+    { name = "langchain-google-genai" },
+]
 llm-openai = [
     { name = "langchain-openai" },
 ]
@@ -1373,6 +1594,8 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "ruff", specifier = ">=0.11.12" },
 ]
+llm-all = [{ name = "waivern-compliance-tool", extras = ["llm-openai", "llm-google"] }]
+llm-google = [{ name = "langchain-google-genai", specifier = ">=2.0.0" }]
 llm-openai = [{ name = "langchain-openai", specifier = ">=0.2.0" }]
 
 [[package]]


### PR DESCRIPTION
## Summary
Implements Google LLM provider (Gemini) following the established multi-provider pattern with strict TDD methodology.

## Changes
- **GoogleLLMService** class with lazy import for `langchain-google-genai`
- Factory method `create_google_service()` and updated `create_service()` for "google" provider
- Dependency groups: `llm-google`, `llm-all` 
- Default model: `gemini-2.5-flash`
- Environment variables: `GOOGLE_API_KEY`, `GOOGLE_MODEL`

## Refactoring
- Extracted duplicate `_extract_content()` from all three service classes to `BaseLLMService`
- Eliminated ~150 lines of code duplication

## Tests
- ✅ 9 new unit tests for GoogleLLMService
- ✅ 2 new factory tests
- ✅ 4 new real API integration tests (verified with Google API)
- ✅ All 737 unit tests + 12 integration tests pass
- ✅ Type checking, linting, formatting all pass

## Feature Plan
Feature 4 of [multi-provider LLM support plan](https://github.com/waivern-compliance/waivern-compliance/blob/feature/google-llm-provider/docs/feature-plans/multi-provider-llm-support.md) complete.

Related: #145