### PR TITLE
feat: add BaseComponentConfiguration for typed component configs

### DIFF
--- a/docs/adr/0002-dependency-injection-for-service-management.md
+++ b/docs/adr/0002-dependency-injection-for-service-management.md
@@ -446,7 +446,7 @@ class PersonalDataAnalyserFactory(ComponentFactory[PersonalDataAnalyser]):
     def create(self, config: dict) -> PersonalDataAnalyser:
         """Create analyser with execution-specific config."""
         return PersonalDataAnalyser(
-            config=PersonalDataAnalyserConfig.from_dict(config),
+            config=PersonalDataAnalyserConfig.from_properties(config),
             llm_service=self._llm_service
         )
 

--- a/docs/architecture/dependency-injection-implementation-plan.md
+++ b/docs/architecture/dependency-injection-implementation-plan.md
@@ -110,15 +110,15 @@ This document outlines the implementation plan for introducing a **Dependency In
 
 - [x] Create `waivern_core/component_factory.py`
 - [x] Implement `ComponentFactory[T]` abstract base class:
-  - `create(config: dict) -> T` - Create component with execution-specific config
+  - `create(config: ComponentConfig) -> T` - Create component with execution-specific config
   - `get_component_name() -> str` - Component type name for runbooks
   - `get_input_schemas() -> list[Schema]` - Supported input schemas
   - `get_output_schemas() -> list[Schema]` - Supported output schemas
-  - `can_create(config: dict) -> bool` - Health check/validation
+  - `can_create(config: ComponentConfig) -> bool` - Health check/validation
   - `get_service_dependencies() -> dict[str, type]` - Optional dependency declaration
 - [x] Add comprehensive docstrings with examples
 - [x] Add type hints with Generic[T] (using PEP 695 syntax)
-- [x] Add ComponentConfig type alias
+- [x] Add ComponentConfig type alias (`type ComponentConfig = BaseComponentConfiguration`)
 
 ### 2.2 Export from waivern-core
 
@@ -182,7 +182,18 @@ This document outlines the implementation plan for introducing a **Dependency In
 - [x] Test graceful degradation when service unavailable
 - [x] Test singleton caching across multiple provider instances
 
-**Deliverable:** LLM services managed via DI (32 tests, all passing)
+### 3.6 Component Configuration Base Class
+
+- [x] Create `BaseComponentConfiguration` in `waivern_core/services/configuration.py`
+- [x] Implement with Pydantic BaseModel (frozen, extra="forbid")
+- [x] Add `from_properties()` factory method for dictionary-based creation
+- [x] Mirror same design pattern as `BaseServiceConfiguration`
+- [x] Update `ComponentConfig` type alias to point to `BaseComponentConfiguration`
+- [x] Export from `waivern_core/services/__init__.py` and `waivern_core/__init__.py`
+- [x] Write unit tests (4 tests for instantiation, immutability, validation, from_properties)
+- [x] Update ComponentFactory contract tests to use typed configs
+
+**Deliverable:** LLM services managed via DI + BaseComponentConfiguration implemented (36 tests, all passing)
 
 ---
 

--- a/libs/waivern-core/src/waivern_core/__init__.py
+++ b/libs/waivern-core/src/waivern_core/__init__.py
@@ -29,6 +29,7 @@ from waivern_core.schemas import (
     SchemaLoadError,
 )
 from waivern_core.services import (
+    BaseComponentConfiguration,
     BaseServiceConfiguration,
     ServiceContainer,
     ServiceDescriptor,
@@ -53,6 +54,7 @@ __all__ = [
     "RuleComplianceData",
     "RulesetData",
     # Dependency Injection
+    "BaseComponentConfiguration",
     "BaseServiceConfiguration",
     "ComponentConfig",
     "ComponentFactory",

--- a/libs/waivern-core/src/waivern_core/services/__init__.py
+++ b/libs/waivern-core/src/waivern_core/services/__init__.py
@@ -1,11 +1,15 @@
 """Service management and dependency injection infrastructure."""
 
-from waivern_core.services.configuration import BaseServiceConfiguration
+from waivern_core.services.configuration import (
+    BaseComponentConfiguration,
+    BaseServiceConfiguration,
+)
 from waivern_core.services.container import ServiceContainer
 from waivern_core.services.lifecycle import ServiceDescriptor
 from waivern_core.services.protocols import ServiceFactory, ServiceProvider
 
 __all__ = [
+    "BaseComponentConfiguration",
     "BaseServiceConfiguration",
     "ServiceContainer",
     "ServiceDescriptor",

--- a/libs/waivern-core/src/waivern_core/services/configuration.py
+++ b/libs/waivern-core/src/waivern_core/services/configuration.py
@@ -1,8 +1,8 @@
-"""Base configuration for infrastructure services.
+"""Base configuration classes for services and components.
 
-This module provides the BaseServiceConfiguration class that all service
+This module provides base configuration classes that all service and component
 configurations should inherit from. It provides consistent validation,
-immutability, and factory patterns across all infrastructure services.
+immutability, and factory patterns across the framework.
 """
 
 from __future__ import annotations
@@ -81,6 +81,84 @@ class BaseServiceConfiguration(BaseModel):
             config = LLMServiceConfiguration.from_properties({
                 "provider": "anthropic",
                 "api_key": "sk-..."
+            })
+            ```
+
+        """
+        return cls.model_validate(properties)
+
+
+class BaseComponentConfiguration(BaseModel):
+    """Base class for all component configurations (analysers and connectors).
+
+    This provides a consistent foundation for component configuration objects
+    across the framework. All component configurations (PersonalDataAnalyserConfig,
+    MySQLConnectorConfig, etc.) should inherit from this base class.
+
+    Features:
+        - Pydantic validation for type safety
+        - Immutable by default (frozen) for configuration integrity
+        - from_properties() factory method for dictionary-based creation
+        - Strict validation (no extra fields allowed)
+
+    Components vs Services:
+        - Components: Transient instances created per execution (analysers, connectors)
+        - Services: Singleton instances managed by DI container (LLM, database, cache)
+
+    Example:
+        ```python
+        class PersonalDataAnalyserConfig(BaseComponentConfiguration):
+            pattern_matching: PatternMatchingConfig
+            llm_validation: LLMValidationConfig
+
+        # Create from properties dictionary (from runbook)
+        config = PersonalDataAnalyserConfig.from_properties({
+            "pattern_matching": {"ruleset": "personal_data"},
+            "llm_validation": {"enable_llm_validation": True}
+        })
+
+        # Or direct instantiation
+        config = PersonalDataAnalyserConfig(
+            pattern_matching=PatternMatchingConfig(ruleset="personal_data"),
+            llm_validation=LLMValidationConfig(enable_llm_validation=True)
+        )
+        ```
+
+    """
+
+    model_config = ConfigDict(
+        # Immutable - configuration cannot be modified after creation
+        frozen=True,
+        # Strict - extra fields not in the model are rejected
+        extra="forbid",
+        # Validate on assignment (if frozen is False in subclass)
+        validate_assignment=True,
+    )
+
+    @classmethod
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from properties dictionary with validation.
+
+        This factory method provides a consistent way to create configuration
+        objects from properties dictionaries (typically from runbook YAML properties).
+
+        Subclasses should override this method to add environment variable
+        support, defaults, or other preprocessing logic specific to the component.
+
+        Args:
+            properties: Dictionary containing configuration properties from runbook
+
+        Returns:
+            Validated configuration instance
+
+        Raises:
+            ValidationError: If properties are invalid or missing required fields
+
+        Example:
+            ```python
+            config = PersonalDataAnalyserConfig.from_properties({
+                "pattern_matching": {"ruleset": "personal_data"},
+                "llm_validation": {"enable_llm_validation": True}
             })
             ```
 

--- a/libs/waivern-core/tests/waivern_core/test_component_factory.py
+++ b/libs/waivern-core/tests/waivern_core/test_component_factory.py
@@ -60,7 +60,12 @@ from typing import override
 
 import pytest
 
-from waivern_core import ComponentConfig, ComponentFactory, Schema
+from waivern_core import (
+    BaseComponentConfiguration,
+    ComponentConfig,
+    ComponentFactory,
+    Schema,
+)
 
 
 class ComponentFactoryContractTests[T]:
@@ -267,7 +272,8 @@ class ComponentFactoryContractTests[T]:
             Exceptions would break discovery process; False enables graceful skip.
 
         """
-        invalid_config = {}  # Empty config should be invalid for most factories
+        # Empty config should be invalid for most factories
+        invalid_config = BaseComponentConfiguration()
         result = factory.can_create(invalid_config)
         assert isinstance(result, bool), (
             "can_create() must return boolean even for invalid config, "


### PR DESCRIPTION
## Summary

Add `BaseComponentConfiguration` as a Pydantic-based base class for all component configurations (analysers and connectors). This provides strong typing, immutability, and validation for component factory configurations throughout the DI system.

## Changes

### Core Implementation
- ✅ Create `BaseComponentConfiguration` in `waivern-core/services/configuration.py`
  - Pydantic BaseModel with `frozen=True` (immutable)
  - `extra="forbid"` for strict validation
  - `from_properties()` factory method for dictionary-based creation
  - Mirrors same design pattern as `BaseServiceConfiguration`

- ✅ Update `ComponentConfig` type alias to point to `BaseComponentConfiguration`
  - Serves dual purpose: base class AND type annotation for factory signatures
  - Provides strong typing at factory interface level

- ✅ Export from waivern-core
  - Added to `waivern_core/services/__init__.py`
  - Added to main `waivern_core/__init__.py`

### Testing
- ✅ Add 4 comprehensive tests for `BaseComponentConfiguration`
  - Instantiation
  - Immutability (frozen fields)
  - Validation with `from_properties()`
  - Extra fields rejection

- ✅ Update ComponentFactory contract tests to use typed configs
  - Replace raw dict with `BaseComponentConfiguration` instances

### Documentation
- ✅ Update `docs/architecture/di-factory-patterns.md`
  - Add comprehensive "BaseComponentConfiguration Pattern" section
  - Update all method signatures from `config: dict` to `config: ComponentConfig`
  - Update all config parsing from `from_dict()` to `from_properties()`
  - Update all code examples (11+ occurrences)

- ✅ Update `docs/architecture/dependency-injection-implementation-plan.md`
  - Add Phase 3.6 documenting BaseComponentConfiguration implementation
  - Update method signatures in Phase 2 checklist

- ✅ Update `docs/adr/0002-dependency-injection-for-service-management.md`
  - Change `from_dict()` to `from_properties()` in example

## Benefits

- **Strong typing**: No raw dicts passed to factories
- **Validation**: Pydantic catches configuration errors early
- **Immutability**: Configurations cannot be modified after creation
- **Flexibility**: Factories accept base config or specific subclass
- **Consistency**: Same pattern as BaseServiceConfiguration

## Test Results

✅ All 802 tests passing
✅ 0 type errors
✅ All quality checks passing

## Related

- Part of Phase 3 DI implementation
- Builds on #167 (ComponentFactory ABC)
- Prepares for Phase 4 (Analyser Factory Implementation)