### PR TITLE
refactor: align RulesetRegistry with SchemaRegistry testing pattern

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,7 @@ the entire monorepo workspace.
 
 import pytest
 from waivern_core.schemas import SchemaRegistry
+from waivern_rulesets import RulesetRegistry
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -31,3 +32,28 @@ def isolate_schema_registry():
 
     # Restore state after test completes (even if test fails)
     SchemaRegistry.restore_state(saved_state)
+
+
+@pytest.fixture(autouse=True, scope="function")
+def isolate_ruleset_registry():
+    """Automatically preserve and restore RulesetRegistry state for each test.
+
+    This fixture ensures test isolation by:
+    1. Capturing RulesetRegistry state before each test
+    2. Restoring the exact state after each test completes
+    3. Running automatically for ALL tests (autouse=True)
+
+    Why this is needed:
+    - RulesetRegistry is a singleton with mutable global state
+    - Tests that clear/modify the registry would break subsequent tests
+    - Without isolation, test execution order affects test results
+
+    This is the industry standard pattern for testing singletons in Python.
+    """
+    # Capture state before test runs
+    saved_state = RulesetRegistry.snapshot_state()
+
+    yield  # Test runs here
+
+    # Restore state after test completes (even if test fails)
+    RulesetRegistry.restore_state(saved_state)

--- a/docs/development/active/align-singleton-testing-patterns.md
+++ b/docs/development/active/align-singleton-testing-patterns.md
@@ -1,0 +1,135 @@
+# Implementation Plan: Align RulesetRegistry with SchemaRegistry Testing Pattern
+
+## Objective
+Eliminate singleton testing tech debt by aligning RulesetRegistry with SchemaRegistry's industry-standard snapshot/restore pattern.
+
+## Approach
+Follow TDD principles: Add new methods → Update fixture → Verify tests pass → Clean up boilerplate
+
+## Implementation Steps
+
+### Phase 1: Add Snapshot/Restore Methods (Core Change)
+**File:** `libs/waivern-rulesets/src/waivern_rulesets/base.py`
+
+**Changes:**
+- Add `snapshot_state()` classmethod to capture registry state
+- Add `restore_state(state)` classmethod to restore from snapshot
+- Keep existing `clear()` method for backward compatibility
+
+**Risk:** Low - purely additive, no breaking changes
+
+---
+
+### Phase 2: Update Package-Level Test Fixture
+**File:** `libs/waivern-rulesets/tests/conftest.py`
+
+**Changes:**
+- Simplify `isolated_registry` fixture to use snapshot/restore
+- Remove manual state capture (accessing `_registry`, `_type_mapping`)
+- Keep fixture non-autouse initially (safer transition)
+
+**Risk:** Low - tests still explicitly request fixture
+
+---
+
+### Phase 3: Verify Test Isolation (Validation)
+**Action:** Run full test suite for waivern-rulesets package
+
+**Command:**
+```bash
+uv run pytest libs/waivern-rulesets/tests/ -v
+```
+
+**Expected:** All tests pass with new fixture implementation
+
+**Risk:** Low - if tests fail, revert fixture changes
+
+---
+
+### Phase 4: Add Workspace-Level Autouse Fixture (Optional)
+**File:** `conftest.py` (workspace root)
+
+**Changes:**
+- Add autouse fixture for automatic RulesetRegistry isolation
+- Similar pattern to existing `isolate_schema_registry` fixture
+
+**Risk:** Medium - affects all tests workspace-wide
+**Mitigation:** Can skip this step if desired, keep package-level only
+
+---
+
+### Phase 5: Clean Up Test Boilerplate (8 test files)
+**Files to modify:**
+- `test_base.py`
+- `test_data_collection.py`
+- `test_data_subject.py`
+- `test_personal_data.py`
+- `test_processing_purposes.py`
+- `test_service_integrations.py`
+- `test_types.py`
+
+**Changes:**
+- Remove manual `isolated_registry.clear()` calls
+- Tests become cleaner (fixture handles isolation)
+
+**Risk:** Low - if autouse fixture not added, keep fixture usage but remove clear()
+
+---
+
+### Phase 6: Full Regression Testing
+**Action:** Run complete workspace test suite
+
+**Command:**
+```bash
+./scripts/dev-checks.sh
+```
+
+**Expected:** All 933+ tests pass
+
+---
+
+## Testing Strategy
+
+**After each phase:**
+1. Run package tests: `uv run pytest libs/waivern-rulesets/tests/ -v`
+2. Verify all tests pass
+3. If failures occur, analyse and fix or revert
+
+**Final validation:**
+- Run full workspace tests
+- Ensure no test pollution or flaky tests
+- Verify parallel execution works correctly
+
+---
+
+## Rollback Strategy
+
+**If issues arise:**
+- Phase 1-2: Revert fixture changes, keep old implementation
+- Phase 4: Remove autouse fixture, rely on package-level only
+- Phase 5: Keep manual clear() calls if needed
+
+**Changes are incremental** - can stop at any phase and still have improvement
+
+---
+
+## Success Criteria
+
+✅ RulesetRegistry has snapshot_state() and restore_state() methods
+✅ Test fixture uses public API (no private attribute access)
+✅ All package tests pass with new implementation
+✅ Consistent pattern with SchemaRegistry
+✅ Less test boilerplate (fewer/no clear() calls)
+
+---
+
+## Dependencies
+None - this is a self-contained change to waivern-rulesets package
+
+---
+
+## Notes
+- Keep `clear()` method for backward compatibility
+- Can stop after Phase 3 and still have significant improvement
+- Phase 4 (autouse) is optional but recommended for full consistency
+- Phase 5 cleanup can be done gradually across multiple commits

--- a/libs/waivern-rulesets/src/waivern_rulesets/base.py
+++ b/libs/waivern-rulesets/src/waivern_rulesets/base.py
@@ -147,6 +147,38 @@ class RulesetRegistry:
         self._registry.clear()
         self._type_mapping.clear()
 
+    @classmethod
+    def snapshot_state(cls) -> dict[str, Any]:
+        """Capture current RulesetRegistry state for later restoration.
+
+        This is primarily used for test isolation - save state before tests,
+        restore after tests to prevent global state pollution.
+
+        Returns:
+            Dictionary containing all mutable state
+
+        """
+        instance = cls()
+        return {
+            "registry": instance._registry.copy(),
+            "type_mapping": instance._type_mapping.copy(),
+        }
+
+    @classmethod
+    def restore_state(cls, state: dict[str, Any]) -> None:
+        """Restore RulesetRegistry state from a previously captured snapshot.
+
+        This is primarily used for test isolation - restore state after tests
+        to ensure tests don't pollute global state.
+
+        Args:
+            state: State dictionary from snapshot_state()
+
+        """
+        instance = cls()
+        instance._registry = state["registry"].copy()
+        instance._type_mapping = state["type_mapping"].copy()
+
 
 class RulesetLoader:
     """Loads rulesets using singleton registry with explicit registration."""

--- a/libs/waivern-rulesets/tests/conftest.py
+++ b/libs/waivern-rulesets/tests/conftest.py
@@ -3,44 +3,31 @@
 This module provides fixtures and configuration for the waivern-rulesets test suite.
 """
 
-from collections.abc import Iterator
-from typing import Any
-
 import pytest
-from waivern_core import BaseRule
 
 from waivern_rulesets import RulesetRegistry
-from waivern_rulesets.base import AbstractRuleset
 
 
 @pytest.fixture
-def isolated_registry() -> Iterator[RulesetRegistry]:
-    """Provide isolated registry that auto-restores state after test.
+def isolated_registry() -> RulesetRegistry:
+    """Provide RulesetRegistry instance for tests that need it.
 
-    This fixture captures the current registry state before the test runs,
-    then restores it after the test completes. This allows tests to safely
-    call registry.clear() without affecting other tests.
+    Note: Workspace-level autouse fixture (conftest.py) already handles
+    state isolation automatically. This fixture is for tests that need
+    to explicitly access the registry instance.
 
     Usage:
         def test_something(isolated_registry):
-            isolated_registry.clear()  # Safe - state will be restored
-            # Test code here
+            # Can safely modify registry - workspace fixture restores state
+            isolated_registry.register(...)
+
+        # Tests that don't need the instance don't request it:
+        def test_without_registry():
+            # Still gets automatic state isolation from workspace fixture
+            pass
 
     Returns:
         The singleton RulesetRegistry instance
 
     """
-    registry = RulesetRegistry()
-
-    # Capture current state before test runs
-    saved_state: dict[str, tuple[type[AbstractRuleset[Any]], type[BaseRule]]] = {
-        name: (registry._registry[name], registry._type_mapping[name])  # type: ignore[attr-defined]
-        for name in list(registry._registry.keys())  # type: ignore[attr-defined]
-    }
-
-    yield registry
-
-    # Restore state after test completes
-    registry.clear()
-    for name, (ruleset_class, rule_type) in saved_state.items():
-        registry.register(name, ruleset_class, rule_type)
+    return RulesetRegistry()

--- a/libs/waivern-rulesets/tests/waivern_rulesets/test_base.py
+++ b/libs/waivern-rulesets/tests/waivern_rulesets/test_base.py
@@ -102,15 +102,14 @@ class TestRulesetRegistry:
     def test_registry_initialises_empty_registry(
         self, isolated_registry: RulesetRegistry
     ) -> None:
-        """Test that registry starts with empty ruleset registry."""
+        """Test that registry can be cleared to empty state."""
+        # Clear registry for this specific test that needs empty state
         isolated_registry.clear()
-
         # Access private attribute for testing purposes
         assert isolated_registry._registry == {}  # type: ignore[attr-defined]
 
     def test_register_ruleset_class(self, isolated_registry: RulesetRegistry) -> None:
         """Test registering a ruleset class."""
-        isolated_registry.clear()
         isolated_registry.register(
             "test_ruleset", ConcreteRuleset, ProcessingPurposeRule
         )
@@ -122,7 +121,6 @@ class TestRulesetRegistry:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test retrieving a registered ruleset class."""
-        isolated_registry.clear()
         isolated_registry.register(
             "test_ruleset", ConcreteRuleset, ProcessingPurposeRule
         )
@@ -137,8 +135,6 @@ class TestRulesetRegistry:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that getting an unregistered ruleset raises RulesetNotFoundError."""
-        isolated_registry.clear()
-
         with pytest.raises(
             RulesetNotFoundError, match="Ruleset nonexistent not registered"
         ):
@@ -148,7 +144,6 @@ class TestRulesetRegistry:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that multiple registrations are maintained across singleton instances."""
-        isolated_registry.clear()
         isolated_registry.register("ruleset1", ConcreteRuleset, ProcessingPurposeRule)
         isolated_registry.register("ruleset2", ConcreteRuleset, ProcessingPurposeRule)
 
@@ -182,7 +177,6 @@ class TestRulesetRegistry:
             def get_rules(self) -> tuple[ProcessingPurposeRule, ...]:
                 return ()
 
-        isolated_registry.clear()
         isolated_registry.register("test_name", ConcreteRuleset, ProcessingPurposeRule)
 
         with pytest.raises(
@@ -207,7 +201,6 @@ class TestRulesetLoader:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that load_ruleset uses the singleton registry."""
-        isolated_registry.clear()
         isolated_registry.register(
             "test_ruleset", ConcreteRuleset, ProcessingPurposeRule
         )
@@ -223,8 +216,6 @@ class TestRulesetLoader:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that loading a nonexistent ruleset raises RulesetNotFoundError."""
-        isolated_registry.clear()
-
         with pytest.raises(
             RulesetNotFoundError, match="Ruleset nonexistent not registered"
         ):
@@ -259,7 +250,6 @@ class TestRulesetLoader:
                     ),
                 )
 
-        isolated_registry.clear()
         isolated_registry.register(
             "name_tracking", NameTrackingRuleset, ProcessingPurposeRule
         )
@@ -273,7 +263,6 @@ class TestRulesetLoader:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that load_ruleset can be called as a class method."""
-        isolated_registry.clear()
         isolated_registry.register(
             "class_method_test", ConcreteRuleset, ProcessingPurposeRule
         )
@@ -324,7 +313,6 @@ class TestRulesetIntegration:
                     ),
                 )
 
-        isolated_registry.clear()
         isolated_registry.register("custom_rules", CustomRuleset, ProcessingPurposeRule)
 
         # Load the ruleset
@@ -374,7 +362,6 @@ class TestRulesetIntegration:
                     ),
                 )
 
-        isolated_registry.clear()
         isolated_registry.register(
             "versioned_rules", VersionedRuleset, ProcessingPurposeRule
         )

--- a/libs/waivern-rulesets/tests/waivern_rulesets/test_data_collection.py
+++ b/libs/waivern-rulesets/tests/waivern_rulesets/test_data_collection.py
@@ -158,7 +158,6 @@ class TestDataCollectionIntegration:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that DataCollectionRuleset works with RulesetLoader."""
-        isolated_registry.clear()
         isolated_registry.register(
             "loader_test", DataCollectionRuleset, DataCollectionRule
         )

--- a/libs/waivern-rulesets/tests/waivern_rulesets/test_data_subject.py
+++ b/libs/waivern-rulesets/tests/waivern_rulesets/test_data_subject.py
@@ -319,7 +319,6 @@ class TestDataSubjectsRulesetIntegration:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that DataSubjectsRuleset works with the registry pattern."""
-        isolated_registry.clear()
         isolated_registry.register(
             "test_data_subjects", DataSubjectsRuleset, DataSubjectRule
         )
@@ -338,7 +337,6 @@ class TestDataSubjectsRulesetIntegration:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that DataSubjectsRuleset works with RulesetLoader."""
-        isolated_registry.clear()
         isolated_registry.register("loader_test", DataSubjectsRuleset, DataSubjectRule)
 
         # Load via RulesetLoader

--- a/libs/waivern-rulesets/tests/waivern_rulesets/test_personal_data.py
+++ b/libs/waivern-rulesets/tests/waivern_rulesets/test_personal_data.py
@@ -186,7 +186,6 @@ class TestPersonalDataIntegration:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that PersonalDataRuleset works with the registry pattern."""
-        isolated_registry.clear()
         isolated_registry.register(
             "test_personal_data", PersonalDataRuleset, PersonalDataRule
         )
@@ -205,7 +204,6 @@ class TestPersonalDataIntegration:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that PersonalDataRuleset works with RulesetLoader."""
-        isolated_registry.clear()
         isolated_registry.register("loader_test", PersonalDataRuleset, PersonalDataRule)
 
         # Load via RulesetLoader

--- a/libs/waivern-rulesets/tests/waivern_rulesets/test_processing_purposes.py
+++ b/libs/waivern-rulesets/tests/waivern_rulesets/test_processing_purposes.py
@@ -239,7 +239,6 @@ class TestProcessingPurposesIntegration:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that ProcessingPurposesRuleset works with the registry pattern."""
-        isolated_registry.clear()
         isolated_registry.register(
             "test_processing_purposes", ProcessingPurposesRuleset, ProcessingPurposeRule
         )
@@ -258,7 +257,6 @@ class TestProcessingPurposesIntegration:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that ProcessingPurposesRuleset works with RulesetLoader."""
-        isolated_registry.clear()
         isolated_registry.register(
             "loader_test", ProcessingPurposesRuleset, ProcessingPurposeRule
         )

--- a/libs/waivern-rulesets/tests/waivern_rulesets/test_service_integrations.py
+++ b/libs/waivern-rulesets/tests/waivern_rulesets/test_service_integrations.py
@@ -176,7 +176,6 @@ class TestServiceIntegrationsIntegration:
         self, isolated_registry: RulesetRegistry
     ) -> None:
         """Test that the ruleset can be registered and retrieved."""
-        isolated_registry.clear()
         isolated_registry.register(
             "test_service_integrations",
             ServiceIntegrationsRuleset,


### PR DESCRIPTION
## Summary

Align RulesetRegistry with SchemaRegistry testing pattern by implementing the Memento pattern with workspace-level autouse fixtures.

## Changes

- Add `snapshot_state()` and `restore_state()` classmethods to RulesetRegistry
- Add workspace-level autouse fixture `isolate_ruleset_registry()` in root conftest.py
- Simplify package-level `isolated_registry` fixture (workspace handles isolation)
- Remove manual `clear()` calls from test files
- Fix fixture return type annotation

## Result

RulesetRegistry now uses the same industry-standard testing pattern as SchemaRegistry, with automatic state isolation for all tests workspace-wide.