### PR TITLE
docs: document Pydantic-based schema generation

### DIFF
--- a/apps/wct/runbooks/README.md
+++ b/apps/wct/runbooks/README.md
@@ -191,6 +191,26 @@ uv run wct generate-schema
 
 This enables real-time validation and autocomplete in VS Code, PyCharm, and other IDEs. See [IDE Integration Guide](../docs/ide-integration.md) for setup instructions.
 
+### How Schema Generation Works
+
+WCT uses Pydantic models as the single source of truth for runbook validation:
+
+1. **Runtime validation**: Pydantic validates runbooks when `wct run` executes
+2. **IDE support**: JSON Schema is auto-generated from Pydantic via `model_json_schema()`
+3. **Single source**: One definition serves both purposes (no duplication)
+
+When you run `wct generate-schema`, it:
+- Extracts JSON Schema from the Pydantic `Runbook` model
+- Adds WCT-specific metadata (version, title, description)
+- Outputs to file for IDE consumption
+
+This ensures runtime validation and IDE autocomplete are always in sync. Field descriptions, constraints, and validation rules defined in the Pydantic model automatically appear in both runtime errors and IDE tooltips.
+
+**Regenerate schema after WCT updates:**
+```bash
+wct generate-schema --output runbook.schema.json
+```
+
 ## Scenario Ideas
 
 Future runbooks could include:


### PR DESCRIPTION
## Summary

Document how WCT generates JSON Schema from Pydantic models for runbook validation.

## Changes

Add "How Schema Generation Works" section to `apps/wct/runbooks/README.md` explaining:
- Pydantic models as single source of truth
- Dual purpose: runtime validation and IDE support
- Schema generation process via `model_json_schema()`
- Synchronisation between runtime errors and IDE tooltips

## Location Rationale

Placed in runbooks README near existing IDE integration section for:
- Proximity to related `wct generate-schema` documentation
- Better discoverability for users setting up IDE support
- Appropriate level of detail for practical usage