### PR TITLE
feat: migrate SQLiteConnector to DI with ComponentFactory pattern

### DIFF
--- a/apps/wct/runbooks/samples/LAMP_stack_lite.yaml
+++ b/apps/wct/runbooks/samples/LAMP_stack_lite.yaml
@@ -7,7 +7,7 @@ contact: "Sarah Johnson (DPO) <sarah.johnson@company.co.uk>"
 
 connectors:
   - name: compliance_sqlite_db
-    type: sqlite
+    type: sqlite_connector
     properties:
       # SQLite database path can be set via environment variable SQLITE_DATABASE_PATH
       # or specified directly in the runbook

--- a/apps/wct/tests/integration/test_sqlite_e2e.py
+++ b/apps/wct/tests/integration/test_sqlite_e2e.py
@@ -47,7 +47,7 @@ class TestSQLiteE2EIntegration:
         # Assert - Verify database metadata
         assert "metadata" in message.content
         metadata = message.content["metadata"]
-        assert metadata["connector_type"] == "sqlite"
+        assert metadata["connector_type"] == "sqlite_connector"
         assert "database_schema" in metadata
         assert metadata["database_schema"]["database_name"] == "sqlite_compliance_test"
 
@@ -66,7 +66,7 @@ class TestSQLiteE2EIntegration:
 
         # Assert - Verify data item metadata structure
         item_metadata = first_item["metadata"]
-        assert item_metadata["connector_type"] == "sqlite"
+        assert item_metadata["connector_type"] == "sqlite_connector"
         assert "table_name" in item_metadata
         assert "column_name" in item_metadata
         assert "schema_name" in item_metadata

--- a/libs/waivern-community/src/waivern_community/connectors/sqlite/__init__.py
+++ b/libs/waivern-community/src/waivern_community/connectors/sqlite/__init__.py
@@ -1,5 +1,11 @@
 """SQLite connector package."""
 
+from waivern_community.connectors.sqlite.config import SQLiteConnectorConfig
 from waivern_community.connectors.sqlite.connector import SQLiteConnector
+from waivern_community.connectors.sqlite.factory import SQLiteConnectorFactory
 
-__all__ = ("SQLiteConnector",)
+__all__ = (
+    "SQLiteConnector",
+    "SQLiteConnectorConfig",
+    "SQLiteConnectorFactory",
+)

--- a/libs/waivern-community/src/waivern_community/connectors/sqlite/config.py
+++ b/libs/waivern-community/src/waivern_community/connectors/sqlite/config.py
@@ -1,13 +1,14 @@
 """Configuration for SQLiteConnector."""
 
 import os
-from typing import Any, Self
+from typing import Any, Self, override
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import Field, ValidationError, field_validator
+from waivern_core import BaseComponentConfiguration
 from waivern_core.errors import ConnectorConfigError
 
 
-class SQLiteConnectorConfig(BaseModel):
+class SQLiteConnectorConfig(BaseComponentConfiguration):
     """Configuration for SQLiteConnector with Pydantic validation.
 
     This provides strong typing and validation for SQLite connector
@@ -21,13 +22,6 @@ class SQLiteConnectorConfig(BaseModel):
         gt=0,
     )
 
-    model_config = ConfigDict(
-        # Forbid extra fields for strict validation
-        extra="forbid",
-        # Validate assignment to catch errors early
-        validate_assignment=True,
-    )
-
     @field_validator("database_path", mode="before")
     @classmethod
     def validate_database_path_not_empty(cls, v: str | None) -> str:
@@ -37,6 +31,7 @@ class SQLiteConnectorConfig(BaseModel):
         return str(v).strip()
 
     @classmethod
+    @override
     def from_properties(cls, properties: dict[str, Any]) -> Self:
         """Create configuration from runbook properties with environment variable support.
 

--- a/libs/waivern-community/src/waivern_community/connectors/sqlite/connector.py
+++ b/libs/waivern-community/src/waivern_community/connectors/sqlite/connector.py
@@ -47,7 +47,7 @@ class SQLiteConnector(DatabaseConnector):
     @override
     def get_name(cls) -> str:
         """Return the name of the connector."""
-        return "sqlite"
+        return "sqlite_connector"
 
     @classmethod
     @override
@@ -58,7 +58,13 @@ class SQLiteConnector(DatabaseConnector):
     @classmethod
     @override
     def from_properties(cls, properties: dict[str, Any]) -> Self:
-        """Create connector from configuration properties.
+        """Create connector from properties (legacy method for Executor compatibility).
+
+        TODO: Remove this method in Phase 6 when Executor uses factories directly.
+
+        This is a backward-compatibility wrapper. New code should use:
+            config = SQLiteConnectorConfig.from_properties(properties)
+            connector = SQLiteConnector(config)
 
         Args:
             properties: Raw properties from runbook configuration
@@ -294,7 +300,7 @@ class SQLiteConnector(DatabaseConnector):
             "source": database_source,
             # Top-level metadata includes complete database schema for reference
             "metadata": {
-                "connector_type": "sqlite",  # Standard connector type field
+                "connector_type": "sqlite_connector",  # Standard connector type field
                 "connection_info": {
                     "database_path": self._config.database_path,
                 },
@@ -335,7 +341,7 @@ class SQLiteConnector(DatabaseConnector):
                         # Create RelationalDatabaseMetadata for the cell
                         cell_metadata = RelationalDatabaseMetadata(
                             source=f"sqlite_database_({Path(self._config.database_path).stem})_table_({table_name})_column_({column_name})_row_({row_index + 1})",
-                            connector_type="sqlite",
+                            connector_type="sqlite_connector",
                             table_name=table_name,
                             column_name=column_name,
                             schema_name=Path(self._config.database_path).stem,

--- a/libs/waivern-community/src/waivern_community/connectors/sqlite/factory.py
+++ b/libs/waivern-community/src/waivern_community/connectors/sqlite/factory.py
@@ -1,0 +1,51 @@
+"""Factory for creating SQLiteConnector instances with dependency injection."""
+
+from typing import override
+
+from waivern_core import ComponentConfig, ComponentFactory, Schema
+from waivern_core.schemas import StandardInputSchema
+
+from .config import SQLiteConnectorConfig
+from .connector import SQLiteConnector
+
+
+class SQLiteConnectorFactory(ComponentFactory[SQLiteConnector]):
+    """Factory for creating SQLiteConnector instances.
+
+    This factory has no service dependencies because SQLite database operations
+    require no infrastructure services from the framework.
+    """
+
+    @override
+    def create(self, config: ComponentConfig) -> SQLiteConnector:
+        """Create a SQLiteConnector instance from configuration."""
+        if not isinstance(config, SQLiteConnectorConfig):
+            msg = f"Expected SQLiteConnectorConfig, got {type(config).__name__}"
+            raise TypeError(msg)
+
+        return SQLiteConnector(config)
+
+    @override
+    def can_create(self, config: ComponentConfig) -> bool:
+        """Check if this factory can create a connector with the given config."""
+        return isinstance(config, SQLiteConnectorConfig)
+
+    @override
+    def get_component_name(self) -> str:
+        """Get the component type name for connector registration."""
+        return "sqlite_connector"
+
+    @override
+    def get_input_schemas(self) -> list[Schema]:
+        """Get the input schemas this connector accepts."""
+        return []  # Connectors extract, don't process
+
+    @override
+    def get_output_schemas(self) -> list[Schema]:
+        """Get the output schemas this connector produces."""
+        return [StandardInputSchema()]
+
+    @override
+    def get_service_dependencies(self) -> dict[str, type]:
+        """Get the service dependencies required by this factory."""
+        return {}  # No service dependencies

--- a/libs/waivern-community/tests/waivern_community/connectors/sqlite/test_factory.py
+++ b/libs/waivern-community/tests/waivern_community/connectors/sqlite/test_factory.py
@@ -1,0 +1,34 @@
+"""Tests for SQLiteConnectorFactory - Contract Tests Only."""
+
+import pytest
+from waivern_core import ComponentConfig, ComponentFactory
+from waivern_core.testing import ComponentFactoryContractTests
+
+from waivern_community.connectors.sqlite import (
+    SQLiteConnector,
+    SQLiteConnectorConfig,
+    SQLiteConnectorFactory,
+)
+
+
+class TestSQLiteConnectorFactory(ComponentFactoryContractTests[SQLiteConnector]):
+    """Test suite for SQLiteConnectorFactory.
+
+    Inherits 6 contract tests from ComponentFactoryContractTests.
+    """
+
+    @pytest.fixture
+    def factory(self) -> ComponentFactory[SQLiteConnector]:
+        """Provide factory instance for contract tests."""
+        return SQLiteConnectorFactory()
+
+    @pytest.fixture
+    def valid_config(self, tmp_path) -> ComponentConfig:
+        """Provide valid configuration for contract tests."""
+        # Create a temporary SQLite database file
+        db_file = tmp_path / "test.db"
+        db_file.touch()
+
+        return SQLiteConnectorConfig.from_properties(
+            {"database_path": str(db_file), "max_rows_per_table": 10}
+        )


### PR DESCRIPTION
## Summary

Migrates SQLiteConnector to dependency injection using the ComponentFactory pattern, following the established approach from FilesystemConnector (#176), MySQLConnector (#178), and SourceCodeConnector (#180).

## Changes

### Core Implementation
- ✅ Updated `SQLiteConnectorConfig` to inherit from `BaseComponentConfiguration`
- ✅ Created `SQLiteConnectorFactory` with zero service dependencies
- ✅ Added 6 contract tests using `ComponentFactoryContractTests` base class
- ✅ Exported factory and config from package `__init__.py`

### Consistency Updates
- ✅ Updated connector name from `"sqlite"` to `"sqlite_connector"`
- ✅ Fixed LAMP_stack_lite.yaml runbook reference (line 10)
- ✅ Updated connector.py metadata fields (2 locations)
- ✅ Updated test assertions (7 in test_connector.py + 2 in test_sqlite_e2e.py)

### Backward Compatibility
- ✅ Added TODO comment to `from_properties()` for Phase 6 removal
- ✅ Documented backward compatibility pattern in docstring
- ✅ Maintained existing `from_properties()` tests
- ✅ Preserved environment variable support (`SQLITE_DATABASE_PATH`)

### Test Modernisation
- ✅ Updated 15 test methods to use DI constructor pattern
- ✅ Changed from: `SQLiteConnector.from_properties({"database_path": ...})`
- ✅ Changed to: `config = SQLiteConnectorConfig.from_properties({...}); connector = SQLiteConnector(config)`
- ✅ Added `SQLiteConnectorConfig` import to test file

## Test Results

```
847 passed, 14 deselected
All checks passed!
0 errors, 0 warnings, 0 notes
```

## Files Changed

- `libs/waivern-community/src/waivern_community/connectors/sqlite/config.py`
- `libs/waivern-community/src/waivern_community/connectors/sqlite/connector.py`
- `libs/waivern-community/src/waivern_community/connectors/sqlite/factory.py` (NEW)
- `libs/waivern-community/src/waivern_community/connectors/sqlite/__init__.py`
- `libs/waivern-community/tests/waivern_community/connectors/sqlite/test_factory.py` (NEW)
- `libs/waivern-community/tests/waivern_community/connectors/sqlite/test_connector.py`
- `apps/wct/tests/integration/test_sqlite_e2e.py`
- `apps/wct/runbooks/samples/LAMP_stack_lite.yaml`

Closes #182
Part of #175 (Phase 4 DI implementation)