### PR TITLE
feat: migrate SourceCodeConnector to DI with ComponentFactory pattern

### DIFF
--- a/apps/wct/runbooks/samples/LAMP_stack.yaml
+++ b/apps/wct/runbooks/samples/LAMP_stack.yaml
@@ -6,7 +6,7 @@ contact: "Sarah Johnson (DPO) <sarah.johnson@company.co.uk>"
 
 connectors:
   - name: "php_source_code"
-    type: "source_code"
+    type: "source_code_connector"
     properties:
       path: "./libs/waivern-community/tests/waivern_community/analysers/processing_purpose_analyser/source_code_mock_php"
       language: "php"

--- a/libs/waivern-community/src/waivern_community/connectors/source_code/__init__.py
+++ b/libs/waivern-community/src/waivern_community/connectors/source_code/__init__.py
@@ -1,5 +1,11 @@
 """Source code connector for WCT."""
 
+from waivern_community.connectors.source_code.config import SourceCodeConnectorConfig
 from waivern_community.connectors.source_code.connector import SourceCodeConnector
+from waivern_community.connectors.source_code.factory import SourceCodeConnectorFactory
 
-__all__ = ["SourceCodeConnector"]
+__all__ = [
+    "SourceCodeConnector",
+    "SourceCodeConnectorConfig",
+    "SourceCodeConnectorFactory",
+]

--- a/libs/waivern-community/src/waivern_community/connectors/source_code/config.py
+++ b/libs/waivern-community/src/waivern_community/connectors/source_code/config.py
@@ -1,16 +1,15 @@
 """Configuration for SourceCodeConnector."""
 
 from pathlib import Path
-from typing import Annotated, Any, Self
+from typing import Annotated, Any, Self, override
 
 from pydantic import (
-    BaseModel,
     BeforeValidator,
-    ConfigDict,
     Field,
     ValidationError,
     field_validator,
 )
+from waivern_core import BaseComponentConfiguration
 from waivern_core.errors import ConnectorConfigError
 
 # Common file patterns to exclude from source code analysis
@@ -55,7 +54,7 @@ def _validate_path_required(v: str | Path | None) -> Path:
     return path_obj
 
 
-class SourceCodeConnectorConfig(BaseModel):
+class SourceCodeConnectorConfig(BaseComponentConfiguration):
     """Configuration for SourceCodeConnector with Pydantic validation.
 
     This provides strong typing and validation for source code connector
@@ -88,13 +87,6 @@ class SourceCodeConnectorConfig(BaseModel):
         description="Glob patterns to exclude from processing. Defaults to common exclusions (*.pyc, __pycache__, etc.). Specify custom patterns to override defaults, or empty list [] to disable all exclusions",
     )
 
-    model_config = ConfigDict(
-        # Allow extra fields for future extensibility
-        extra="forbid",
-        # Validate assignment to catch errors early
-        validate_assignment=True,
-    )
-
     @field_validator("language")
     @classmethod
     def validate_language_if_provided(cls, v: str | None) -> str | None:
@@ -116,6 +108,7 @@ class SourceCodeConnectorConfig(BaseModel):
         return v
 
     @classmethod
+    @override
     def from_properties(cls, properties: dict[str, Any]) -> Self:
         """Create configuration from runbook properties.
 

--- a/libs/waivern-community/src/waivern_community/connectors/source_code/connector.py
+++ b/libs/waivern-community/src/waivern_community/connectors/source_code/connector.py
@@ -76,7 +76,7 @@ class SourceCodeConnector(Connector):
     @override
     def get_name(cls) -> str:
         """Return the name of the connector."""
-        return "source_code"
+        return "source_code_connector"
 
     @classmethod
     @override
@@ -87,7 +87,13 @@ class SourceCodeConnector(Connector):
     @classmethod
     @override
     def from_properties(cls, properties: dict[str, Any]) -> Self:
-        """Create a source code connector instance from configuration properties.
+        """Create connector from properties (legacy method for Executor compatibility).
+
+        TODO: Remove this method in Phase 6 when Executor uses factories directly.
+
+        This is a backward-compatibility wrapper. New code should use:
+            config = SourceCodeConnectorConfig.from_properties(properties)
+            connector = SourceCodeConnector(config)
 
         Args:
             properties: Configuration properties dictionary containing:

--- a/libs/waivern-community/src/waivern_community/connectors/source_code/factory.py
+++ b/libs/waivern-community/src/waivern_community/connectors/source_code/factory.py
@@ -1,0 +1,51 @@
+"""Factory for creating SourceCodeConnector instances with dependency injection."""
+
+from typing import override
+
+from waivern_core import ComponentConfig, ComponentFactory, Schema
+
+from .config import SourceCodeConnectorConfig
+from .connector import SourceCodeConnector
+from .schemas import SourceCodeSchema
+
+
+class SourceCodeConnectorFactory(ComponentFactory[SourceCodeConnector]):
+    """Factory for creating SourceCodeConnector instances.
+
+    This factory has no service dependencies because source code parsing
+    requires no infrastructure services from the framework.
+    """
+
+    @override
+    def create(self, config: ComponentConfig) -> SourceCodeConnector:
+        """Create a SourceCodeConnector instance from configuration."""
+        if not isinstance(config, SourceCodeConnectorConfig):
+            msg = f"Expected SourceCodeConnectorConfig, got {type(config).__name__}"
+            raise TypeError(msg)
+
+        return SourceCodeConnector(config)
+
+    @override
+    def can_create(self, config: ComponentConfig) -> bool:
+        """Check if this factory can create a connector with the given config."""
+        return isinstance(config, SourceCodeConnectorConfig)
+
+    @override
+    def get_component_name(self) -> str:
+        """Get the component type name for connector registration."""
+        return "source_code_connector"
+
+    @override
+    def get_input_schemas(self) -> list[Schema]:
+        """Get the input schemas this connector accepts."""
+        return []  # Connectors extract, don't process
+
+    @override
+    def get_output_schemas(self) -> list[Schema]:
+        """Get the output schemas this connector produces."""
+        return [SourceCodeSchema()]
+
+    @override
+    def get_service_dependencies(self) -> dict[str, type]:
+        """Get the service dependencies required by this factory."""
+        return {}  # No service dependencies

--- a/libs/waivern-community/tests/waivern_community/connectors/source_code/test_connector.py
+++ b/libs/waivern-community/tests/waivern_community/connectors/source_code/test_connector.py
@@ -25,7 +25,8 @@ class TestSourceCodeConnectorInitialisation:
             f.flush()
 
             try:
-                connector = SourceCodeConnector.from_properties({"path": f.name})
+                config = SourceCodeConnectorConfig.from_properties({"path": f.name})
+                connector = SourceCodeConnector(config)
                 assert connector is not None
 
             finally:
@@ -91,7 +92,7 @@ class TestSourceCodeConnectorClassMethods:
         """Test that get_name returns correct connector name."""
         name = SourceCodeConnector.get_name()
 
-        assert name == "source_code"
+        assert name == "source_code_connector"
         assert isinstance(name, str)
 
     def test_get_supported_output_schemas_returns_source_code(self):
@@ -185,7 +186,8 @@ class UserManager {
             f.flush()
 
             try:
-                connector = SourceCodeConnector.from_properties({"path": f.name})
+                config = SourceCodeConnectorConfig.from_properties({"path": f.name})
+                connector = SourceCodeConnector(config)
                 message = connector.extract()
 
                 # Verify Message structure
@@ -276,7 +278,8 @@ class UserManager {
             # Create non-PHP file (should be ignored)
             (temp_path / "readme.txt").write_text("This is not PHP")
 
-            connector = SourceCodeConnector.from_properties({"path": temp_dir})
+            config = SourceCodeConnectorConfig.from_properties({"path": temp_dir})
+            connector = SourceCodeConnector(config)
             message = connector.extract()
 
             # Verify Message structure
@@ -303,7 +306,8 @@ class UserManager {
             f.flush()
 
             try:
-                connector = SourceCodeConnector.from_properties({"path": f.name})
+                config = SourceCodeConnectorConfig.from_properties({"path": f.name})
+                connector = SourceCodeConnector(config)
                 explicit_schema = SourceCodeSchema()
 
                 message = connector.extract(output_schema=explicit_schema)
@@ -334,9 +338,10 @@ class UserManager {
 
             try:
                 # Set a very small max file size
-                connector = SourceCodeConnector.from_properties(
+                config = SourceCodeConnectorConfig.from_properties(
                     {"path": f.name, "max_file_size": 100}
-                )  # 100 bytes
+                )
+                connector = SourceCodeConnector(config)
                 message = connector.extract()
 
                 # Should handle gracefully (file may be skipped)
@@ -367,12 +372,13 @@ class UserManager {
             )
 
             # Test with specific pattern
-            connector = SourceCodeConnector.from_properties(
+            config = SourceCodeConnectorConfig.from_properties(
                 {
                     "path": temp_dir,
                     "file_patterns": ["*.php"],  # Only .php files
                 }
             )
+            connector = SourceCodeConnector(config)
             message = connector.extract()
 
             assert isinstance(message, Message)
@@ -417,7 +423,8 @@ class UserManager {
             (temp_path / "node_modules").mkdir()
             (temp_path / "node_modules" / "package.json").write_text("{}")
 
-            connector = SourceCodeConnector.from_properties({"path": temp_dir})
+            config = SourceCodeConnectorConfig.from_properties({"path": temp_dir})
+            connector = SourceCodeConnector(config)
             message = connector.extract()
 
             assert isinstance(message, Message)
@@ -467,7 +474,7 @@ class UserManager {
             (temp_path / "test.log").write_text("log content")  # Normally excluded
 
             # Test with patterns that only include specific files
-            connector = SourceCodeConnector.from_properties(
+            config = SourceCodeConnectorConfig.from_properties(
                 {
                     "path": temp_dir,
                     "file_patterns": [
@@ -475,6 +482,7 @@ class UserManager {
                     ],  # Only files starting with "include_me"
                 }
             )
+            connector = SourceCodeConnector(config)
             message = connector.extract()
 
             assert isinstance(message, Message)
@@ -520,7 +528,8 @@ class UserManager {
                 "<?php class UserController {} ?>"
             )
 
-            connector = SourceCodeConnector.from_properties({"path": temp_dir})
+            config = SourceCodeConnectorConfig.from_properties({"path": temp_dir})
+            connector = SourceCodeConnector(config)
             message = connector.extract()
 
             assert isinstance(message, Message)
@@ -550,7 +559,8 @@ class TestSourceCodeConnectorEdgeCases:
     def test_extract_from_empty_directory(self):
         """Test extraction from empty directory."""
         with tempfile.TemporaryDirectory() as temp_dir:
-            connector = SourceCodeConnector.from_properties({"path": temp_dir})
+            config = SourceCodeConnectorConfig.from_properties({"path": temp_dir})
+            connector = SourceCodeConnector(config)
 
             # Empty directory should raise ConnectorExtractionError
             with pytest.raises(ConnectorExtractionError, match="No files found"):
@@ -566,7 +576,8 @@ class TestSourceCodeConnectorEdgeCases:
             (temp_path / "config.json").write_text('{"key": "value"}')
             (temp_path / "script.py").write_text("print('hello')")
 
-            connector = SourceCodeConnector.from_properties({"path": temp_dir})
+            config = SourceCodeConnectorConfig.from_properties({"path": temp_dir})
+            connector = SourceCodeConnector(config)
             message = connector.extract()
 
             assert isinstance(message, Message)
@@ -585,7 +596,8 @@ class TestSourceCodeConnectorEdgeCases:
             f.flush()
 
             try:
-                connector = SourceCodeConnector.from_properties({"path": f.name})
+                config = SourceCodeConnectorConfig.from_properties({"path": f.name})
+                connector = SourceCodeConnector(config)
                 # Should not raise exception - tree-sitter handles invalid syntax
                 message = connector.extract()
 
@@ -610,7 +622,8 @@ class TestSourceCodeConnectorEdgeCases:
             f.flush()
 
             try:
-                connector = SourceCodeConnector.from_properties({"path": f.name})
+                config = SourceCodeConnectorConfig.from_properties({"path": f.name})
+                connector = SourceCodeConnector(config)
 
                 # Should handle gracefully or raise appropriate exception
                 try:
@@ -633,7 +646,8 @@ class TestSourceCodeConnectorEdgeCases:
             f.flush()
 
             try:
-                connector = SourceCodeConnector.from_properties({"path": f.name})
+                config = SourceCodeConnectorConfig.from_properties({"path": f.name})
+                connector = SourceCodeConnector(config)
                 unsupported_schema = StandardInputSchema()
 
                 with pytest.raises(
@@ -671,7 +685,8 @@ class TestClass{i} {{
 ?>"""
                 (temp_path / f"file{i}.php").write_text(file_content)
 
-            connector = SourceCodeConnector.from_properties({"path": temp_dir})
+            config = SourceCodeConnectorConfig.from_properties({"path": temp_dir})
+            connector = SourceCodeConnector(config)
             message = connector.extract()
 
             assert isinstance(message, Message)
@@ -697,9 +712,10 @@ class TestClass{i} {{
                 (temp_path / f"file{i}.php").write_text(file_content)
 
             # Set low max_files limit
-            connector = SourceCodeConnector.from_properties(
+            config = SourceCodeConnectorConfig.from_properties(
                 {"path": temp_dir, "max_files": 5}
             )
+            connector = SourceCodeConnector(config)
             message = connector.extract()
 
             assert isinstance(message, Message)
@@ -742,7 +758,8 @@ class PrivacyManager {
             f.flush()
 
             try:
-                connector = SourceCodeConnector.from_properties({"path": f.name})
+                config = SourceCodeConnectorConfig.from_properties({"path": f.name})
+                connector = SourceCodeConnector(config)
                 message = connector.extract()
 
                 content = message.content
@@ -793,7 +810,8 @@ class PrivacyManager {
             f.flush()
 
             try:
-                connector = SourceCodeConnector.from_properties({"path": f.name})
+                config = SourceCodeConnectorConfig.from_properties({"path": f.name})
+                connector = SourceCodeConnector(config)
                 message = connector.extract()
 
                 # Message should be pre-validated by connector
@@ -824,7 +842,8 @@ class PrivacyManager {
                 "<?php class UserController { public function index() { return true; } } ?>"
             )
 
-            connector = SourceCodeConnector.from_properties({"path": temp_dir})
+            config = SourceCodeConnectorConfig.from_properties({"path": temp_dir})
+            connector = SourceCodeConnector(config)
             message = connector.extract()
 
             content = message.content
@@ -865,12 +884,13 @@ class TestSourceCodeConnectorExcludePatterns:
             (build_dir / "BuildScript.php").write_text("<?php class BuildScript {} ?>")
 
             # Exclude specific directories
-            connector = SourceCodeConnector.from_properties(
+            config = SourceCodeConnectorConfig.from_properties(
                 {
                     "path": temp_dir,
                     "exclude_patterns": ["tests/*", "vendor/*", "build/*"],
                 }
             )
+            connector = SourceCodeConnector(config)
             message = connector.extract()
 
             assert isinstance(message, Message)

--- a/libs/waivern-community/tests/waivern_community/connectors/source_code/test_factory.py
+++ b/libs/waivern-community/tests/waivern_community/connectors/source_code/test_factory.py
@@ -1,0 +1,39 @@
+"""Tests for SourceCodeConnectorFactory - Contract Tests Only."""
+
+import pytest
+from waivern_core import ComponentConfig, ComponentFactory
+from waivern_core.testing import ComponentFactoryContractTests
+
+from waivern_community.connectors.source_code import (
+    SourceCodeConnector,
+    SourceCodeConnectorConfig,
+    SourceCodeConnectorFactory,
+)
+
+
+class TestSourceCodeConnectorFactory(
+    ComponentFactoryContractTests[SourceCodeConnector]
+):
+    """Test suite for SourceCodeConnectorFactory.
+
+    Inherits 6 contract tests from ComponentFactoryContractTests.
+    """
+
+    @pytest.fixture
+    def factory(self) -> ComponentFactory[SourceCodeConnector]:
+        """Provide factory instance for contract tests."""
+        return SourceCodeConnectorFactory()
+
+    @pytest.fixture
+    def valid_config(self, tmp_path) -> ComponentConfig:
+        """Provide valid configuration for contract tests."""
+        # Create a temporary PHP file for testing
+        test_file = tmp_path / "test.php"
+        test_file.write_text("<?php\nfunction hello() {\n    return 'world';\n}\n")
+
+        return SourceCodeConnectorConfig.from_properties(
+            {
+                "path": str(test_file),
+                "language": "php",
+            }
+        )


### PR DESCRIPTION
## Summary

Migrates SourceCodeConnector to dependency injection using the ComponentFactory pattern, following the established approach from FilesystemConnector (#176) and MySQLConnector (#178).

## Changes

### Core Implementation
- ✅ Updated `SourceCodeConnectorConfig` to inherit from `BaseComponentConfiguration`
- ✅ Created `SourceCodeConnectorFactory` with zero service dependencies
- ✅ Added 6 contract tests using `ComponentFactoryContractTests` base class
- ✅ Exported factory and config from package `__init__.py`

### Consistency Updates
- ✅ Updated connector name from `"source_code"` to `"source_code_connector"`
- ✅ Fixed LAMP_stack.yaml runbook reference (line 9)

### Backward Compatibility
- ✅ Added TODO comment to `from_properties()` for Phase 6 removal
- ✅ Documented backward compatibility pattern in docstring
- ✅ Maintained existing `from_properties()` tests

### Test Modernisation
- ✅ Updated 18 test methods to use DI constructor pattern
- ✅ Changed from: `SourceCodeConnector.from_properties({"path": ...})`
- ✅ Changed to: `config = SourceCodeConnectorConfig.from_properties({...}); connector = SourceCodeConnector(config)`

## Test Results

```
841 passed, 14 deselected
All checks passed!
0 errors, 0 warnings, 0 notes
```

## Files Changed

- `libs/waivern-community/src/waivern_community/connectors/source_code/config.py`
- `libs/waivern-community/src/waivern_community/connectors/source_code/connector.py`
- `libs/waivern-community/src/waivern_community/connectors/source_code/factory.py` (NEW)
- `libs/waivern-community/src/waivern_community/connectors/source_code/__init__.py`
- `libs/waivern-community/tests/waivern_community/connectors/source_code/test_factory.py` (NEW)
- `libs/waivern-community/tests/waivern_community/connectors/source_code/test_connector.py`
- `apps/wct/runbooks/samples/LAMP_stack.yaml`

Closes #180
Part of #175 (Phase 4 DI implementation)