### PR TITLE
feat(core): add DispatcherFactory protocol and dispatcher autodiscovery

### DIFF
--- a/libs/waivern-core/src/waivern_core/__init__.py
+++ b/libs/waivern-core/src/waivern_core/__init__.py
@@ -13,6 +13,7 @@ from waivern_core.base_processor import Processor
 from waivern_core.base_ruleset import BaseRuleset, RulesetError
 from waivern_core.component_factory import ComponentConfig, ComponentFactory
 from waivern_core.dispatch import (
+    DispatcherFactory,
     DispatchRequest,
     DispatchResult,
     DistributedProcessor,
@@ -112,6 +113,7 @@ __all__ = [
     "FindingMetadata",
     "RequestDispatcher",
     # Dispatch
+    "DispatcherFactory",
     "DispatchRequest",
     "DispatchResult",
     "PrepareResult",

--- a/libs/waivern-core/src/waivern_core/dispatch.py
+++ b/libs/waivern-core/src/waivern_core/dispatch.py
@@ -12,6 +12,8 @@ Core types:
     - ``PrepareResult``: Returned by ``DistributedProcessor.prepare()`` — carries
       processor-specific intermediate state and a dict of dispatch requests.
     - ``RequestDispatcher``: Protocol for dispatching grouped requests to a service.
+    - ``DispatcherFactory``: Protocol for factories that create dispatchers,
+      discovered via entry points by the ``ComponentRegistry``.
     - ``DistributedProcessor``: Protocol for processors that separate domain logic
       (prepare/finalise) from external I/O (dispatch).
 
@@ -122,6 +124,43 @@ class RequestDispatcher[R: DispatchRequest, V: DispatchResult](Protocol):
         Returns:
             Results, each carrying the ``request_id`` of the
             originating request.
+
+        """
+        ...
+
+
+class DispatcherFactory[R: DispatchRequest, V: DispatchResult](Protocol):
+    """Protocol for factories that create ``RequestDispatcher`` instances.
+
+    Dispatcher factories are discovered via entry points and instantiated
+    with a ``ServiceContainer`` for dependency injection. The registry
+    uses ``request_type`` to match factories to request types without
+    creating a dispatcher instance.
+
+    The generic parameters mirror ``RequestDispatcher`` — concrete
+    implementations declare which request/result pair they produce.
+
+    """
+
+    @property
+    def request_type(self) -> type[R]:
+        """The concrete ``DispatchRequest`` subclass this factory's dispatchers handle."""
+        ...
+
+    def can_create(self) -> bool:
+        """Check if a dispatcher can be created.
+
+        Validates prerequisites such as configuration availability
+        and service dependencies without attempting creation.
+
+        """
+        ...
+
+    def create(self) -> RequestDispatcher[R, V] | None:
+        """Create a dispatcher instance, or ``None`` if unavailable.
+
+        Returns ``None`` when prerequisites are not met (e.g., missing
+        API key, required service not registered in the container).
 
         """
         ...

--- a/libs/waivern-core/src/waivern_core/services/registry.py
+++ b/libs/waivern-core/src/waivern_core/services/registry.py
@@ -2,7 +2,7 @@
 
 The ComponentRegistry provides a single source of truth for component
 discovery via entry points. It wraps the ServiceContainer and provides
-lazy-loaded access to connector and processor factories.
+lazy-loaded access to connector, processor, and dispatcher factories.
 """
 
 from __future__ import annotations
@@ -14,6 +14,12 @@ from importlib.metadata import entry_points
 from waivern_core.base_connector import Connector
 from waivern_core.base_processor import Processor
 from waivern_core.component_factory import ComponentFactory
+from waivern_core.dispatch import (
+    DispatcherFactory,
+    DispatchRequest,
+    DispatchResult,
+    RequestDispatcher,
+)
 from waivern_core.services.container import ServiceContainer
 
 logger = logging.getLogger(__name__)
@@ -22,11 +28,12 @@ logger = logging.getLogger(__name__)
 class ComponentRegistry:
     """Centralises component discovery and factory management.
 
-    ComponentRegistry discovers connector and processor factories from entry points
-    and provides unified access for all consumers (Planner, Executor, CLI commands).
+    ComponentRegistry discovers connector, processor, and dispatcher factories from
+    entry points and provides unified access for all consumers (Planner, Executor,
+    CLI commands).
 
     Discovery is lazy - factories are only instantiated on first access to
-    connector_factories or processor_factories properties.
+    connector_factories, processor_factories, or dispatcher_factories properties.
 
     Example:
         >>> container = ServiceContainer()
@@ -49,6 +56,9 @@ class ComponentRegistry:
         self._container = container
         self._connector_factories: dict[str, ComponentFactory[Connector]] | None = None
         self._processor_factories: dict[str, ComponentFactory[Processor]] | None = None
+        self._dispatcher_factories: (
+            dict[str, DispatcherFactory[DispatchRequest, DispatchResult]] | None
+        ) = None
 
     @property
     def container(self) -> ServiceContainer:
@@ -69,8 +79,59 @@ class ComponentRegistry:
             self._discover_components()
         return self._processor_factories  # type: ignore[return-value]
 
+    @property
+    def dispatcher_factories(
+        self,
+    ) -> Mapping[str, DispatcherFactory[DispatchRequest, DispatchResult]]:
+        """Get discovered dispatcher factories (lazy discovery)."""
+        if self._dispatcher_factories is None:
+            self._discover_components()
+        return self._dispatcher_factories  # type: ignore[return-value]
+
+    def get_dispatcher_for(
+        self, request_type: type[DispatchRequest]
+    ) -> RequestDispatcher[DispatchRequest, DispatchResult]:
+        """Resolve a dispatcher for the given request type.
+
+        Iterates discovered dispatcher factories and returns a dispatcher
+        from the first factory whose ``request_type`` matches.
+
+        Args:
+            request_type: The concrete ``DispatchRequest`` subclass to
+                dispatch.
+
+        Raises:
+            ValueError: If no registered factory handles this request type.
+            RuntimeError: If a matching factory cannot create a dispatcher
+                (e.g., missing API key or required service).
+
+        """
+        for name, factory in self.dispatcher_factories.items():
+            if factory.request_type is not request_type:
+                continue
+
+            if not factory.can_create():
+                msg = (
+                    f"Dispatcher factory '{name}' matches request type "
+                    f"'{request_type.__name__}' but cannot create a dispatcher"
+                )
+                raise RuntimeError(msg)
+
+            dispatcher = factory.create()
+            if dispatcher is None:
+                msg = (
+                    f"Dispatcher factory '{name}' matched request type "
+                    f"'{request_type.__name__}' but create() returned None"
+                )
+                raise RuntimeError(msg)
+
+            return dispatcher
+
+        msg = f"No dispatcher factory registered for request type '{request_type.__name__}'"
+        raise ValueError(msg)
+
     def _discover_components(self) -> None:
-        """Discover connector and processor factories from entry points.
+        """Discover connector, processor, and dispatcher factories from entry points.
 
         Also registers schemas from packages via waivern.schemas entry points.
         Schema registration must happen before components are used to ensure
@@ -81,6 +142,7 @@ class ComponentRegistry:
 
         self._connector_factories = {}
         self._processor_factories = {}
+        self._dispatcher_factories = {}
 
         # Discover connectors
         for ep in entry_points(group="waivern.connectors"):
@@ -93,6 +155,12 @@ class ComponentRegistry:
             factory_class = ep.load()
             factory = factory_class(self._container)
             self._processor_factories[ep.name] = factory
+
+        # Discover dispatchers
+        for ep in entry_points(group="waivern.dispatchers"):
+            factory_class = ep.load()
+            factory = factory_class(self._container)
+            self._dispatcher_factories[ep.name] = factory
 
     def _register_schemas(self) -> None:
         """Register schemas from all packages via entry points."""

--- a/libs/waivern-core/tests/waivern_core/services/test_registry.py
+++ b/libs/waivern-core/tests/waivern_core/services/test_registry.py
@@ -4,10 +4,14 @@ These tests verify the registry's ability to:
 - Expose the underlying ServiceContainer
 - Lazily discover components from entry points
 - Cache discovered factories after first access
+- Discover dispatcher factories and resolve dispatchers by request type
 """
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from waivern_core.dispatch import DispatchRequest
 from waivern_core.services import ComponentRegistry, ServiceContainer
 
 # =============================================================================
@@ -55,8 +59,8 @@ class TestComponentRegistry:
             # Act - access connector_factories
             _ = registry.connector_factories
 
-            # Assert - entry_points called for schemas, connectors, processors
-            assert mock_ep.call_count == 3
+            # Assert - entry_points called for schemas, connectors, processors, dispatchers
+            assert mock_ep.call_count == 4
 
     def test_processor_factories_triggers_discovery(self) -> None:
         """Verify accessing processor_factories triggers entry point discovery."""
@@ -70,8 +74,8 @@ class TestComponentRegistry:
             # Act - access processor_factories
             _ = registry.processor_factories
 
-            # Assert - entry_points called for schemas, connectors, processors
-            assert mock_ep.call_count == 3
+            # Assert - entry_points called for schemas, connectors, processors, dispatchers
+            assert mock_ep.call_count == 4
 
     def test_discovery_called_only_once(self) -> None:
         """Verify _discover_components called exactly once despite multiple accesses."""
@@ -88,8 +92,8 @@ class TestComponentRegistry:
             _ = registry.connector_factories
             _ = registry.processor_factories
 
-        # Assert - entry_points called only 3 times (schemas, connectors, processors)
-        assert mock_ep.call_count == 3
+        # Assert - entry_points called only once (schemas, connectors, processors, dispatchers)
+        assert mock_ep.call_count == 4
 
     def test_discovered_connector_factory_accessible_by_name(self) -> None:
         """Verify discovered connector factories are accessible by entry point name."""
@@ -267,3 +271,111 @@ class TestComponentRegistrySchemaDiscovery:
         # Assert - both schema entry points were invoked
         mock_register_func_1.assert_called_once()
         mock_register_func_2.assert_called_once()
+
+
+# =============================================================================
+# Dispatcher Discovery
+# =============================================================================
+
+
+class TestGetDispatcherFor:
+    """Test suite for dispatcher resolution by request type.
+
+    These tests verify the registry's ability to resolve dispatchers
+    by matching request types against discovered dispatcher factories.
+    """
+
+    def test_returns_dispatcher_from_matching_factory(self) -> None:
+        """Returns a dispatcher when a factory matches the request type."""
+        # Arrange
+        container = ServiceContainer()
+        registry = ComponentRegistry(container)
+
+        mock_dispatcher = MagicMock()
+
+        mock_factory_class = MagicMock()
+        mock_factory_instance = MagicMock()
+        mock_factory_instance.request_type = DispatchRequest
+        mock_factory_instance.can_create.return_value = True
+        mock_factory_instance.create.return_value = mock_dispatcher
+        mock_factory_class.return_value = mock_factory_instance
+
+        mock_ep = MagicMock()
+        mock_ep.name = "test_dispatcher"
+        mock_ep.load.return_value = mock_factory_class
+
+        with patch("waivern_core.services.registry.entry_points") as mock_entry_points:
+            mock_entry_points.side_effect = lambda group: (
+                [mock_ep] if group == "waivern.dispatchers" else []
+            )
+
+            # Act
+            result = registry.get_dispatcher_for(DispatchRequest)
+
+        # Assert
+        assert result is mock_dispatcher
+        mock_factory_instance.create.assert_called_once()
+
+    def test_raises_value_error_when_no_factory_matches(self) -> None:
+        """Raises ValueError when no factory handles the request type."""
+        # Arrange
+        container = ServiceContainer()
+        registry = ComponentRegistry(container)
+
+        with patch("waivern_core.services.registry.entry_points") as mock_entry_points:
+            mock_entry_points.return_value = []
+
+            # Act / Assert
+            with pytest.raises(ValueError, match="No dispatcher factory registered"):
+                registry.get_dispatcher_for(DispatchRequest)
+
+    def test_raises_runtime_error_when_factory_cannot_create(self) -> None:
+        """Raises RuntimeError when the matching factory's can_create returns False."""
+        # Arrange
+        container = ServiceContainer()
+        registry = ComponentRegistry(container)
+
+        mock_factory_class = MagicMock()
+        mock_factory_instance = MagicMock()
+        mock_factory_instance.request_type = DispatchRequest
+        mock_factory_instance.can_create.return_value = False
+        mock_factory_class.return_value = mock_factory_instance
+
+        mock_ep = MagicMock()
+        mock_ep.name = "unavailable_dispatcher"
+        mock_ep.load.return_value = mock_factory_class
+
+        with patch("waivern_core.services.registry.entry_points") as mock_entry_points:
+            mock_entry_points.side_effect = lambda group: (
+                [mock_ep] if group == "waivern.dispatchers" else []
+            )
+
+            # Act / Assert
+            with pytest.raises(RuntimeError, match="cannot create a dispatcher"):
+                registry.get_dispatcher_for(DispatchRequest)
+
+    def test_raises_runtime_error_when_create_returns_none(self) -> None:
+        """Raises RuntimeError when the matching factory cannot create."""
+        # Arrange
+        container = ServiceContainer()
+        registry = ComponentRegistry(container)
+
+        mock_factory_class = MagicMock()
+        mock_factory_instance = MagicMock()
+        mock_factory_instance.request_type = DispatchRequest
+        mock_factory_instance.can_create.return_value = True
+        mock_factory_instance.create.return_value = None
+        mock_factory_class.return_value = mock_factory_instance
+
+        mock_ep = MagicMock()
+        mock_ep.name = "broken_dispatcher"
+        mock_ep.load.return_value = mock_factory_class
+
+        with patch("waivern_core.services.registry.entry_points") as mock_entry_points:
+            mock_entry_points.side_effect = lambda group: (
+                [mock_ep] if group == "waivern.dispatchers" else []
+            )
+
+            # Act / Assert
+            with pytest.raises(RuntimeError, match="create\\(\\) returned None"):
+                registry.get_dispatcher_for(DispatchRequest)

--- a/libs/waivern-llm/src/waivern_llm/dispatcher_factory.py
+++ b/libs/waivern-llm/src/waivern_llm/dispatcher_factory.py
@@ -8,7 +8,7 @@ dependencies lazily from the ServiceContainer.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
 from waivern_artifact_store.base import ArtifactStore
@@ -16,6 +16,7 @@ from waivern_artifact_store.base import ArtifactStore
 from waivern_llm.di.configuration import LLMServiceConfiguration
 from waivern_llm.dispatcher import LLMDispatcher
 from waivern_llm.providers import create_provider
+from waivern_llm.types import LLMRequest
 
 if TYPE_CHECKING:
     from waivern_core.services import ServiceContainer
@@ -26,9 +27,8 @@ logger = logging.getLogger(__name__)
 class LLMDispatcherFactory:
     """Factory for creating LLMDispatcher instances with DI support.
 
-    Implements the ``ServiceFactory[LLMDispatcher]`` protocol, resolving
-    dependencies lazily from the ``ServiceContainer``. Follows the same
-    pattern as ``LLMServiceFactory``.
+    Satisfies the ``DispatcherFactory[LLMRequest, LLMDispatchResult]``
+    protocol, resolving dependencies lazily from the ``ServiceContainer``.
 
     """
 
@@ -47,6 +47,11 @@ class LLMDispatcherFactory:
         """
         self._container = container
         self._config = config
+
+    @property
+    def request_type(self) -> type[LLMRequest[Any]]:
+        """The request type this factory's dispatchers handle."""
+        return LLMRequest
 
     def _get_config(self) -> LLMServiceConfiguration | None:
         """Get configuration, either from constructor or environment.


### PR DESCRIPTION
## Summary

- Add `DispatcherFactory[R, V]` protocol to `waivern-core` dispatch module with `request_type`, `can_create()`, and `create()` methods
- Extend `ComponentRegistry` to discover dispatcher factories from `waivern.dispatchers` entry points during lazy discovery
- Add `get_dispatcher_for(request_type)` method to resolve a dispatcher by matching request type against discovered factories
- Add `request_type` property to `LLMDispatcherFactory` to satisfy the protocol

## Test plan

- [x] Existing discovery tests updated for new entry point group (`call_count` 3 → 4)
- [x] `get_dispatcher_for` happy path: matching factory returns dispatcher
- [x] `get_dispatcher_for` raises `ValueError` when no factory matches
- [x] `get_dispatcher_for` raises `RuntimeError` when `can_create()` returns `False`
- [x] `get_dispatcher_for` raises `RuntimeError` when `create()` returns `None`
- [x] Full dev-checks pass (1979 tests, 0 type errors, 0 lint errors)