### PR TITLE
feat(orchestration): three-phase DAG execution for distributed processors

### DIFF
--- a/libs/waivern-core/src/waivern_core/dispatch.py
+++ b/libs/waivern-core/src/waivern_core/dispatch.py
@@ -27,7 +27,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, Field, SerializeAsAny
 
-from waivern_core.message import Message
+from waivern_core.message import ExecutionContext, Message
 from waivern_core.schemas import Schema
 
 
@@ -69,6 +69,19 @@ class DispatchResult(BaseModel):
 
     name: str = ""
     """Human-readable label copied from the originating ``DispatchRequest``."""
+
+    def enrich_execution_context(self, context: ExecutionContext) -> ExecutionContext:
+        """Enrich execution context with dispatch-specific metadata.
+
+        Subclasses override to contribute metadata from their dispatch
+        results (e.g., ``LLMDispatchResult`` sets ``model_name``).
+        The executor calls this on each result to build the final
+        execution context for the artifact.
+
+        Default implementation returns the context unchanged.
+
+        """
+        return context
 
 
 class PrepareResult[S: BaseModel](BaseModel):

--- a/libs/waivern-core/src/waivern_core/dispatch.py
+++ b/libs/waivern-core/src/waivern_core/dispatch.py
@@ -22,10 +22,10 @@ Core types:
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SerializeAsAny
 
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
@@ -93,7 +93,8 @@ class PrepareResult[S: BaseModel](BaseModel):
     """
 
     state: S
-    requests: list[DispatchRequest]
+    requests: SerializeAsAny[list[DispatchRequest]]
+    """Dispatch requests, serialised with runtime type to preserve subclass fields."""
 
 
 class RequestDispatcher[R: DispatchRequest, V: DispatchResult](Protocol):
@@ -206,6 +207,25 @@ class DistributedProcessor[S: BaseModel](Protocol):
         Returns:
             A ``PrepareResult`` carrying intermediate state and dispatch
             requests (empty list if no dispatch is needed).
+
+        """
+        ...
+
+    def deserialise_prepare_result(self, raw: dict[str, Any]) -> PrepareResult[S]:
+        """Reconstruct a typed ``PrepareResult`` from a raw dict.
+
+        Called on the resume path where a persisted ``PrepareResult``
+        must be restored to its typed form. The processor knows its
+        concrete state type ``S`` and request subclass, so it is the
+        natural owner of deserialisation.
+
+        Args:
+            raw: Raw dict from ``PrepareResult.model_dump(mode="json")``,
+                loaded from the artifact store.
+
+        Returns:
+            Typed ``PrepareResult`` with properly deserialised state
+            and request objects.
 
         """
         ...

--- a/libs/waivern-llm/src/waivern_llm/types.py
+++ b/libs/waivern-llm/src/waivern_llm/types.py
@@ -14,12 +14,12 @@ This module defines the foundational types used throughout the LLM service:
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum, auto
-from typing import Protocol, runtime_checkable
+from typing import Protocol, override, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field
-from waivern_core import Finding, JsonValue
+from waivern_core import ExecutionContext, Finding, JsonValue
 from waivern_core.dispatch import DispatchRequest, DispatchResult
 
 
@@ -298,3 +298,8 @@ class LLMDispatchResult(DispatchResult):
 
     skipped: list[SkippedFinding[Finding]]
     """Findings that could not be processed, with reasons."""
+
+    @override
+    def enrich_execution_context(self, context: ExecutionContext) -> ExecutionContext:
+        """Set ``model_name`` from the LLM response."""
+        return replace(context, model_name=self.model_name)

--- a/libs/waivern-orchestration/src/waivern_orchestration/executor.py
+++ b/libs/waivern-orchestration/src/waivern_orchestration/executor.py
@@ -66,7 +66,7 @@ from typing import Any
 from waivern_artifact_store.base import ArtifactStore
 from waivern_artifact_store.errors import ArtifactNotFoundError
 from waivern_core import ExecutionContext, JsonValue, Message, MessageExtensions, Schema
-from waivern_core.dispatch import DistributedProcessor
+from waivern_core.dispatch import DistributedProcessor, PrepareResult
 from waivern_core.errors import PendingProcessingError
 from waivern_core.services import ComponentRegistry
 
@@ -527,6 +527,27 @@ class DAGExecutor:
 
         input_refs = [inputs] if isinstance(inputs, str) else inputs
         return [await ctx.store.get_artifact(ctx.run_id, ref) for ref in input_refs]
+
+    async def _run_prepare(
+        self,
+        entry: _DistributedEntry,
+        ctx: _ExecutionContext,
+    ) -> PrepareResult[Any]:
+        """Run prepare() in the thread pool, governed by the semaphore.
+
+        Follows the same bridge pattern as ``_run_connector`` and
+        ``_run_processor``, but acquires the semaphore internally
+        (called from ``asyncio.gather``, not wrapped by ``_produce``).
+
+        """
+        async with ctx.semaphore:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                ctx.thread_pool,
+                entry.processor.prepare,
+                entry.inputs,
+                entry.output_schema,
+            )
 
     async def _handle_artifact_result(
         self,

--- a/libs/waivern-orchestration/src/waivern_orchestration/executor.py
+++ b/libs/waivern-orchestration/src/waivern_orchestration/executor.py
@@ -62,6 +62,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from dataclasses import field as dataclass_field
 from datetime import UTC, datetime
+from graphlib import TopologicalSorter
 from pathlib import Path
 from typing import Any
 
@@ -556,6 +557,159 @@ class DAGExecutor:
                 entry.inputs,
                 entry.output_schema,
             )
+
+    async def _run_finalise(
+        self,
+        entry: _DistributedEntry,
+        results: Sequence[DispatchResult],
+        ctx: _ExecutionContext,
+    ) -> Message | PrepareResult[Any]:
+        """Run finalise() in the thread pool, governed by the semaphore.
+
+        Follows the same bridge pattern as ``_run_prepare``.
+
+        Args:
+            entry: The distributed entry with processor, state, and schema.
+            results: Dispatch results routed to this entry.
+            ctx: The execution context with semaphore and thread pool.
+
+        """
+        if entry.prepare_result is None:
+            msg = f"Cannot finalise '{entry.artifact_id}': no prepare_result"
+            raise RuntimeError(msg)
+
+        async with ctx.semaphore:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                ctx.thread_pool,
+                entry.processor.finalise,
+                entry.prepare_result.state,
+                results,
+                entry.output_schema,
+            )
+
+    async def _finalise_distributed_artifacts(
+        self,
+        entries: list[_DistributedEntry],
+        plan: ExecutionPlan,
+        ctx: _ExecutionContext,
+        sorter: TopologicalSorter[str],
+        *,
+        max_rounds: int = 3,
+    ) -> None:
+        """Orchestrate Phase 2–3 with multi-round loop for distributed entries.
+
+        Drives the dispatch → finalise cycle until all entries produce a
+        ``Message`` or max rounds is exceeded:
+        1. Filter out entries already marked pending by dispatch
+        2. Dispatch all entries with requests (Phase 2)
+        3. Finalise each entry (Phase 3)
+        4. Message → save artifact, mark completed, clean up, notify sorter
+        5. PrepareResult → queue for another round
+        6. Repeat until no entries remain or max rounds exceeded
+
+        Args:
+            entries: Distributed entries with ``prepare_result`` populated.
+            plan: The execution plan (for failure handling and metadata).
+            ctx: The execution context.
+            sorter: The topological sorter (to notify on completion).
+            max_rounds: Maximum dispatch-finalise cycles (default 3).
+
+        """
+        active_entries = [
+            e for e in entries if e.artifact_id not in ctx.pending_batch_artifacts
+        ]
+
+        for _round in range(max_rounds):
+            if not active_entries:
+                return
+
+            # Phase 2: dispatch
+            results_by_artifact = await self._dispatch_all(active_entries, plan, ctx)
+
+            # Phase 3: finalise each non-pending entry
+            next_round: list[_DistributedEntry] = []
+            for entry in active_entries:
+                if entry.artifact_id in ctx.pending_batch_artifacts:
+                    continue
+                if entry.artifact_id not in results_by_artifact:
+                    continue
+
+                try:
+                    result = await self._run_finalise(
+                        entry, results_by_artifact[entry.artifact_id], ctx
+                    )
+                except Exception as exc:
+                    message = self._create_error_message_for_exception(
+                        entry.artifact_id, exc, plan, ctx
+                    )
+                    await ctx.store.save_artifact(
+                        ctx.run_id, entry.artifact_id, message
+                    )
+                    await self._mark_failed_and_skip_dependents(
+                        entry.artifact_id, plan, ctx
+                    )
+                    continue
+
+                if isinstance(result, Message):
+                    await self._save_distributed_artifact(
+                        entry, result, results_by_artifact[entry.artifact_id], plan, ctx
+                    )
+                    sorter.done(entry.artifact_id)
+                else:
+                    entry.prepare_result = result
+                    next_round.append(entry)
+
+            active_entries = next_round
+
+        # Entries still active after max rounds → fail
+        for entry in active_entries:
+            logger.warning(
+                "Artifact '%s' exceeded max dispatch rounds (%d)",
+                entry.artifact_id,
+                max_rounds,
+            )
+            await self._mark_failed_and_skip_dependents(entry.artifact_id, plan, ctx)
+
+    async def _save_distributed_artifact(
+        self,
+        entry: _DistributedEntry,
+        message: Message,
+        results: Sequence[DispatchResult],
+        plan: ExecutionPlan,
+        ctx: _ExecutionContext,
+    ) -> None:
+        """Save a completed distributed artifact with metadata.
+
+        Follows the same metadata pattern as ``_produce``: populates
+        ``run_id``, ``source``, and ``extensions`` with ``ExecutionContext``.
+        Calls ``enrich_execution_context`` on each dispatch result to
+        propagate dispatch-specific metadata (e.g., ``model_name``).
+
+        """
+        definition = plan.runbook.artifacts[entry.artifact_id]
+        origin = get_origin_from_artifact_id(entry.artifact_id)
+        alias = plan.reversed_aliases.get(entry.artifact_id)
+
+        execution_context = ExecutionContext(
+            status="success",
+            duration_seconds=0.0,
+            origin=origin,
+            alias=alias,
+        )
+        for result in results:
+            execution_context = result.enrich_execution_context(execution_context)
+
+        message = replace(
+            message,
+            run_id=ctx.run_id,
+            source=self._determine_source(definition),
+            extensions=MessageExtensions(execution=execution_context),
+        )
+        await ctx.store.save_artifact(ctx.run_id, entry.artifact_id, message)
+        await ctx.store.delete_prepared(ctx.run_id, entry.artifact_id)
+        ctx.state.mark_completed(entry.artifact_id)
+        await ctx.state.save(ctx.store)
 
     async def _dispatch_all(
         self,

--- a/libs/waivern-orchestration/src/waivern_orchestration/executor.py
+++ b/libs/waivern-orchestration/src/waivern_orchestration/executor.py
@@ -335,10 +335,14 @@ class DAGExecutor:
     ) -> None:
         """Execute artifacts in topological order with parallel batches.
 
-        Handles three artifact outcomes:
-        1. Success — mark completed, notify sorter
-        2. Failure — mark failed, skip dependents, notify sorter
-        3. PendingProcessingError — leave in not_started, do NOT notify sorter
+        Each level of the DAG is processed in three phases:
+        1. **Classification** — split ready artifacts into regular,
+           distributed, and resuming groups
+        2. **Concurrent execution** — ``_produce`` for regular artifacts
+           and ``_run_prepare`` for distributed artifacts run together
+           in ``asyncio.gather``
+        3. **Dispatch and finalise** — distributed entries go through
+           dispatch → finalise (possibly multi-round)
 
         The loop exits when no more progress is possible. If pending batch
         artifacts exist at that point, the run is marked interrupted.
@@ -368,15 +372,60 @@ class DAGExecutor:
                     break
                 continue
 
-            logger.debug("Starting batch execution for artifacts: %s", ready)
-            tasks = [self._produce(aid, plan, ctx) for aid in ready]
-            batch_results = await asyncio.gather(*tasks, return_exceptions=True)
-            logger.debug("Batch execution complete for artifacts: %s", ready)
+            # ── Classification ──
+            (
+                regular_aids,
+                distributed_entries,
+                resuming_entries,
+            ) = await self._classify_artifacts(ready, plan, ctx)
 
-            for aid, result in zip(ready, batch_results, strict=True):
-                await self._handle_artifact_result(aid, result, plan, ctx)
-                if aid not in ctx.pending_batch_artifacts:
-                    sorter.done(aid)
+            # ── Regular + Phase 1 (concurrent) ──
+            regular_tasks = [self._produce(aid, plan, ctx) for aid in regular_aids]
+            prepare_tasks = [
+                self._run_prepare(entry, ctx) for entry in distributed_entries
+            ]
+
+            logger.debug(
+                "Starting batch: %d regular, %d distributed, %d resuming",
+                len(regular_aids),
+                len(distributed_entries),
+                len(resuming_entries),
+            )
+            regular_batch, prepare_batch = await asyncio.gather(
+                asyncio.gather(*regular_tasks, return_exceptions=True),
+                asyncio.gather(*prepare_tasks, return_exceptions=True),
+            )
+
+            # ── Handle regular results ──
+            for aid, regular_result in zip(regular_aids, regular_batch, strict=True):
+                await self._handle_artifact_result(aid, regular_result, plan, ctx)
+                sorter.done(aid)
+
+            # ── Collect Phase 1 results ──
+            phase2_entries: list[_DistributedEntry] = list(resuming_entries)
+            for entry, prepare_result in zip(
+                distributed_entries, prepare_batch, strict=True
+            ):
+                if isinstance(prepare_result, BaseException):
+                    message = self._create_error_message_for_exception(
+                        entry.artifact_id, prepare_result, plan, ctx
+                    )
+                    await ctx.store.save_artifact(
+                        ctx.run_id, entry.artifact_id, message
+                    )
+                    await self._mark_failed_and_skip_dependents(
+                        entry.artifact_id, plan, ctx
+                    )
+                    sorter.done(entry.artifact_id)
+                else:
+                    entry.prepare_result = prepare_result
+                    phase2_entries.append(entry)
+
+            # ── Phase 2→3: Dispatch and Finalise (with multi-round) ──
+            if phase2_entries:
+                await self._finalise_distributed_artifacts(
+                    phase2_entries, plan, ctx, sorter
+                )
 
         logger.debug("DAG execution complete.")
 
@@ -459,8 +508,16 @@ class DAGExecutor:
 
             # 3. Has process config → check isinstance
             if definition.process is not None:
-                factory = self._registry.processor_factories[definition.process.type]
-                processor_instance = factory.create(definition.process.properties)
+                try:
+                    factory = self._registry.processor_factories[
+                        definition.process.type
+                    ]
+                    processor_instance = factory.create(definition.process.properties)
+                except KeyError:
+                    # Unknown processor type — classify as regular so _produce
+                    # handles it with a proper error message
+                    regular.append(aid)
+                    continue
 
                 if isinstance(processor_instance, DistributedProcessor):
                     inputs = await self._load_inputs(definition, ctx)
@@ -816,23 +873,14 @@ class DAGExecutor:
         plan: ExecutionPlan,
         ctx: _ExecutionContext,
     ) -> None:
-        """Handle the result of producing an artifact.
+        """Handle the result of producing a regular artifact.
 
         Persists state transitions. On failure, skips all dependent artifacts.
-        PendingProcessingError leaves the artifact in not_started for retry
-        on resume. Success messages are saved in _produce(). Error messages
-        from exceptions caught in _produce() need to be saved here.
+        Success messages are saved in _produce(). Error messages from
+        exceptions caught in _produce() need to be saved here.
 
         """
-        if isinstance(result, PendingProcessingError):
-            # Async processing pending — leave artifact in not_started
-            ctx.pending_batch_artifacts.add(artifact_id)
-            logger.info(
-                "Artifact '%s' has pending async processing: %s",
-                artifact_id,
-                result,
-            )
-        elif isinstance(result, BaseException):
+        if isinstance(result, BaseException):
             # Exception during production (from asyncio.gather) - create and save
             message = self._create_error_message_for_exception(
                 artifact_id, result, plan, ctx
@@ -949,8 +997,6 @@ class DAGExecutor:
 
                 return message
 
-            except PendingProcessingError:
-                raise
             except Exception as e:
                 duration = time.monotonic() - start_time
                 logger.debug(

--- a/libs/waivern-orchestration/src/waivern_orchestration/executor.py
+++ b/libs/waivern-orchestration/src/waivern_orchestration/executor.py
@@ -125,6 +125,7 @@ class _DistributedEntry:
     inputs: list[Message]
     output_schema: Schema
     prepare_result: PrepareResult[Any] | None = None
+    start_time: float = 0.0
 
 
 class DAGExecutor:
@@ -497,6 +498,7 @@ class DAGExecutor:
                         inputs=[],
                         output_schema=output_schema,
                         prepare_result=prepare_result,
+                        start_time=time.monotonic(),
                     )
                 )
                 continue
@@ -527,6 +529,7 @@ class DAGExecutor:
                             processor=processor_instance,
                             inputs=inputs,
                             output_schema=output_schema,
+                            start_time=time.monotonic(),
                         )
                     )
                 else:
@@ -748,9 +751,10 @@ class DAGExecutor:
         origin = get_origin_from_artifact_id(entry.artifact_id)
         alias = plan.reversed_aliases.get(entry.artifact_id)
 
+        duration = time.monotonic() - entry.start_time
         execution_context = ExecutionContext(
             status="success",
-            duration_seconds=0.0,
+            duration_seconds=duration,
             origin=origin,
             alias=alias,
         )
@@ -833,6 +837,12 @@ class DAGExecutor:
                 await self._persist_pending_entries(affected_entries, ctx)
                 continue
             except Exception:
+                affected_ids = [e.artifact_id for e in affected_entries]
+                logger.exception(
+                    "Dispatch failed for request type %s affecting artifacts %s",
+                    request_type.__name__,
+                    affected_ids,
+                )
                 for entry in affected_entries:
                     await self._mark_failed_and_skip_dependents(
                         entry.artifact_id, plan, ctx

--- a/libs/waivern-orchestration/src/waivern_orchestration/executor.py
+++ b/libs/waivern-orchestration/src/waivern_orchestration/executor.py
@@ -61,10 +61,12 @@ from dataclasses import dataclass, replace
 from dataclasses import field as dataclass_field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from waivern_artifact_store.base import ArtifactStore
 from waivern_artifact_store.errors import ArtifactNotFoundError
-from waivern_core import ExecutionContext, Message, MessageExtensions, Schema
+from waivern_core import ExecutionContext, JsonValue, Message, MessageExtensions, Schema
+from waivern_core.dispatch import DistributedProcessor
 from waivern_core.errors import PendingProcessingError
 from waivern_core.services import ComponentRegistry
 
@@ -98,6 +100,23 @@ class _ExecutionContext:
     semaphore: asyncio.Semaphore
     thread_pool: ThreadPoolExecutor
     pending_batch_artifacts: set[str] = dataclass_field(default_factory=set)
+
+
+@dataclass
+class _DistributedEntry:
+    """Tracks a distributed processor through its prepare-dispatch-finalise lifecycle.
+
+    Bundles the processor instance, inputs, and schema so they survive
+    across phases. ``prepare_result`` is populated after Phase 1 (or
+    loaded from store on resume).
+
+    """
+
+    artifact_id: str
+    processor: DistributedProcessor[Any]
+    inputs: list[Message]
+    output_schema: Schema
+    prepare_result: dict[str, JsonValue] | None = None
 
 
 class DAGExecutor:
@@ -377,6 +396,138 @@ class DAGExecutor:
 
         return ready, done
 
+    async def _classify_artifacts(
+        self,
+        ready_aids: list[str],
+        plan: ExecutionPlan,
+        ctx: _ExecutionContext,
+    ) -> tuple[list[str], list[_DistributedEntry], list[_DistributedEntry]]:
+        """Classify ready artifacts into regular, distributed, and resuming.
+
+        Classification order for each artifact:
+        1. In ``state.pending`` → resuming (load PrepareResult from store)
+        2. Source/reuse artifact → regular
+        3. Has process config with ``DistributedProcessor`` → distributed
+        4. Has process config without ``DistributedProcessor`` → regular
+        5. Passthrough (no process config) → regular
+
+        Args:
+            ready_aids: Artifact IDs ready for execution at this level.
+            plan: The execution plan with artifact definitions and schemas.
+            ctx: The execution context with store and state.
+
+        Returns:
+            Tuple of (regular_aids, distributed_entries, resuming_entries).
+
+        """
+        regular: list[str] = []
+        distributed: list[_DistributedEntry] = []
+        resuming: list[_DistributedEntry] = []
+
+        for aid in ready_aids:
+            definition = plan.runbook.artifacts[aid]
+            _, output_schema = plan.artifact_schemas[aid]
+
+            # 1. Pending → resuming
+            if aid in ctx.state.pending:
+                prepared_data = await ctx.store.load_prepared(ctx.run_id, aid)
+                processor = self._create_distributed_processor(definition)
+                resuming.append(
+                    _DistributedEntry(
+                        artifact_id=aid,
+                        processor=processor,
+                        inputs=[],
+                        output_schema=output_schema,
+                        prepare_result=prepared_data,
+                    )
+                )
+                continue
+
+            # 2. Source/reuse → regular
+            if definition.source is not None or definition.reuse is not None:
+                regular.append(aid)
+                continue
+
+            # 3. Has process config → check isinstance
+            if definition.process is not None:
+                factory = self._registry.processor_factories[definition.process.type]
+                processor_instance = factory.create(definition.process.properties)
+
+                if isinstance(processor_instance, DistributedProcessor):
+                    inputs = await self._load_inputs(definition, ctx)
+                    distributed.append(
+                        _DistributedEntry(
+                            artifact_id=aid,
+                            processor=processor_instance,
+                            inputs=inputs,
+                            output_schema=output_schema,
+                        )
+                    )
+                else:
+                    regular.append(aid)
+                continue
+
+            # 4. Passthrough → regular
+            regular.append(aid)
+
+        return regular, distributed, resuming
+
+    def _create_distributed_processor(
+        self,
+        definition: ArtifactDefinition,
+    ) -> DistributedProcessor[Any]:
+        """Re-create a DistributedProcessor from its factory.
+
+        Used on the resume path where the processor must be re-created
+        (stateless — all state lives in the persisted PrepareResult).
+
+        Raises:
+            KeyError: If processor type not found in registry.
+            TypeError: If the processor does not implement DistributedProcessor.
+
+        """
+        if definition.process is None:
+            msg = f"Cannot create distributed processor: no process config on '{definition}'"
+            raise TypeError(msg)
+
+        factory = self._registry.processor_factories[definition.process.type]
+        processor = factory.create(definition.process.properties)
+
+        if not isinstance(processor, DistributedProcessor):
+            msg = (
+                f"Processor '{definition.process.type}' does not implement "
+                f"DistributedProcessor but artifact is in pending state"
+            )
+            raise TypeError(msg)
+
+        return processor
+
+    async def _load_inputs(
+        self,
+        definition: ArtifactDefinition,
+        ctx: _ExecutionContext,
+    ) -> list[Message]:
+        """Load input messages for an artifact from the store.
+
+        Args:
+            definition: The artifact definition with input references.
+            ctx: The execution context with store and run_id.
+
+        Returns:
+            List of input messages.
+
+        Raises:
+            ValueError: If the artifact has no inputs defined.
+
+        """
+        inputs = definition.inputs
+        if inputs is None:
+            msg = "Cannot load inputs: artifact has no inputs defined"
+            raise ValueError(msg)
+
+        input_refs = [inputs] if isinstance(inputs, str) else inputs
+        return [await ctx.store.get_artifact(ctx.run_id, ref) for ref in input_refs]
+
     async def _handle_artifact_result(
         self,
         artifact_id: str,
@@ -640,20 +791,7 @@ class DAGExecutor:
             The produced message.
 
         """
-        # Get input artifact IDs
-        inputs = definition.inputs
-        if inputs is None:
-            # Should never happen - Planner validates this
-            raise ValueError(
-                "Bug: derived artifact has no inputs (Planner should have caught this)"
-            )
-
-        input_refs = [inputs] if isinstance(inputs, str) else inputs
-
-        # Retrieve input messages from store (async)
-        input_messages = [
-            await ctx.store.get_artifact(ctx.run_id, ref) for ref in input_refs
-        ]
+        input_messages = await self._load_inputs(definition, ctx)
 
         if definition.process is not None:
             return await self._run_processor(

--- a/libs/waivern-orchestration/src/waivern_orchestration/executor.py
+++ b/libs/waivern-orchestration/src/waivern_orchestration/executor.py
@@ -56,6 +56,8 @@ import asyncio
 import logging
 import time
 import uuid
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from dataclasses import field as dataclass_field
@@ -65,8 +67,13 @@ from typing import Any
 
 from waivern_artifact_store.base import ArtifactStore
 from waivern_artifact_store.errors import ArtifactNotFoundError
-from waivern_core import ExecutionContext, JsonValue, Message, MessageExtensions, Schema
-from waivern_core.dispatch import DistributedProcessor, PrepareResult
+from waivern_core import ExecutionContext, Message, MessageExtensions, Schema
+from waivern_core.dispatch import (
+    DispatchRequest,
+    DispatchResult,
+    DistributedProcessor,
+    PrepareResult,
+)
 from waivern_core.errors import PendingProcessingError
 from waivern_core.services import ComponentRegistry
 
@@ -116,7 +123,7 @@ class _DistributedEntry:
     processor: DistributedProcessor[Any]
     inputs: list[Message]
     output_schema: Schema
-    prepare_result: dict[str, JsonValue] | None = None
+    prepare_result: PrepareResult[Any] | None = None
 
 
 class DAGExecutor:
@@ -430,15 +437,16 @@ class DAGExecutor:
 
             # 1. Pending → resuming
             if aid in ctx.state.pending:
-                prepared_data = await ctx.store.load_prepared(ctx.run_id, aid)
+                raw = await ctx.store.load_prepared(ctx.run_id, aid)
                 processor = self._create_distributed_processor(definition)
+                prepare_result = processor.deserialise_prepare_result(raw)
                 resuming.append(
                     _DistributedEntry(
                         artifact_id=aid,
                         processor=processor,
                         inputs=[],
                         output_schema=output_schema,
-                        prepare_result=prepared_data,
+                        prepare_result=prepare_result,
                     )
                 )
                 continue
@@ -548,6 +556,104 @@ class DAGExecutor:
                 entry.inputs,
                 entry.output_schema,
             )
+
+    async def _dispatch_all(
+        self,
+        entries: list[_DistributedEntry],
+        plan: ExecutionPlan,
+        ctx: _ExecutionContext,
+    ) -> Mapping[str, Sequence[DispatchResult]]:
+        """Group requests by type, dispatch each group, and route results back.
+
+        Orchestrates Phase 2 of the distributed processor lifecycle:
+        1. Collect all requests from entries and build request-to-artifact mapping
+        2. Group requests by concrete type (e.g., all LLMRequest together)
+        3. Resolve a dispatcher per group and dispatch
+        4. Route results back to artifacts via request_id
+
+        Short-circuited entries (empty requests) get empty result sequences
+        without going through dispatch.
+
+        Args:
+            entries: Distributed entries with ``prepare_result`` populated.
+            plan: The execution plan (needed for failure handling).
+            ctx: The execution context with store, state, and registry access.
+
+        Returns:
+            Mapping from artifact_id to its dispatch results. Artifacts
+            that were marked pending (PendingBatchError) or failed are
+            excluded from the returned mapping.
+
+        """
+        results_by_artifact: dict[str, list[DispatchResult]] = {
+            entry.artifact_id: [] for entry in entries
+        }
+
+        # Map request_id → artifact_id for result routing
+        request_to_artifact: dict[str, str] = {}
+        # Group requests by concrete type for consolidated dispatch
+        requests_by_type: dict[type[DispatchRequest], list[DispatchRequest]] = (
+            defaultdict(list)
+        )
+        # Track which entries are affected by each request type group
+        entries_by_type: dict[type[DispatchRequest], list[_DistributedEntry]] = (
+            defaultdict(list)
+        )
+
+        for entry in entries:
+            if entry.prepare_result is None or not entry.prepare_result.requests:
+                continue
+
+            request_type = type(entry.prepare_result.requests[0])
+            for request in entry.prepare_result.requests:
+                request_to_artifact[request.request_id] = entry.artifact_id
+                requests_by_type[request_type].append(request)
+
+            if entry not in entries_by_type[request_type]:
+                entries_by_type[request_type].append(entry)
+
+        # Dispatch each type group
+        for request_type, requests in requests_by_type.items():
+            affected_entries = entries_by_type[request_type]
+            try:
+                dispatcher = self._registry.get_dispatcher_for(request_type)
+                group_results = await dispatcher.dispatch(requests)
+            except PendingProcessingError:
+                await self._persist_pending_entries(affected_entries, ctx)
+                continue
+            except Exception:
+                for entry in affected_entries:
+                    await self._mark_failed_and_skip_dependents(
+                        entry.artifact_id, plan, ctx
+                    )
+                    results_by_artifact.pop(entry.artifact_id, None)
+                continue
+
+            # Route results back to artifacts via request_id
+            for result in group_results:
+                artifact_id = request_to_artifact[result.request_id]
+                results_by_artifact[artifact_id].append(result)
+
+        return results_by_artifact
+
+    async def _persist_pending_entries(
+        self,
+        entries: list[_DistributedEntry],
+        ctx: _ExecutionContext,
+    ) -> None:
+        """Persist PrepareResult for entries affected by PendingBatchError.
+
+        Serialises each entry's PrepareResult, saves to store, marks the
+        artifact as pending, and adds to the pending tracking set.
+
+        """
+        for entry in entries:
+            if entry.prepare_result is not None:
+                data = entry.prepare_result.model_dump(mode="json")
+                await ctx.store.save_prepared(ctx.run_id, entry.artifact_id, data)
+            ctx.state.mark_pending(entry.artifact_id)
+            ctx.pending_batch_artifacts.add(entry.artifact_id)
+        await ctx.state.save(ctx.store)
 
     async def _handle_artifact_result(
         self,

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor.py
@@ -389,7 +389,7 @@ class TestDAGExecutorProcess:
         mock_processor_class.get_name.return_value = "personal_data_analyser"
         mock_processor_class.get_supported_output_schemas.return_value = [output_schema]
         processor_factory.component_class = mock_processor_class
-        mock_processor = MagicMock()
+        mock_processor = MagicMock(spec=["process"])
         mock_processor.process.return_value = processed_message
         processor_factory.create.return_value = mock_processor
 
@@ -563,7 +563,7 @@ class TestDAGExecutorArtifactMetadata:
         mock_processor_class.get_name.return_value = "personal_data"
         mock_processor_class.get_supported_output_schemas.return_value = [output_schema]
         processor_factory.component_class = mock_processor_class
-        mock_processor = MagicMock()
+        mock_processor = MagicMock(spec=["process"])
         mock_processor.process.return_value = processed_message
         processor_factory.create.return_value = mock_processor
 

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_batch.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_batch.py
@@ -1,19 +1,16 @@
-"""Tests for DAGExecutor handling of PendingProcessingError (batch mode).
+"""Tests for PendingProcessingError handling on the regular path (post-migration).
 
-When a processor raises PendingProcessingError (e.g. via LLM batch API),
-the executor should leave the artifact in not_started, continue executing
-independent branches, and mark the run as interrupted.
+After the Distributed Processor Protocol migration, PendingProcessingError is no
+longer special-cased on the regular (non-distributed) path. Regular processors are
+synchronous — any exception is treated as failure. The distributed path handles
+batch pending via PendingBatchError in _dispatch_all.
 """
 
-from pathlib import Path
-
-from waivern_artifact_store import ArtifactStore
 from waivern_core.errors import PendingProcessingError
 from waivern_core.schemas import Schema
 
 from waivern_orchestration.executor import DAGExecutor
 from waivern_orchestration.models import ArtifactDefinition, SourceConfig
-from waivern_orchestration.run_metadata import RunMetadata
 
 from .test_executor_state import create_failing_connector_factory
 from .test_helpers import (
@@ -23,19 +20,16 @@ from .test_helpers import (
     create_test_message,
 )
 
-# =============================================================================
-# Batch Handling Tests
-# =============================================================================
 
+class TestPendingProcessingErrorOnRegularPath:
+    """PendingProcessingError from regular connectors/processors is treated as failure."""
 
-class TestDAGExecutorBatchHandling:
-    """Tests for PendingProcessingError handling in DAGExecutor."""
+    async def test_pending_processing_error_treated_as_failure(self) -> None:
+        """PendingProcessingError from a connector is treated as a regular failure.
 
-    async def test_pending_processing_error_leaves_artifact_not_started_and_run_interrupted(
-        self,
-    ) -> None:
-        """PendingProcessingError leaves artifact in not_started, run marked interrupted."""
-        # Arrange — single source artifact that raises PendingProcessingError
+        Post-migration, only the distributed dispatch path handles pending
+        state. Regular connectors raising PendingProcessingError fail normally.
+        """
         output_schema = Schema("standard_input", "1.0.0")
 
         pending_factory = create_failing_connector_factory(
@@ -57,25 +51,20 @@ class TestDAGExecutorBatchHandling:
         )
         executor = DAGExecutor(registry)
 
-        # Act
         result = await executor.execute(plan)
 
-        # Assert — artifact NOT in completed, failed, or skipped
+        # PendingProcessingError is now treated as failure, not pending
+        assert "data" in result.failed
         assert "data" not in result.completed
-        assert "data" not in result.failed
-        assert "data" not in result.skipped
 
-        # Assert — run metadata status is "interrupted"
-        store = registry.container.get_service(ArtifactStore)
-        metadata = await RunMetadata.load(store, result.run_id)
-        assert metadata.status == "interrupted"
-        assert metadata.completed_at is not None
-
-    async def test_dag_continues_independent_branches_after_pending_error(
+    async def test_independent_branches_continue_after_pending_error_failure(
         self,
     ) -> None:
-        """Independent branches continue executing after a PendingProcessingError."""
-        # Arrange — source_a (pending), source_b (succeeds), derived_c (depends on both)
+        """Independent branches continue executing after PendingProcessingError failure.
+
+        The failed artifact's dependents are skipped, but independent
+        artifacts at the same level continue normally.
+        """
         output_schema = Schema("standard_input", "1.0.0")
         message = create_test_message({"files": []})
 
@@ -115,23 +104,15 @@ class TestDAGExecutorBatchHandling:
         )
         executor = DAGExecutor(registry)
 
-        # Act
         result = await executor.execute(plan)
 
-        # Assert — source_b completed, source_a and derived_c did not
+        # source_a failed, source_b completed, derived_c skipped (dep on failed source_a)
+        assert "source_a" in result.failed
         assert "source_b" in result.completed
-        assert "source_a" not in result.completed
-        assert "source_a" not in result.failed
-        assert "derived_c" not in result.completed
+        assert "derived_c" in result.skipped
 
-        # Assert — run interrupted (not failed)
-        store = registry.container.get_service(ArtifactStore)
-        metadata = await RunMetadata.load(store, result.run_id)
-        assert metadata.status == "interrupted"
-
-    async def test_multiple_artifacts_pending_in_same_gather_batch(self) -> None:
-        """Multiple PendingProcessingErrors in the same gather batch are tracked."""
-        # Arrange — two independent source artifacts, both pending
+    async def test_multiple_pending_errors_all_treated_as_failure(self) -> None:
+        """Multiple PendingProcessingErrors in the same batch all treated as failures."""
         output_schema = Schema("standard_input", "1.0.0")
 
         pending_factory = create_failing_connector_factory(
@@ -162,138 +143,7 @@ class TestDAGExecutorBatchHandling:
         )
         executor = DAGExecutor(registry)
 
-        # Act
         result = await executor.execute(plan)
 
-        # Assert — neither in completed or failed
-        assert "source_a" not in result.completed
-        assert "source_a" not in result.failed
-        assert "source_b" not in result.completed
-        assert "source_b" not in result.failed
-
-        # Assert — run interrupted
-        store = registry.container.get_service(ArtifactStore)
-        metadata = await RunMetadata.load(store, result.run_id)
-        assert metadata.status == "interrupted"
-
-    async def test_resume_after_interrupted_run_completes_pending_artifacts(
-        self, tmp_path: Path
-    ) -> None:
-        """Resuming an interrupted run re-executes pending artifacts successfully."""
-        # Arrange — single source artifact, first run pending, second run succeeds
-        output_schema = Schema("standard_input", "1.0.0")
-        message = create_test_message({"files": []})
-
-        pending_factory = create_failing_connector_factory(
-            "my_source",
-            [output_schema],
-            PendingProcessingError("Batch pending"),
-        )
-        ok_factory = create_mock_connector_factory(
-            "my_source", [output_schema], message
-        )
-
-        artifacts = {
-            "data": ArtifactDefinition(
-                source=SourceConfig(type="my_source", properties={})
-            ),
-        }
-        plan = create_simple_plan(artifacts, {"data": (None, output_schema)})
-
-        runbook_file = tmp_path / "runbook.yaml"
-        runbook_file.write_text("name: test\ndescription: test\n")
-
-        # First run — connector raises PendingProcessingError
-        registry = create_mock_registry(
-            with_container=True,
-            connector_factories={"my_source": pending_factory},
-        )
-        executor = DAGExecutor(registry)
-
-        result1 = await executor.execute(plan, runbook_path=runbook_file)
-        assert "data" not in result1.completed
-
-        store = registry.container.get_service(ArtifactStore)
-        metadata = await RunMetadata.load(store, result1.run_id)
-        assert metadata.status == "interrupted"
-
-        # Second run (resume) — swap to a working connector
-        registry.connector_factories["my_source"] = ok_factory
-
-        result2 = await executor.execute(
-            plan,
-            runbook_path=runbook_file,
-            resume_run_id=result1.run_id,
-        )
-
-        # Assert — artifact now completed
-        assert "data" in result2.completed
-
-        # Assert — status transitioned to completed
-        metadata2 = await RunMetadata.load(store, result2.run_id)
-        assert metadata2.status == "completed"
-
-    async def test_mixed_pending_failed_and_succeeded_artifacts(self) -> None:
-        """Pending, failed, and succeeded artifacts coexist with correct final status."""
-        # Arrange — three independent source artifacts:
-        #   source_ok (succeeds), source_pending (pending), source_fail (fails)
-        output_schema = Schema("standard_input", "1.0.0")
-        message = create_test_message({"files": []})
-
-        ok_factory = create_mock_connector_factory(
-            "ok_source", [output_schema], message
-        )
-        pending_factory = create_failing_connector_factory(
-            "pending_source",
-            [output_schema],
-            PendingProcessingError("Batch pending"),
-        )
-        fail_factory = create_failing_connector_factory(
-            "fail_source",
-            [output_schema],
-            RuntimeError("Connection failed"),
-        )
-
-        artifacts = {
-            "source_ok": ArtifactDefinition(
-                source=SourceConfig(type="ok_source", properties={})
-            ),
-            "source_pending": ArtifactDefinition(
-                source=SourceConfig(type="pending_source", properties={})
-            ),
-            "source_fail": ArtifactDefinition(
-                source=SourceConfig(type="fail_source", properties={})
-            ),
-        }
-        plan = create_simple_plan(
-            artifacts,
-            {
-                "source_ok": (None, output_schema),
-                "source_pending": (None, output_schema),
-                "source_fail": (None, output_schema),
-            },
-        )
-
-        registry = create_mock_registry(
-            with_container=True,
-            connector_factories={
-                "ok_source": ok_factory,
-                "pending_source": pending_factory,
-                "fail_source": fail_factory,
-            },
-        )
-        executor = DAGExecutor(registry)
-
-        # Act
-        result = await executor.execute(plan)
-
-        # Assert — each artifact in the correct bucket
-        assert "source_ok" in result.completed
-        assert "source_fail" in result.failed
-        assert "source_pending" not in result.completed
-        assert "source_pending" not in result.failed
-
-        # Assert — interrupted takes priority over failed
-        store = registry.container.get_service(ArtifactStore)
-        metadata = await RunMetadata.load(store, result.run_id)
-        assert metadata.status == "interrupted"
+        assert "source_a" in result.failed
+        assert "source_b" in result.failed

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_child_runbooks.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_child_runbooks.py
@@ -102,7 +102,7 @@ class TestExecutorChildRunbookAliases:
         mock_processor_class.get_name.return_value = "analyser"
         mock_processor_class.get_supported_output_schemas.return_value = [output_schema]
         processor_factory.component_class = mock_processor_class
-        mock_processor = MagicMock()
+        mock_processor = MagicMock(spec=["process"])
         mock_processor.process.return_value = processed_message
         processor_factory.create.return_value = mock_processor
 

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_classification.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_classification.py
@@ -1,10 +1,11 @@
-"""Tests for artifact classification in DAGExecutor.
+"""Tests for artifact classification and dispatch in DAGExecutor.
 
-These tests verify that the executor correctly separates ready artifacts
-into regular, distributed, and resuming groups based on their definition
-and execution state. Tested end-to-end through execute().
+These tests verify end-to-end through execute() that the executor correctly:
+- Separates ready artifacts into regular, distributed, and resuming groups
+- Groups dispatch requests by type and routes results back
+- Handles PendingBatchError and dispatch failures
 
-Stubs written in Step 1; implementations added in Step 5 when the
+Stubs written in Steps 1 and 3; implementations added in Step 5 when the
 three-phase orchestration is integrated into _execute_dag.
 """
 
@@ -15,32 +16,152 @@ three-phase orchestration is integrated into _execute_dag.
 
 
 class TestClassifyArtifacts:
-    """Tests for artifact classification in DAGExecutor."""
+    """Tests for artifact classification in DAGExecutor.
+
+    Verified end-to-end: the classification outcome is observable by which
+    code path executes (connector extract vs processor prepare/finalise).
+    """
 
     async def test_source_artifact_classified_as_regular(self) -> None:
-        """Source artifact (has SourceConfig) is classified as regular."""
+        """Source artifact (has SourceConfig) is classified as regular.
+
+        Arrange: single source artifact with a connector factory.
+        Assert: connector.extract() is called (not prepare/finalise).
+        """
         pass
 
     async def test_reuse_artifact_classified_as_regular(self) -> None:
-        """Reuse artifact (has ReuseConfig) is classified as regular."""
+        """Reuse artifact (has ReuseConfig) is classified as regular.
+
+        Arrange: reuse artifact referencing a previous run.
+        Assert: artifact loaded from previous run (not prepare/finalise).
+        """
         pass
 
     async def test_passthrough_artifact_classified_as_regular(self) -> None:
-        """Passthrough artifact (inputs, no process) is classified as regular."""
+        """Passthrough artifact (inputs, no process) is classified as regular.
+
+        Arrange: artifact with inputs but no process config.
+        Assert: input message passed through (not prepare/finalise).
+        """
         pass
 
     async def test_regular_processor_classified_as_regular(self) -> None:
-        """Processor not implementing DistributedProcessor is classified as regular."""
+        """Processor not implementing DistributedProcessor is classified as regular.
+
+        Arrange: processor factory returning a Processor-only instance
+        (no prepare/finalise methods).
+        Assert: processor.process() is called (not prepare/finalise).
+        """
         pass
 
     async def test_distributed_processor_classified_as_distributed(self) -> None:
-        """Processor implementing DistributedProcessor is classified as distributed."""
+        """Processor implementing DistributedProcessor is classified as distributed.
+
+        Arrange: processor factory returning a dual-protocol instance
+        (implements both Processor and DistributedProcessor).
+        Assert: prepare() is called, then finalise() with dispatch results.
+        process() is NOT called.
+        """
         pass
 
     async def test_pending_artifact_classified_as_resuming(self) -> None:
-        """Pending artifact is classified as resuming with PrepareResult loaded."""
+        """Pending artifact is classified as resuming with PrepareResult loaded.
+
+        Arrange: execution state with artifact in pending set; PrepareResult
+        persisted in store from a previous interrupted run.
+        Assert: deserialise_prepare_result() called with raw dict from store,
+        then dispatch (Phase 2) and finalise (Phase 3) — no prepare (Phase 1).
+        """
         pass
 
     async def test_mixed_level_classifies_all_types_correctly(self) -> None:
-        """Mixed level with all artifact types classifies each correctly."""
+        """Mixed level with all artifact types classifies each correctly.
+
+        Arrange: level with source, reuse, passthrough, regular processor,
+        distributed processor, and resuming artifact.
+        Assert: each artifact follows its expected code path; regular and
+        distributed artifacts execute concurrently in the same gather.
+        """
+        pass
+
+
+# =============================================================================
+# Dispatch Tests
+# =============================================================================
+
+
+class TestDispatchAll:
+    """Tests for dispatch grouping, routing, and error handling.
+
+    Verified end-to-end: dispatch behaviour is observable through the
+    final execution result (completed/failed/pending) and store state.
+    """
+
+    async def test_requests_grouped_by_type_and_dispatched(self) -> None:
+        """Requests from multiple artifacts of the same type are grouped.
+
+        Arrange: two distributed processors at the same level, both
+        producing LLMRequest objects.
+        Assert: dispatcher.dispatch() called once with all requests
+        combined, not once per artifact.
+        """
+        pass
+
+    async def test_results_routed_back_to_correct_artifacts(self) -> None:
+        """Dispatch results are routed to the correct artifact via request_id.
+
+        Arrange: two distributed processors each producing requests with
+        distinct request_ids. Dispatcher returns results with matching ids.
+        Assert: each processor's finalise() receives only its own results,
+        not the other artifact's results.
+        """
+        pass
+
+    async def test_pending_batch_error_persists_and_marks_pending(self) -> None:
+        """PendingBatchError persists PrepareResult and marks artifacts pending.
+
+        Arrange: dispatcher raises PendingBatchError.
+        Assert:
+        - PrepareResult serialised via model_dump(mode="json") and saved
+          to store via save_prepared()
+        - Artifact marked pending in ExecutionState
+        - Run status is "interrupted" (not failed)
+        - Artifact NOT in completed, failed, or skipped
+        """
+        pass
+
+    async def test_dispatch_error_fails_affected_artifacts_only(self) -> None:
+        """Non-pending dispatch errors fail only the affected dispatch group.
+
+        Arrange: two distributed processors at the same level using the
+        same request type. Dispatcher raises RuntimeError.
+        Assert:
+        - Both artifacts in the dispatch group marked as failed
+        - Their dependents are skipped
+        - Regular artifacts at the same level that already completed
+          remain completed (not affected by the dispatch failure)
+        """
+        pass
+
+    async def test_short_circuited_entries_get_empty_results(self) -> None:
+        """Entries with empty requests skip dispatch and get empty results.
+
+        Arrange: distributed processor whose prepare() returns a
+        PrepareResult with empty requests list.
+        Assert: finalise() called with empty results sequence.
+        No dispatcher resolved or called.
+        """
+        pass
+
+    async def test_mixed_request_types_dispatched_to_different_dispatchers(
+        self,
+    ) -> None:
+        """Mixed request types at the same level dispatch to separate dispatchers.
+
+        Arrange: two distributed processors producing different request
+        types (e.g., LLMRequest and a hypothetical HTTPRequest).
+        Assert: each request type group dispatched to its own dispatcher.
+        Results correctly routed back despite different dispatchers.
+        """
         pass

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_classification.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_classification.py
@@ -1,167 +1,782 @@
-"""Tests for artifact classification and dispatch in DAGExecutor.
+"""Tests for distributed processor integration in DAGExecutor.
 
-These tests verify end-to-end through execute() that the executor correctly:
-- Separates ready artifacts into regular, distributed, and resuming groups
+Verifies end-to-end through execute() that the executor correctly:
+- Classifies artifacts and routes distributed processors through prepare-dispatch-finalise
 - Groups dispatch requests by type and routes results back
-- Handles PendingBatchError and dispatch failures
-
-Stubs written in Steps 1 and 3; implementations added in Step 5 when the
-three-phase orchestration is integrated into _execute_dag.
+- Handles PendingBatchError and dispatch failures with error isolation
+- Resumes pending artifacts from interrupted runs
 """
 
+from pathlib import Path
+from typing import override
+
+from waivern_artifact_store import ArtifactStore
+from waivern_core import Message
+from waivern_core.dispatch import (
+    DispatchRequest,
+    DispatchResult,
+    PrepareResult,
+)
+from waivern_core.errors import PendingProcessingError
+from waivern_core.schemas import Schema
+
+from waivern_orchestration.executor import DAGExecutor
+from waivern_orchestration.models import (
+    ArtifactDefinition,
+    ProcessConfig,
+    SourceConfig,
+)
+from waivern_orchestration.run_metadata import RunMetadata
+
+from .test_helpers import (
+    StubDistributedProcessor,
+    StubState,
+    create_distributed_processor_factory,
+    create_mock_connector_factory,
+    create_mock_dispatcher,
+    create_mock_processor_factory,
+    create_mock_registry,
+    create_simple_plan,
+    create_test_message,
+)
 
 # =============================================================================
-# Classification Tests
-# =============================================================================
-
-
-class TestClassifyArtifacts:
-    """Tests for artifact classification in DAGExecutor.
-
-    Verified end-to-end: the classification outcome is observable by which
-    code path executes (connector extract vs processor prepare/finalise).
-    """
-
-    async def test_source_artifact_classified_as_regular(self) -> None:
-        """Source artifact (has SourceConfig) is classified as regular.
-
-        Arrange: single source artifact with a connector factory.
-        Assert: connector.extract() is called (not prepare/finalise).
-        """
-        pass
-
-    async def test_reuse_artifact_classified_as_regular(self) -> None:
-        """Reuse artifact (has ReuseConfig) is classified as regular.
-
-        Arrange: reuse artifact referencing a previous run.
-        Assert: artifact loaded from previous run (not prepare/finalise).
-        """
-        pass
-
-    async def test_passthrough_artifact_classified_as_regular(self) -> None:
-        """Passthrough artifact (inputs, no process) is classified as regular.
-
-        Arrange: artifact with inputs but no process config.
-        Assert: input message passed through (not prepare/finalise).
-        """
-        pass
-
-    async def test_regular_processor_classified_as_regular(self) -> None:
-        """Processor not implementing DistributedProcessor is classified as regular.
-
-        Arrange: processor factory returning a Processor-only instance
-        (no prepare/finalise methods).
-        Assert: processor.process() is called (not prepare/finalise).
-        """
-        pass
-
-    async def test_distributed_processor_classified_as_distributed(self) -> None:
-        """Processor implementing DistributedProcessor is classified as distributed.
-
-        Arrange: processor factory returning a dual-protocol instance
-        (implements both Processor and DistributedProcessor).
-        Assert: prepare() is called, then finalise() with dispatch results.
-        process() is NOT called.
-        """
-        pass
-
-    async def test_pending_artifact_classified_as_resuming(self) -> None:
-        """Pending artifact is classified as resuming with PrepareResult loaded.
-
-        Arrange: execution state with artifact in pending set; PrepareResult
-        persisted in store from a previous interrupted run.
-        Assert: deserialise_prepare_result() called with raw dict from store,
-        then dispatch (Phase 2) and finalise (Phase 3) — no prepare (Phase 1).
-        """
-        pass
-
-    async def test_mixed_level_classifies_all_types_correctly(self) -> None:
-        """Mixed level with all artifact types classifies each correctly.
-
-        Arrange: level with source, reuse, passthrough, regular processor,
-        distributed processor, and resuming artifact.
-        Assert: each artifact follows its expected code path; regular and
-        distributed artifacts execute concurrently in the same gather.
-        """
-        pass
-
-
-# =============================================================================
-# Dispatch Tests
+# Happy Path
 # =============================================================================
 
 
-class TestDispatchAll:
-    """Tests for dispatch grouping, routing, and error handling.
+class TestDistributedProcessorHappyPath:
+    """Tests for the distributed processor three-phase lifecycle."""
 
-    Verified end-to-end: dispatch behaviour is observable through the
-    final execution result (completed/failed/pending) and store state.
-    """
+    async def test_distributed_processor_end_to_end(self) -> None:
+        """Source → distributed processor → output with dependent.
+
+        Arrange: source artifact → distributed processor → passthrough dependent.
+        Distributed processor's prepare() returns PrepareResult with requests.
+        Dispatcher returns matching results. finalise() returns Message.
+        Assert: all three artifacts completed. prepare() called (not process()).
+        Dependent executes (proving sorter.done was called).
+        """
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        final_message = create_test_message(
+            {"findings": ["result"]}, schema=output_schema
+        )
+
+        # Build dispatch request/result pair
+        request = DispatchRequest(name="test_request")
+        result = DispatchResult(request_id=request.request_id, name="test_result")
+
+        processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(
+                state=StubState(value="my_state"),
+                requests=[request],
+            ),
+            finalise_results=[final_message],
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "filesystem", [source_schema], source_message
+        )
+        processor_factory = create_distributed_processor_factory(
+            "distributed_analyser", processor
+        )
+        dispatcher = create_mock_dispatcher([result])
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="filesystem", properties={})
+            ),
+            "findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="distributed_analyser", properties={}),
+            ),
+            "downstream": ArtifactDefinition(inputs="findings"),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "findings": ([source_schema], output_schema),
+                "downstream": ([output_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"filesystem": connector_factory},
+            processor_factories={"distributed_analyser": processor_factory},
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        # Act
+        exec_result = await executor.execute(plan)
+
+        # Assert — all three completed
+        assert {"source", "findings", "downstream"} == exec_result.completed
+
+        # Assert — distributed path used (prepare + finalise, not process)
+        assert processor.call_log == ["prepare", "finalise"]
+
+        # Assert — artifact content saved correctly
+        store = registry.container.get_service(ArtifactStore)
+        findings_msg = await store.get_artifact(exec_result.run_id, "findings")
+        assert findings_msg.is_success
+        assert findings_msg.content == final_message.content
+
+    async def test_mixed_level_regular_and_distributed_concurrent(self) -> None:
+        """Regular processor + distributed processor at same level both complete.
+
+        Arrange: source → two derived artifacts at same level: one regular
+        processor, one distributed processor. Both depend on the same source.
+        Assert: both derived artifacts completed. Regular used process(),
+        distributed used prepare/finalise.
+        """
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        regular_result_msg = Message(
+            id="regular_out", content={"findings": ["regular"]}, schema=output_schema
+        )
+        distributed_result_msg = create_test_message(
+            {"findings": ["distributed"]}, schema=output_schema
+        )
+
+        # Distributed processor setup
+        request = DispatchRequest(name="test_req")
+        dispatch_result = DispatchResult(request_id=request.request_id, name="test_res")
+        dist_processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(state=StubState(), requests=[request]),
+            finalise_results=[distributed_result_msg],
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "filesystem", [source_schema], source_message
+        )
+        regular_factory = create_mock_processor_factory(
+            "regular_analyser",
+            [source_schema],
+            [output_schema],
+            process_result=regular_result_msg,
+        )
+        distributed_factory = create_distributed_processor_factory(
+            "distributed_analyser", dist_processor
+        )
+        dispatcher = create_mock_dispatcher([dispatch_result])
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="filesystem", properties={})
+            ),
+            "regular_findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="regular_analyser", properties={}),
+            ),
+            "distributed_findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="distributed_analyser", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "regular_findings": ([source_schema], output_schema),
+                "distributed_findings": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"filesystem": connector_factory},
+            processor_factories={
+                "regular_analyser": regular_factory,
+                "distributed_analyser": distributed_factory,
+            },
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        # Act
+        exec_result = await executor.execute(plan)
+
+        # Assert — all three completed
+        assert {
+            "source",
+            "regular_findings",
+            "distributed_findings",
+        } == exec_result.completed
+
+        # Assert — correct code paths used
+        assert dist_processor.call_log == ["prepare", "finalise"]
+        regular_factory.create.return_value.process.assert_called_once()
+
+
+# =============================================================================
+# Dispatch
+# =============================================================================
+
+
+class TestDistributedDispatch:
+    """Tests for dispatch grouping, routing, and error handling."""
 
     async def test_requests_grouped_by_type_and_dispatched(self) -> None:
         """Requests from multiple artifacts of the same type are grouped.
 
         Arrange: two distributed processors at the same level, both
-        producing LLMRequest objects.
+        producing requests of the same DispatchRequest subclass.
         Assert: dispatcher.dispatch() called once with all requests
         combined, not once per artifact.
         """
-        pass
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        final_message = create_test_message(
+            {"findings": ["done"]}, schema=output_schema
+        )
+
+        # Two processors, each with one request
+        req_a = DispatchRequest(name="req_a")
+        req_b = DispatchRequest(name="req_b")
+        res_a = DispatchResult(request_id=req_a.request_id)
+        res_b = DispatchResult(request_id=req_b.request_id)
+
+        proc_a = StubDistributedProcessor(
+            prepare_result=PrepareResult(state=StubState(), requests=[req_a]),
+            finalise_results=[final_message],
+        )
+        proc_b = StubDistributedProcessor(
+            prepare_result=PrepareResult(state=StubState(), requests=[req_b]),
+            finalise_results=[final_message],
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        dispatcher = create_mock_dispatcher([res_a, res_b])
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "a": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="proc_a", properties={}),
+            ),
+            "b": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="proc_b", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "a": ([source_schema], output_schema),
+                "b": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "proc_a": create_distributed_processor_factory("proc_a", proc_a),
+                "proc_b": create_distributed_processor_factory("proc_b", proc_b),
+            },
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        assert {"source", "a", "b"} == exec_result.completed
+        # dispatch() called once with both requests grouped
+        dispatcher.dispatch.assert_called_once()
+        dispatched_requests = dispatcher.dispatch.call_args[0][0]
+        assert len(dispatched_requests) == 2
 
     async def test_results_routed_back_to_correct_artifacts(self) -> None:
         """Dispatch results are routed to the correct artifact via request_id.
 
         Arrange: two distributed processors each producing requests with
         distinct request_ids. Dispatcher returns results with matching ids.
-        Assert: each processor's finalise() receives only its own results,
-        not the other artifact's results.
+        Assert: each processor's finalise() receives only its own results.
         """
-        pass
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+
+        req_a = DispatchRequest(name="req_a")
+        req_b = DispatchRequest(name="req_b")
+        res_a = DispatchResult(request_id=req_a.request_id, name="result_for_a")
+        res_b = DispatchResult(request_id=req_b.request_id, name="result_for_b")
+
+        # Track what each finalise receives
+        finalise_args: dict[str, list[DispatchResult]] = {}
+
+        class TrackingProcessor(StubDistributedProcessor):
+            def __init__(
+                self,
+                tag: str,
+                prepare_result: PrepareResult[StubState],
+                final_msg: Message,
+            ) -> None:
+                super().__init__(prepare_result, [final_msg])
+                self.tag = tag
+
+            def finalise(self, state, results, output_schema):  # type: ignore[override]
+                finalise_args[self.tag] = list(results)
+                return super().finalise(state, results, output_schema)
+
+        final_msg = create_test_message({"findings": []}, schema=output_schema)
+        proc_a = TrackingProcessor(
+            "a", PrepareResult(state=StubState(), requests=[req_a]), final_msg
+        )
+        proc_b = TrackingProcessor(
+            "b", PrepareResult(state=StubState(), requests=[req_b]), final_msg
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        dispatcher = create_mock_dispatcher([res_a, res_b])
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "a": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="proc_a", properties={}),
+            ),
+            "b": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="proc_b", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "a": ([source_schema], output_schema),
+                "b": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "proc_a": create_distributed_processor_factory("proc_a", proc_a),
+                "proc_b": create_distributed_processor_factory("proc_b", proc_b),
+            },
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        assert {"source", "a", "b"} == exec_result.completed
+        # Each processor got only its own result
+        assert len(finalise_args["a"]) == 1
+        assert finalise_args["a"][0].name == "result_for_a"
+        assert len(finalise_args["b"]) == 1
+        assert finalise_args["b"][0].name == "result_for_b"
 
     async def test_pending_batch_error_persists_and_marks_pending(self) -> None:
         """PendingBatchError persists PrepareResult and marks artifacts pending.
 
-        Arrange: dispatcher raises PendingBatchError.
+        Arrange: dispatcher raises PendingProcessingError (PendingBatchError).
         Assert:
-        - PrepareResult serialised via model_dump(mode="json") and saved
-          to store via save_prepared()
+        - PrepareResult saved to store via save_prepared()
         - Artifact marked pending in ExecutionState
         - Run status is "interrupted" (not failed)
         - Artifact NOT in completed, failed, or skipped
         """
-        pass
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
 
-    async def test_dispatch_error_fails_affected_artifacts_only(self) -> None:
-        """Non-pending dispatch errors fail only the affected dispatch group.
+        request = DispatchRequest(name="pending_req")
+        processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(
+                state=StubState(value="pending_state"),
+                requests=[request],
+            ),
+            finalise_results=[create_test_message({}, schema=output_schema)],
+        )
 
-        Arrange: two distributed processors at the same level using the
-        same request type. Dispatcher raises RuntimeError.
-        Assert:
-        - Both artifacts in the dispatch group marked as failed
-        - Their dependents are skipped
-        - Regular artifacts at the same level that already completed
-          remain completed (not affected by the dispatch failure)
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        dispatcher = create_mock_dispatcher(
+            [], side_effect=PendingProcessingError("Batch pending")
+        )
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="dist_proc", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "findings": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "dist_proc": create_distributed_processor_factory(
+                    "dist_proc", processor
+                ),
+            },
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        # Artifact not in completed, failed, or skipped
+        assert "findings" not in exec_result.completed
+        assert "findings" not in exec_result.failed
+        assert "findings" not in exec_result.skipped
+        assert "source" in exec_result.completed
+
+        # Run status is interrupted
+        store = registry.container.get_service(ArtifactStore)
+        metadata = await RunMetadata.load(store, exec_result.run_id)
+        assert metadata.status == "interrupted"
+
+        # PrepareResult was persisted
+        raw = await store.load_prepared(exec_result.run_id, "findings")
+        assert raw["state"]["value"] == "pending_state"
+
+    async def test_dispatch_error_fails_distributed_regular_unaffected(self) -> None:
+        """Dispatch error fails distributed artifacts; regular at same level unaffected.
+
+        Arrange: source → regular processor + distributed processor at same level.
+        Dispatcher raises RuntimeError.
+        Assert: distributed artifact failed, regular artifact completed.
         """
-        pass
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        regular_result = Message(
+            id="regular", content={"findings": []}, schema=output_schema
+        )
+
+        request = DispatchRequest(name="failing_req")
+        dist_processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(state=StubState(), requests=[request]),
+            finalise_results=[create_test_message({}, schema=output_schema)],
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        regular_factory = create_mock_processor_factory(
+            "regular", [source_schema], [output_schema], process_result=regular_result
+        )
+        dispatcher = create_mock_dispatcher(
+            [], side_effect=RuntimeError("Dispatch failed")
+        )
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "regular_out": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="regular", properties={}),
+            ),
+            "distributed_out": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="dist_proc", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "regular_out": ([source_schema], output_schema),
+                "distributed_out": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "regular": regular_factory,
+                "dist_proc": create_distributed_processor_factory(
+                    "dist_proc", dist_processor
+                ),
+            },
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        assert {"source", "regular_out"} == exec_result.completed
+        assert "distributed_out" in exec_result.failed
 
     async def test_short_circuited_entries_get_empty_results(self) -> None:
         """Entries with empty requests skip dispatch and get empty results.
 
         Arrange: distributed processor whose prepare() returns a
         PrepareResult with empty requests list.
-        Assert: finalise() called with empty results sequence.
+        Assert: artifact completed. finalise() called with empty results.
         No dispatcher resolved or called.
         """
-        pass
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        final_message = create_test_message(
+            {"findings": ["short_circuit"]}, schema=output_schema
+        )
 
-    async def test_mixed_request_types_dispatched_to_different_dispatchers(
-        self,
-    ) -> None:
-        """Mixed request types at the same level dispatch to separate dispatchers.
+        processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(state=StubState(), requests=[]),
+            finalise_results=[final_message],
+        )
 
-        Arrange: two distributed processors producing different request
-        types (e.g., LLMRequest and a hypothetical HTTPRequest).
-        Assert: each request type group dispatched to its own dispatcher.
-        Results correctly routed back despite different dispatchers.
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="dist_proc", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "findings": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "dist_proc": create_distributed_processor_factory(
+                    "dist_proc", processor
+                ),
+            },
+        )
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        assert {"source", "findings"} == exec_result.completed
+        assert processor.call_log == ["prepare", "finalise"]
+        # No dispatcher was needed
+        registry.get_dispatcher_for.assert_not_called()
+
+
+# =============================================================================
+# Error Isolation
+# =============================================================================
+
+
+class TestDistributedErrorIsolation:
+    """Tests for error isolation between regular and distributed paths."""
+
+    async def test_prepare_failure_fails_artifact_regular_unaffected(self) -> None:
+        """prepare() throwing fails only that artifact; regular at same level unaffected.
+
+        Arrange: source → regular processor + distributed processor at same level.
+        Distributed processor's prepare() raises RuntimeError.
+        Assert: distributed artifact failed with dependents skipped.
+        Regular artifact completed normally.
         """
-        pass
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        regular_result = Message(
+            id="ok", content={"findings": []}, schema=output_schema
+        )
+
+        # Processor whose prepare() raises
+        class FailingPrepareProcessor(StubDistributedProcessor):
+            @override
+            def prepare(self, inputs, output_schema):  # type: ignore[override]
+                raise RuntimeError("prepare failed")
+
+        failing_processor = FailingPrepareProcessor(
+            prepare_result=PrepareResult(state=StubState(), requests=[]),
+            finalise_results=[create_test_message({}, schema=output_schema)],
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        regular_factory = create_mock_processor_factory(
+            "regular", [source_schema], [output_schema], process_result=regular_result
+        )
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "regular_out": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="regular", properties={}),
+            ),
+            "distributed_out": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="dist_proc", properties={}),
+            ),
+            "dependent": ArtifactDefinition(inputs="distributed_out"),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "regular_out": ([source_schema], output_schema),
+                "distributed_out": ([source_schema], output_schema),
+                "dependent": ([output_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "regular": regular_factory,
+                "dist_proc": create_distributed_processor_factory(
+                    "dist_proc", failing_processor
+                ),
+            },
+        )
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        assert {"source", "regular_out"} == exec_result.completed
+        assert "distributed_out" in exec_result.failed
+        assert "dependent" in exec_result.skipped
+
+
+# =============================================================================
+# Resume
+# =============================================================================
+
+
+class TestDistributedResume:
+    """Tests for resuming interrupted runs with pending distributed artifacts."""
+
+    async def test_resume_pending_artifact_skips_prepare(self, tmp_path: Path) -> None:
+        """Pending artifact from interrupted run skips prepare, dispatches, completes.
+
+        Arrange: first run — distributed processor, dispatcher raises
+        PendingProcessingError → artifact pending, run interrupted.
+        Second run (resume) — dispatcher succeeds.
+        Assert: prepare() called once (first run only). deserialise_prepare_result()
+        called on resume. finalise() produces Message → artifact completed.
+        """
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        final_message = create_test_message(
+            {"findings": ["resumed"]}, schema=output_schema
+        )
+
+        request = DispatchRequest(name="resume_req")
+        dispatch_result = DispatchResult(request_id=request.request_id)
+
+        processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(
+                state=StubState(value="resume_state"),
+                requests=[request],
+            ),
+            finalise_results=[final_message],
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        processor_factory = create_distributed_processor_factory("dist_proc", processor)
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="dist_proc", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "findings": ([source_schema], output_schema),
+            },
+        )
+
+        runbook_file = tmp_path / "runbook.yaml"
+        runbook_file.write_text("name: test\ndescription: test\n")
+
+        # First run — dispatcher raises PendingProcessingError
+        pending_dispatcher = create_mock_dispatcher(
+            [], side_effect=PendingProcessingError("Batch pending")
+        )
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={"dist_proc": processor_factory},
+        )
+        registry.get_dispatcher_for.return_value = pending_dispatcher
+        executor = DAGExecutor(registry)
+
+        result1 = await executor.execute(plan, runbook_path=runbook_file)
+        assert "findings" not in result1.completed
+        assert "source" in result1.completed
+
+        # Second run (resume) — dispatcher succeeds
+        ok_dispatcher = create_mock_dispatcher([dispatch_result])
+        registry.get_dispatcher_for.return_value = ok_dispatcher
+
+        # Re-create processor to track second-run calls separately
+        processor2 = StubDistributedProcessor(
+            prepare_result=PrepareResult(
+                state=StubState(value="resume_state"),
+                requests=[request],
+            ),
+            finalise_results=[final_message],
+        )
+        processor_factory2 = create_distributed_processor_factory(
+            "dist_proc", processor2
+        )
+        registry.processor_factories["dist_proc"] = processor_factory2
+
+        result2 = await executor.execute(
+            plan, runbook_path=runbook_file, resume_run_id=result1.run_id
+        )
+
+        # Assert — artifact completed on resume
+        assert "findings" in result2.completed
+
+        # Assert — prepare NOT called on resume (only deserialise + finalise)
+        assert "prepare" not in processor2.call_log
+        assert "deserialise_prepare_result" in processor2.call_log
+        assert "finalise" in processor2.call_log

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_classification.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_classification.py
@@ -1,0 +1,46 @@
+"""Tests for artifact classification in DAGExecutor.
+
+These tests verify that the executor correctly separates ready artifacts
+into regular, distributed, and resuming groups based on their definition
+and execution state. Tested end-to-end through execute().
+
+Stubs written in Step 1; implementations added in Step 5 when the
+three-phase orchestration is integrated into _execute_dag.
+"""
+
+
+# =============================================================================
+# Classification Tests
+# =============================================================================
+
+
+class TestClassifyArtifacts:
+    """Tests for artifact classification in DAGExecutor."""
+
+    async def test_source_artifact_classified_as_regular(self) -> None:
+        """Source artifact (has SourceConfig) is classified as regular."""
+        pass
+
+    async def test_reuse_artifact_classified_as_regular(self) -> None:
+        """Reuse artifact (has ReuseConfig) is classified as regular."""
+        pass
+
+    async def test_passthrough_artifact_classified_as_regular(self) -> None:
+        """Passthrough artifact (inputs, no process) is classified as regular."""
+        pass
+
+    async def test_regular_processor_classified_as_regular(self) -> None:
+        """Processor not implementing DistributedProcessor is classified as regular."""
+        pass
+
+    async def test_distributed_processor_classified_as_distributed(self) -> None:
+        """Processor implementing DistributedProcessor is classified as distributed."""
+        pass
+
+    async def test_pending_artifact_classified_as_resuming(self) -> None:
+        """Pending artifact is classified as resuming with PrepareResult loaded."""
+        pass
+
+    async def test_mixed_level_classifies_all_types_correctly(self) -> None:
+        """Mixed level with all artifact types classifies each correctly."""
+        pass

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_classification.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_classification.py
@@ -618,7 +618,9 @@ class TestDistributedErrorIsolation:
         # Processor whose prepare() raises
         class FailingPrepareProcessor(StubDistributedProcessor):
             @override
-            def prepare(self, inputs, output_schema):  # type: ignore[override]
+            def prepare(
+                self, inputs: list[Message], output_schema: Schema
+            ) -> PrepareResult[StubState]:
                 raise RuntimeError("prepare failed")
 
         failing_processor = FailingPrepareProcessor(

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_finalise.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_finalise.py
@@ -1,0 +1,106 @@
+"""Tests for finalise and multi-round dispatch in DAGExecutor.
+
+These tests verify end-to-end through execute() that the executor correctly:
+- Calls finalise() with the right state, results, and schema
+- Saves artifacts with correct metadata (including model_name from dispatch results)
+- Handles multi-round PrepareResult → dispatch → finalise cycles
+- Enforces max round limits and cleans up persisted PrepareResult on completion
+
+Stubs written in Step 4; implementations added in Step 5 when the
+three-phase orchestration is integrated into _execute_dag.
+"""
+
+
+# =============================================================================
+# Finalise Tests
+# =============================================================================
+
+
+class TestFinaliseDistributedArtifacts:
+    """Tests for finalise orchestration in DAGExecutor.
+
+    Verified end-to-end: finalise behaviour is observable through the
+    final execution result, saved artifact content, and store state.
+    """
+
+    async def test_finalise_called_with_correct_args(self) -> None:
+        """finalise() receives state from prepare, routed results, and output schema.
+
+        Arrange: distributed processor whose prepare() returns a PrepareResult
+        with known state and requests. Dispatcher returns matching results.
+        Assert: finalise() called with (state, matching_results, output_schema).
+        The returned Message becomes the artifact content.
+        """
+        pass
+
+    async def test_message_result_saves_artifact_with_metadata(self) -> None:
+        """Message from finalise() is saved with correct executor metadata.
+
+        Arrange: distributed processor completing in one round.
+        Assert: saved artifact has run_id, source='processor:{type}',
+        ExecutionContext with status='success', duration_seconds > 0,
+        correct origin and alias.
+        """
+        pass
+
+    async def test_model_name_flows_from_dispatch_result(self) -> None:
+        """enrich_execution_context propagates model_name to saved artifact.
+
+        Arrange: dispatcher returns results with model_name set
+        (e.g., LLMDispatchResult). Processor finalise() returns Message.
+        Assert: saved artifact's ExecutionContext.model_name matches
+        the dispatch result's model_name.
+        """
+        pass
+
+    async def test_message_result_marks_completed_and_notifies_sorter(self) -> None:
+        """Completed artifact is marked and its dependents become eligible.
+
+        Arrange: distributed processor (A) with a dependent artifact (B).
+        A completes via finalise() returning a Message.
+        Assert: A in execution result's completed set. B executes
+        (proving sorter.done(A) was called, unblocking B).
+        """
+        pass
+
+    async def test_completed_artifact_deletes_persisted_prepare_result(self) -> None:
+        """delete_prepared called on completion regardless of resume status.
+
+        Arrange: distributed processor completing via finalise().
+        Assert: store.delete_prepared() called for the artifact.
+        (No-op for non-resumed artifacts; cleanup for resumed ones.)
+        """
+        pass
+
+
+# =============================================================================
+# Multi-Round Tests
+# =============================================================================
+
+
+class TestMultiRoundDispatch:
+    """Tests for multi-round dispatch loop in DAGExecutor.
+
+    Verified end-to-end: multi-round behaviour is observable through
+    the number of dispatch calls and the final execution result.
+    """
+
+    async def test_prepare_result_triggers_another_dispatch_round(self) -> None:
+        """finalise() returning PrepareResult triggers another dispatch-finalise cycle.
+
+        Arrange: distributed processor whose finalise() returns a
+        PrepareResult on the first call, then a Message on the second.
+        Assert: dispatcher.dispatch() called twice (once per round).
+        Final artifact content matches the second finalise() Message.
+        """
+        pass
+
+    async def test_max_rounds_exceeded_fails_artifact(self) -> None:
+        """Exceeding max rounds marks the artifact as failed.
+
+        Arrange: distributed processor whose finalise() always returns
+        a PrepareResult (never completes).
+        Assert: artifact marked failed after 3 rounds (default limit).
+        Dependents are skipped. Run status reflects the failure.
+        """
+        pass

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_finalise.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_finalise.py
@@ -1,91 +1,271 @@
-"""Tests for finalise and multi-round dispatch in DAGExecutor.
+"""Tests for distributed processor finalise behaviour and multi-round dispatch.
 
-These tests verify end-to-end through execute() that the executor correctly:
-- Calls finalise() with the right state, results, and schema
-- Saves artifacts with correct metadata (including model_name from dispatch results)
-- Handles multi-round PrepareResult → dispatch → finalise cycles
-- Enforces max round limits and cleans up persisted PrepareResult on completion
-
-Stubs written in Step 4; implementations added in Step 5 when the
-three-phase orchestration is integrated into _execute_dag.
+Verifies end-to-end through execute() that the executor correctly:
+- Saves completed distributed artifacts with correct metadata
+- Propagates model_name via enrich_execution_context
+- Cleans up persisted PrepareResult on completion
+- Handles multi-round dispatch-finalise cycles
+- Enforces max round limits
 """
 
+from dataclasses import replace
+from typing import override
+from unittest.mock import AsyncMock
+
+from waivern_artifact_store import ArtifactStore
+from waivern_core import ExecutionContext
+from waivern_core.dispatch import (
+    DispatchRequest,
+    DispatchResult,
+    PrepareResult,
+)
+from waivern_core.schemas import Schema
+
+from waivern_orchestration.executor import DAGExecutor
+from waivern_orchestration.models import (
+    ArtifactDefinition,
+    ProcessConfig,
+    SourceConfig,
+)
+
+from .test_helpers import (
+    StubDistributedProcessor,
+    StubState,
+    create_distributed_processor_factory,
+    create_mock_connector_factory,
+    create_mock_dispatcher,
+    create_mock_registry,
+    create_simple_plan,
+    create_test_message,
+)
 
 # =============================================================================
-# Finalise Tests
+# Metadata & Cleanup
 # =============================================================================
 
 
-class TestFinaliseDistributedArtifacts:
-    """Tests for finalise orchestration in DAGExecutor.
+class TestDistributedArtifactMetadata:
+    """Tests for metadata on completed distributed artifacts."""
 
-    Verified end-to-end: finalise behaviour is observable through the
-    final execution result, saved artifact content, and store state.
-    """
+    async def test_message_result_saves_with_correct_metadata(self) -> None:
+        """Saved distributed artifact has correct executor metadata.
 
-    async def test_finalise_called_with_correct_args(self) -> None:
-        """finalise() receives state from prepare, routed results, and output schema.
-
-        Arrange: distributed processor whose prepare() returns a PrepareResult
-        with known state and requests. Dispatcher returns matching results.
-        Assert: finalise() called with (state, matching_results, output_schema).
-        The returned Message becomes the artifact content.
-        """
-        pass
-
-    async def test_message_result_saves_artifact_with_metadata(self) -> None:
-        """Message from finalise() is saved with correct executor metadata.
-
-        Arrange: distributed processor completing in one round.
+        Arrange: source → distributed processor completing in one round.
         Assert: saved artifact has run_id, source='processor:{type}',
-        ExecutionContext with status='success', duration_seconds > 0,
-        correct origin and alias.
+        ExecutionContext with status='success'.
         """
-        pass
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        final_message = create_test_message(
+            {"findings": ["meta_test"]}, schema=output_schema
+        )
+
+        request = DispatchRequest(name="meta_req")
+        dispatch_result = DispatchResult(request_id=request.request_id)
+
+        processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(state=StubState(), requests=[request]),
+            finalise_results=[final_message],
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        dispatcher = create_mock_dispatcher([dispatch_result])
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="dist_proc", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "findings": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "dist_proc": create_distributed_processor_factory(
+                    "dist_proc", processor
+                ),
+            },
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+        assert "findings" in exec_result.completed
+
+        store = registry.container.get_service(ArtifactStore)
+        stored = await store.get_artifact(exec_result.run_id, "findings")
+
+        assert stored.run_id == exec_result.run_id
+        assert stored.source == "processor:dist_proc"
+        assert stored.extensions is not None
+        assert stored.extensions.execution is not None
+        assert stored.extensions.execution.status == "success"
 
     async def test_model_name_flows_from_dispatch_result(self) -> None:
         """enrich_execution_context propagates model_name to saved artifact.
 
-        Arrange: dispatcher returns results with model_name set
-        (e.g., LLMDispatchResult). Processor finalise() returns Message.
+        Arrange: dispatcher returns results whose enrich_execution_context
+        sets model_name. Processor finalise() returns Message.
         Assert: saved artifact's ExecutionContext.model_name matches
-        the dispatch result's model_name.
+        the value set by the dispatch result.
         """
-        pass
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        final_message = create_test_message(
+            {"findings": ["model_test"]}, schema=output_schema
+        )
 
-    async def test_message_result_marks_completed_and_notifies_sorter(self) -> None:
-        """Completed artifact is marked and its dependents become eligible.
+        request = DispatchRequest(name="model_req")
 
-        Arrange: distributed processor (A) with a dependent artifact (B).
-        A completes via finalise() returning a Message.
-        Assert: A in execution result's completed set. B executes
-        (proving sorter.done(A) was called, unblocking B).
-        """
-        pass
+        # Create a custom DispatchResult that enriches with model_name
+        class ModelNameResult(DispatchResult):
+            model_name: str
 
-    async def test_completed_artifact_deletes_persisted_prepare_result(self) -> None:
-        """delete_prepared called on completion regardless of resume status.
+            @override
+            def enrich_execution_context(
+                self, context: ExecutionContext
+            ) -> ExecutionContext:
+                return replace(context, model_name=self.model_name)
+
+        dispatch_result = ModelNameResult(
+            request_id=request.request_id,
+            model_name="claude-sonnet-4-5-20250929",
+        )
+
+        processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(state=StubState(), requests=[request]),
+            finalise_results=[final_message],
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        dispatcher = create_mock_dispatcher([dispatch_result])
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="dist_proc", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "findings": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "dist_proc": create_distributed_processor_factory(
+                    "dist_proc", processor
+                ),
+            },
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        store = registry.container.get_service(ArtifactStore)
+        stored = await store.get_artifact(exec_result.run_id, "findings")
+        assert stored.execution_model_name == "claude-sonnet-4-5-20250929"
+
+    async def test_completed_artifact_deletes_persisted_prepare_result(
+        self,
+    ) -> None:
+        """delete_prepared called on completion.
 
         Arrange: distributed processor completing via finalise().
         Assert: store.delete_prepared() called for the artifact.
-        (No-op for non-resumed artifacts; cleanup for resumed ones.)
         """
-        pass
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        final_message = create_test_message(
+            {"findings": ["cleanup"]}, schema=output_schema
+        )
+
+        request = DispatchRequest(name="cleanup_req")
+        dispatch_result = DispatchResult(request_id=request.request_id)
+
+        processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(state=StubState(), requests=[request]),
+            finalise_results=[final_message],
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        dispatcher = create_mock_dispatcher([dispatch_result])
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="dist_proc", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "findings": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "dist_proc": create_distributed_processor_factory(
+                    "dist_proc", processor
+                ),
+            },
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+        assert "findings" in exec_result.completed
+
+        # Verify prepared state was cleaned up (should not exist)
+        store = registry.container.get_service(ArtifactStore)
+        assert not await store.prepared_exists(exec_result.run_id, "findings")
 
 
 # =============================================================================
-# Multi-Round Tests
+# Multi-Round
 # =============================================================================
 
 
 class TestMultiRoundDispatch:
-    """Tests for multi-round dispatch loop in DAGExecutor.
+    """Tests for multi-round dispatch-finalise cycles."""
 
-    Verified end-to-end: multi-round behaviour is observable through
-    the number of dispatch calls and the final execution result.
-    """
-
-    async def test_prepare_result_triggers_another_dispatch_round(self) -> None:
+    async def test_multi_round_finalise_dispatches_again(self) -> None:
         """finalise() returning PrepareResult triggers another dispatch-finalise cycle.
 
         Arrange: distributed processor whose finalise() returns a
@@ -93,14 +273,152 @@ class TestMultiRoundDispatch:
         Assert: dispatcher.dispatch() called twice (once per round).
         Final artifact content matches the second finalise() Message.
         """
-        pass
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        final_message = create_test_message(
+            {"findings": ["round_2"]}, schema=output_schema
+        )
+
+        # Round 1 request/result
+        req1 = DispatchRequest(name="round_1")
+        res1 = DispatchResult(request_id=req1.request_id)
+
+        # Round 2 request/result
+        req2 = DispatchRequest(name="round_2")
+        res2 = DispatchResult(request_id=req2.request_id)
+
+        # Processor that needs two rounds
+        round2_prepare = PrepareResult(
+            state=StubState(value="round_2"), requests=[req2]
+        )
+        processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(
+                state=StubState(value="round_1"), requests=[req1]
+            ),
+            finalise_results=[round2_prepare, final_message],
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        # Dispatcher returns the right result for each call
+        dispatcher = create_mock_dispatcher([])
+        dispatcher.dispatch = AsyncMock(side_effect=[[res1], [res2]])
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="dist_proc", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "findings": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "dist_proc": create_distributed_processor_factory(
+                    "dist_proc", processor
+                ),
+            },
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        assert "findings" in exec_result.completed
+        assert dispatcher.dispatch.call_count == 2
+        assert processor.call_log == ["prepare", "finalise", "finalise"]
+
+        store = registry.container.get_service(ArtifactStore)
+        stored = await store.get_artifact(exec_result.run_id, "findings")
+        assert stored.content == final_message.content
 
     async def test_max_rounds_exceeded_fails_artifact(self) -> None:
         """Exceeding max rounds marks the artifact as failed.
 
         Arrange: distributed processor whose finalise() always returns
         a PrepareResult (never completes).
-        Assert: artifact marked failed after 3 rounds (default limit).
-        Dependents are skipped. Run status reflects the failure.
+        Assert: artifact marked failed. Dependents are skipped.
         """
-        pass
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+
+        # Processor that always returns another PrepareResult.
+        # Each round: dispatch req_N → get res_N → finalise returns PrepareResult with req_N+1
+        requests = [DispatchRequest(name=f"round_{i}") for i in range(4)]
+        results = [DispatchResult(request_id=r.request_id) for r in requests]
+
+        # finalise_results[0] is returned after round 0 dispatch → uses req_1
+        # finalise_results[1] is returned after round 1 dispatch → uses req_2
+        # finalise_results[2] is returned after round 2 dispatch → uses req_3
+        infinite_prepares = [
+            PrepareResult(
+                state=StubState(value=f"round_{i + 1}"),
+                requests=[requests[i + 1]],
+            )
+            for i in range(3)
+        ]
+        processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(
+                state=StubState(value="initial"), requests=[requests[0]]
+            ),
+            finalise_results=infinite_prepares,
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        # Each dispatch call returns the result matching that round's request
+        dispatcher = create_mock_dispatcher([])
+        dispatcher.dispatch = AsyncMock(side_effect=[[results[i]] for i in range(4)])
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="dist_proc", properties={}),
+            ),
+            "dependent": ArtifactDefinition(inputs="findings"),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "findings": ([source_schema], output_schema),
+                "dependent": ([output_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "dist_proc": create_distributed_processor_factory(
+                    "dist_proc", processor
+                ),
+            },
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        assert "findings" in exec_result.failed
+        assert "dependent" in exec_result.skipped
+        # Dispatch called max_rounds times (default 3)
+        assert dispatcher.dispatch.call_count == 3

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_finalise.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_finalise.py
@@ -114,6 +114,8 @@ class TestDistributedArtifactMetadata:
         assert stored.extensions is not None
         assert stored.extensions.execution is not None
         assert stored.extensions.execution.status == "success"
+        assert stored.extensions.execution.duration_seconds is not None
+        assert stored.extensions.execution.duration_seconds >= 0
 
     async def test_model_name_flows_from_dispatch_result(self) -> None:
         """enrich_execution_context propagates model_name to saved artifact.

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_helpers.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_helpers.py
@@ -1,14 +1,17 @@
 """Shared test helpers for waivern-orchestration tests."""
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Literal
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import yaml
+from pydantic import BaseModel
 from waivern_artifact_store.base import ArtifactStore
 from waivern_artifact_store.configuration import ArtifactStoreConfiguration
 from waivern_artifact_store.factory import ArtifactStoreFactory
 from waivern_core import ExecutionContext, Message, MessageExtensions
+from waivern_core.dispatch import DispatchResult, PrepareResult
 from waivern_core.schemas import Schema
 from waivern_core.services import ComponentRegistry, ServiceContainer, ServiceDescriptor
 
@@ -95,7 +98,9 @@ def create_mock_processor_factory(
     factory.component_class = mock_class
 
     if process_result is not None:
-        mock_processor = MagicMock()
+        # Use spec to limit mock to only 'process' — prevents matching
+        # DistributedProcessor's runtime_checkable isinstance check
+        mock_processor = MagicMock(spec=["process"])
         mock_processor.process.return_value = process_result
         factory.create.return_value = mock_processor
 
@@ -276,3 +281,110 @@ def write_runbook(path: Path, runbook: dict[str, object]) -> None:
 
     """
     path.write_text(yaml.dump(runbook))
+
+
+# =============================================================================
+# Distributed Processor Helpers
+# =============================================================================
+
+
+class StubState(BaseModel):
+    """Minimal Pydantic state model for distributed processor tests."""
+
+    value: str = "test_state"
+
+
+class StubDistributedProcessor:
+    """Stub implementing DistributedProcessor for tests.
+
+    Uses concrete methods instead of MagicMock to correctly satisfy
+    the ``@runtime_checkable`` isinstance check for DistributedProcessor.
+    Call tracking is done via ``call_log`` list.
+
+    Args:
+        prepare_result: The PrepareResult to return from prepare().
+        finalise_results: Sequence of results to return from successive
+            finalise() calls. If a single item, it's returned every time.
+
+    """
+
+    def __init__(
+        self,
+        prepare_result: PrepareResult[StubState],
+        finalise_results: Sequence[Message | PrepareResult[StubState]],
+    ) -> None:
+        self.prepare_result = prepare_result
+        self.finalise_results = list(finalise_results)
+        self._finalise_call_count = 0
+        self.call_log: list[str] = []
+
+    def prepare(
+        self, inputs: list[Message], output_schema: Schema
+    ) -> PrepareResult[StubState]:
+        self.call_log.append("prepare")
+        return self.prepare_result
+
+    def deserialise_prepare_result(
+        self, raw: dict[str, Any]
+    ) -> PrepareResult[StubState]:
+        self.call_log.append("deserialise_prepare_result")
+        return PrepareResult[StubState].model_validate(raw)
+
+    def finalise(
+        self,
+        state: StubState,
+        results: Sequence[DispatchResult],
+        output_schema: Schema,
+    ) -> Message | PrepareResult[StubState]:
+        self.call_log.append("finalise")
+        idx = min(self._finalise_call_count, len(self.finalise_results) - 1)
+        self._finalise_call_count += 1
+        return self.finalise_results[idx]
+
+
+def create_distributed_processor_factory(
+    name: str,
+    processor: StubDistributedProcessor,
+) -> MagicMock:
+    """Create a mock factory that returns a StubDistributedProcessor.
+
+    The factory mock has a component_class with the expected class methods,
+    and create() returns the real StubDistributedProcessor instance.
+
+    Args:
+        name: Component name (e.g., "distributed_analyser").
+        processor: The StubDistributedProcessor instance to return.
+
+    Returns:
+        Mock ComponentFactory whose create() returns the given processor.
+
+    """
+    factory = MagicMock()
+    mock_class = MagicMock()
+    mock_class.get_name.return_value = name
+    factory.component_class = mock_class
+    factory.create.return_value = processor
+    return factory
+
+
+def create_mock_dispatcher(
+    results: Sequence[DispatchResult],
+    *,
+    side_effect: BaseException | None = None,
+) -> MagicMock:
+    """Create a mock RequestDispatcher.
+
+    Args:
+        results: Results to return from dispatch(). Ignored if side_effect is set.
+        side_effect: If set, dispatch() raises this exception.
+
+    Returns:
+        Mock dispatcher with an async dispatch() method.
+
+    """
+    dispatcher = MagicMock()
+    if side_effect is not None:
+        dispatcher.dispatch = AsyncMock(side_effect=side_effect)
+    else:
+        dispatcher.dispatch = AsyncMock(return_value=results)
+    return dispatcher


### PR DESCRIPTION
## Summary

- Modify `_execute_dag` to classify artifacts into regular, distributed, and resuming groups, then route distributed processors through prepare → dispatch → finalise alongside regular artifacts
- Add `enrich_execution_context` polymorphic method to `DispatchResult` for dispatch-specific metadata propagation (e.g., `LLMDispatchResult` sets `model_name`)
- Add `SerializeAsAny` on `PrepareResult.requests` and `deserialise_prepare_result` to `DistributedProcessor` protocol for correct serialisation round-trip on resume
- Remove legacy `PendingProcessingError` handling from `_handle_artifact_result` and `_produce` — regular processors are synchronous post-migration
- Add multi-round dispatch-finalise loop with max round guard (default 3)

## Key design decisions

- **Nested `asyncio.gather`** for regular and prepare task groups — type-safe result separation without slice-and-cast
- **Unknown processor types** fall back to regular path for proper error messaging via `_produce`
- **`spec=['process']`** on processor mocks prevents `MagicMock` from matching `@runtime_checkable` `DistributedProcessor` protocol

## Test plan

- [x] 14 new end-to-end tests: happy path, dispatch grouping, result routing, error isolation, resume, metadata, model_name flow, cleanup, multi-round, max rounds
- [x] 3 rewritten batch tests reflecting post-migration behaviour (PendingProcessingError treated as failure on regular path)
- [x] All existing executor tests pass with mock spec fix
- [x] `./scripts/dev-checks.sh` passes (formatting, linting, type checking, 1991 tests)