### PR TITLE
docs: mark connectors DI migration complete and export connector factories

### DIFF
--- a/docs/architecture/dependency-injection-implementation-plan.md
+++ b/docs/architecture/dependency-injection-implementation-plan.md
@@ -260,43 +260,59 @@ All three analysers followed these steps:
 
 ### 5.1 FilesystemConnector
 
-- [ ] Create `FilesystemConnectorFactory` in waivern-community
-- [ ] Implement ComponentFactory[FilesystemConnector]
-- [ ] Update connector constructor (no services needed currently)
-- [ ] Remove `from_properties()`
-- [ ] Update tests
+- [x] Create `FilesystemConnectorFactory` in waivern-community
+- [x] Implement ComponentFactory[FilesystemConnector]
+- [x] Update connector constructor (no services needed currently)
+- [ ] Remove `from_properties()` (deferred to Phase 6.4)
+- [x] Update tests
+
+**Completed:** Issue #176, PR #177 (merged Oct 29, 2025)
 
 ### 5.2 SourceCodeConnector
 
-- [ ] Create `SourceCodeConnectorFactory` in waivern-community
-- [ ] Implement ComponentFactory[SourceCodeConnector]
-- [ ] Update connector constructor
-- [ ] Remove `from_properties()`
-- [ ] Update tests
+- [x] Create `SourceCodeConnectorFactory` in waivern-community
+- [x] Implement ComponentFactory[SourceCodeConnector]
+- [x] Update connector constructor
+- [ ] Remove `from_properties()` (deferred to Phase 6.4)
+- [x] Update tests
+
+**Completed:** Issue #180, PR #181 (merged Oct 30, 2025)
 
 ### 5.3 MySQLConnector
 
-- [ ] Create `MySQLConnectorFactory` in waivern-mysql package
-- [ ] Implement ComponentFactory[MySQLConnector]
-- [ ] Constructor could accept `db_pool: DatabasePool | None` (future)
-- [ ] Update connector constructor
-- [ ] Remove `from_properties()`
-- [ ] Update tests
+- [x] Create `MySQLConnectorFactory` in waivern-mysql package
+- [x] Implement ComponentFactory[MySQLConnector]
+- [x] Constructor could accept `db_pool: DatabasePool | None` (future)
+- [x] Update connector constructor
+- [ ] Remove `from_properties()` (deferred to Phase 6.4)
+- [x] Update tests
+
+**Completed:** Issue #178, PR #179 (merged Oct 30, 2025)
 
 ### 5.4 SQLiteConnector
 
-- [ ] Create `SQLiteConnectorFactory` in waivern-community
-- [ ] Implement ComponentFactory[SQLiteConnector]
-- [ ] Update connector constructor
-- [ ] Remove `from_properties()`
-- [ ] Update tests
+- [x] Create `SQLiteConnectorFactory` in waivern-community
+- [x] Implement ComponentFactory[SQLiteConnector]
+- [x] Update connector constructor
+- [ ] Remove `from_properties()` (deferred to Phase 6.4)
+- [x] Update tests
+
+**Completed:** Issue #182, PR #183 (merged Oct 30, 2025)
 
 ### 5.5 Export Factories
 
-- [ ] Export each connector factory from its package `__init__.py`
-- [ ] Update docstrings to reference factory pattern
+- [x] Export each connector factory from its package `__init__.py`
+  - [x] MySQLConnectorFactory exported from waivern-mysql
+  - [x] FilesystemConnectorFactory, SourceCodeConnectorFactory, SQLiteConnectorFactory exported from waivern-community
+- [x] Update docstrings to reference factory pattern
+
+**Completed:** All factories exported and documented
 
 **Deliverable:** All connectors DI-enabled with factories, backward compatible via `from_properties()`
+
+---
+
+**Phase 5 Status: ✅ Complete** - All 4 connectors have DI-enabled factories with contract tests. Backward compatibility maintained via `from_properties()` wrappers (to be removed in Phase 6.4).
 
 ---
 

--- a/libs/waivern-community/src/waivern_community/connectors/__init__.py
+++ b/libs/waivern-community/src/waivern_community/connectors/__init__.py
@@ -12,9 +12,18 @@ from waivern_core.errors import (
 )
 from waivern_mysql import MySQLConnector
 
-from waivern_community.connectors.filesystem import FilesystemConnector
-from waivern_community.connectors.source_code import SourceCodeConnector
-from waivern_community.connectors.sqlite import SQLiteConnector
+from waivern_community.connectors.filesystem import (
+    FilesystemConnector,
+    FilesystemConnectorFactory,
+)
+from waivern_community.connectors.source_code import (
+    SourceCodeConnector,
+    SourceCodeConnectorFactory,
+)
+from waivern_community.connectors.sqlite import (
+    SQLiteConnector,
+    SQLiteConnectorFactory,
+)
 
 __all__ = (
     "Connector",
@@ -22,9 +31,12 @@ __all__ = (
     "ConnectorError",
     "ConnectorExtractionError",
     "FilesystemConnector",
+    "FilesystemConnectorFactory",
     "MySQLConnector",
     "SourceCodeConnector",
+    "SourceCodeConnectorFactory",
     "SQLiteConnector",
+    "SQLiteConnectorFactory",
     "BUILTIN_CONNECTORS",
 )
 


### PR DESCRIPTION
## Summary

This PR completes Phase 5 documentation and exports all connector factories needed for Phase 6 Executor integration.

### Changes

1. **Update Connectors DI migration  status in implementation plan**
   - Mark all 4 connector factory implementations as complete
   - Add completion dates and PR references:
     - FilesystemConnector: Issue #176, PR #177 (Oct 29, 2025)
     - MySQLConnector: Issue #178, PR #179 (Oct 30, 2025)
     - SourceCodeConnector: Issue #180, PR #181 (Oct 30, 2025)
     - SQLiteConnector: Issue #182, PR #183 (Oct 30, 2025)
   - Note that `from_properties()` removal is deferred to Phase 6.4
   - Add Phase 5 completion summary

2. **Export connector factories from waivern_community.connectors**
   - Export `FilesystemConnectorFactory`
   - Export `SourceCodeConnectorFactory`
   - Export `SQLiteConnectorFactory`
   - All factories now importable from top-level connector package

### Context

Connectors DI migration work was completed across 4 PRs (#177, #179, #181, #183) but:
- Implementation plan document still showed the work as incomplete
- Three connector factories were not exported from package `__init__.py`

This PR brings documentation in sync with reality and completes the factory export infrastructure needed for the next phase.

### Testing

- ✅ All 3 factories import successfully
- ✅ 847 tests passed (no breaking changes)
- ✅ All quality checks passed (formatting, linting, type checking)

### Next Steps

Connectors DI migration is now complete. Ready to proceed with the next phase: Executor Integration.