### PR TITLE
refactor: remove invalid strong typing TODO in MySQL connector

### DIFF
--- a/libs/waivern-mysql/src/waivern_mysql/connector.py
+++ b/libs/waivern-mysql/src/waivern_mysql/connector.py
@@ -290,7 +290,6 @@ class MySQLConnector(Connector):
             # Extract database metadata (connection test included)
             metadata = self._get_database_metadata()
 
-            # TODO: This should be strongly typed - even just a TypedDict
             # Transform data for standard_input schema
             extracted_data = self._transform_for_standard_input_schema(
                 output_schema, metadata


### PR DESCRIPTION
## Summary

Remove TODO suggesting strong typing for `extracted_data` intermediate variable in MySQL connector.

## Rationale

The current dict-based approach is correct for schema-driven architectures where validation occurs at boundaries (Message.validate()) rather than intermediate transformation steps.

This pattern is consistent with:
- FastAPI (Pydantic at boundaries, dicts internally)
- Django REST Framework (serializers produce dicts)
- Apache Airflow (XComs use dict[str, Any])

The Message layer already handles validation via JSON Schema, making additional Pydantic typing redundant and potentially harmful (double validation overhead).