### PR TITLE
feat(iso27001): convert ISO27001Assessor to dual protocol

### DIFF
--- a/libs/waivern-iso27001-control-assessor/src/waivern_iso27001_control_assessor/analyser.py
+++ b/libs/waivern-iso27001-control-assessor/src/waivern_iso27001_control_assessor/analyser.py
@@ -1,14 +1,16 @@
 """ISO 27001 control assessor."""
 
-import asyncio
 import logging
-from typing import override
+from collections.abc import Sequence
+from typing import Any, override
 
 from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core import Analyser, InputRequirement
+from waivern_core.dispatch import DispatchRequest, DispatchResult, PrepareResult
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
-from waivern_llm import BatchingMode, ItemGroup, LLMService, PendingBatchError
+from waivern_llm import BatchingMode, ItemGroup, LLMService
+from waivern_llm.types import LLMDispatchResult, LLMRequest
 from waivern_rulesets.iso27001_domains import ISO27001DomainsRule
 from waivern_schemas.iso27001_assessment import (
     AssessmentVerdict,
@@ -21,7 +23,7 @@ from waivern_schemas.security_evidence import SecurityEvidenceModel
 from .prompts.prompt_builder import ControlContext, ISO27001PromptBuilder
 from .prompts.response_model import ISO27001LLMResponse
 from .result_builder import ISO27001ResultBuilder
-from .types import ISO27001AssessorConfig
+from .types import ISO27001AssessorConfig, ISO27001PrepareState
 
 logger = logging.getLogger(__name__)
 
@@ -42,13 +44,14 @@ class ISO27001Assessor(Analyser):
     def __init__(
         self,
         config: ISO27001AssessorConfig,
-        llm_service: LLMService,
+        llm_service: LLMService | None = None,
     ) -> None:
         """Initialise the assessor with dependency injection.
 
         Args:
             config: Validated configuration with control_ref and ruleset URI.
-            llm_service: LLM service for assessment verdicts.
+            llm_service: LLM service for standalone ``process()`` fallback.
+                Pass ``None`` for LLM-disabled mode (degraded output only).
 
         """
         self._config = config
@@ -88,57 +91,103 @@ class ISO27001Assessor(Analyser):
         """Declare output schemas this assessor can produce."""
         return [Schema("iso27001_assessment", "1.0.0")]
 
-    @override
-    def process(
-        self,
-        inputs: list[Message],
-        output_schema: Schema,
-    ) -> Message:
-        """Assess a single ISO 27001 control against provided evidence.
+    # ── DistributedProcessor ────────���────────────────────────────────────
 
-        Orchestrates the complete assessment flow:
-        1. Load matching rule from iso27001_domains ruleset
-        2. Partition inputs by schema and extract findings
-        3. Filter evidence by security_domains and evidence_source
-        4. Derive evidence_status (may short-circuit without LLM)
-        5. Call LLM with filtered evidence and document context
-        6. Parse LLM response into structured assessment verdict
+    def prepare(
+        self, inputs: list[Message], output_schema: Schema
+    ) -> PrepareResult[ISO27001PrepareState]:
+        """Analyse inputs and declare LLM dispatch needs.
 
-        Args:
-            inputs: Input messages (security_evidence and/or document_context).
-            output_schema: Expected output schema (iso27001_assessment/1.0.0).
-
-        Returns:
-            Output message with ISO27001AssessmentModel findings.
+        1. Validate inputs and extract run_id
+        2. Load matching rule and filter evidence by domain/evidence_source
+        3. Derive evidence_status from filtered evidence
+        4. If AUTOMATED and LLM enabled, build LLMRequest; otherwise empty requests
 
         """
+        if not inputs:
+            raise ValueError("No input messages provided")
+        run_id = inputs[0].run_id
+        if not run_id:
+            raise ValueError(
+                f"Missing run_id on input for control '{self._config.control_ref}'"
+            )
+
         rule = self._load_rule()
         evidence, documents = self._partition_and_filter(inputs, rule)
         evidence_status = self._derive_evidence_status(rule, evidence, documents)
+        llm_enabled = self._llm_service is not None
 
-        match evidence_status:
-            case EvidenceStatus.REQUIRES_ATTESTATION:
-                return self._result_builder.build_output_message(
-                    rule,
-                    verdict=AssessmentVerdict(
-                        status=ControlStatus.NOT_ASSESSED,
-                        evidence_status=evidence_status,
-                        rationale=(
-                            "Awaiting document evidence. This control requires "
-                            "human-produced documentation (e.g. policy, procedure, "
-                            "inspection report) that has not yet been provided."
-                        ),
-                        gap_description=None,
-                    ),
-                    llm_enabled=False,
-                    output_schema=output_schema,
+        requests: list[DispatchRequest] = []
+        if evidence_status == EvidenceStatus.AUTOMATED and llm_enabled:
+            requests.append(self._build_llm_request(rule, evidence, documents, run_id))
+
+        return PrepareResult(
+            state=ISO27001PrepareState(
+                rule=rule,
+                evidence_status=evidence_status,
+                evidence=evidence,
+                documents=documents,
+                run_id=run_id,
+                llm_enabled=llm_enabled,
+            ),
+            requests=requests,
+        )
+
+    def _build_llm_request(
+        self,
+        rule: ISO27001DomainsRule,
+        evidence: list[SecurityEvidenceModel],
+        documents: list[SecurityDocumentContextModel],
+        run_id: str,
+    ) -> LLMRequest[SecurityEvidenceModel]:
+        """Build an LLMRequest for automated assessment."""
+        doc_content = self._format_document_content(documents)
+        control = ControlContext(
+            guidance_text=rule.guidance_text,
+            control_type=rule.control_type,
+            cia=list(rule.cia),
+            cybersecurity_concept=rule.cybersecurity_concept,
+            operational_capability=rule.operational_capability,
+            iso_security_domain=rule.iso_security_domain,
+        )
+
+        return LLMRequest(
+            name=f"assessment:{rule.control_ref}",
+            groups=[
+                ItemGroup(
+                    items=evidence,
+                    content=doc_content,
+                    group_id=rule.control_ref,
                 )
+            ],
+            prompt_builder=ISO27001PromptBuilder(control),
+            response_model=ISO27001LLMResponse,
+            batching_mode=BatchingMode.INDEPENDENT,
+            run_id=run_id,
+        )
+
+    def finalise(
+        self,
+        state: ISO27001PrepareState,
+        results: Sequence[DispatchResult],
+        output_schema: Schema,
+    ) -> Message:
+        """Produce assessment verdict from state and dispatch results.
+
+        1. Short-circuit paths (empty results): build NOT_ASSESSED from evidence_status
+        2. AUTOMATED + LLM result: parse response and build verdict
+        3. AUTOMATED + empty LLM responses: evidence exceeded context window
+
+        """
+        rule = state.rule
+
+        match state.evidence_status:
             case EvidenceStatus.INSUFFICIENT_EVIDENCE:
                 return self._result_builder.build_output_message(
                     rule,
                     verdict=AssessmentVerdict(
                         status=ControlStatus.NOT_ASSESSED,
-                        evidence_status=evidence_status,
+                        evidence_status=state.evidence_status,
                         rationale=(
                             "No relevant evidence found. Neither technical findings "
                             "nor document context matched this control's security "
@@ -149,21 +198,139 @@ class ISO27001Assessor(Analyser):
                     llm_enabled=False,
                     output_schema=output_schema,
                 )
-            case EvidenceStatus.AUTOMATED:
-                return self._assess_with_llm(
-                    rule, evidence, documents, inputs, output_schema
+            case EvidenceStatus.REQUIRES_ATTESTATION:
+                return self._result_builder.build_output_message(
+                    rule,
+                    verdict=AssessmentVerdict(
+                        status=ControlStatus.NOT_ASSESSED,
+                        evidence_status=state.evidence_status,
+                        rationale=(
+                            "Awaiting document evidence. This control requires "
+                            "human-produced documentation (e.g. policy, procedure, "
+                            "inspection report) that has not yet been provided."
+                        ),
+                        gap_description=None,
+                    ),
+                    llm_enabled=False,
+                    output_schema=output_schema,
                 )
+            case EvidenceStatus.AUTOMATED if not state.llm_enabled:
+                return self._result_builder.build_output_message(
+                    rule,
+                    verdict=AssessmentVerdict(
+                        status=ControlStatus.NOT_ASSESSED,
+                        evidence_status=state.evidence_status,
+                        rationale=(
+                            "LLM assessment not available. Evidence was sufficient "
+                            "for automated assessment but LLM service is not "
+                            "configured."
+                        ),
+                        gap_description=None,
+                    ),
+                    llm_enabled=False,
+                    output_schema=output_schema,
+                )
+            case EvidenceStatus.AUTOMATED:
+                return self._finalise_llm_result(rule, results, output_schema)
 
-    def _load_rule(self) -> ISO27001DomainsRule:
-        """Load the matching rule from the iso27001_domains ruleset.
+    def _finalise_llm_result(
+        self,
+        rule: ISO27001DomainsRule,
+        results: Sequence[DispatchResult],
+        output_schema: Schema,
+    ) -> Message:
+        """Interpret LLM dispatch results into an assessment verdict."""
+        for result in results:
+            match result:
+                case LLMDispatchResult() as llm_result:
+                    if not llm_result.responses:
+                        return self._result_builder.build_output_message(
+                            rule,
+                            verdict=AssessmentVerdict(
+                                status=ControlStatus.NOT_ASSESSED,
+                                evidence_status=EvidenceStatus.AUTOMATED,
+                                rationale=(
+                                    "LLM assessment skipped — evidence "
+                                    "exceeded context window."
+                                ),
+                                gap_description=None,
+                            ),
+                            llm_enabled=False,
+                            output_schema=output_schema,
+                        )
 
-        Returns:
-            The rule matching config.control_ref.
+                    llm_response = ISO27001LLMResponse.model_validate(
+                        llm_result.responses[0]
+                    )
+                    return self._result_builder.build_output_message(
+                        rule,
+                        verdict=AssessmentVerdict(
+                            status=ControlStatus(llm_response.status),
+                            evidence_status=EvidenceStatus.AUTOMATED,
+                            rationale=llm_response.rationale,
+                            gap_description=llm_response.gap_description,
+                            recommended_actions=llm_response.recommended_actions,
+                        ),
+                        llm_enabled=True,
+                        output_schema=output_schema,
+                    )
+                case _:
+                    continue
 
-        Raises:
-            ValueError: If no rule matches the configured control_ref.
+        # No LLMDispatchResult found — unexpected but handle gracefully
+        return self._result_builder.build_output_message(
+            rule,
+            verdict=AssessmentVerdict(
+                status=ControlStatus.NOT_ASSESSED,
+                evidence_status=EvidenceStatus.AUTOMATED,
+                rationale="No LLM dispatch result received.",
+                gap_description=None,
+            ),
+            llm_enabled=False,
+            output_schema=output_schema,
+        )
+
+    def deserialise_prepare_result(
+        self, raw: dict[str, Any]
+    ) -> PrepareResult[ISO27001PrepareState]:
+        """Reconstruct a typed PrepareResult from a raw dict.
+
+        Called on the resume path where a persisted PrepareResult must be
+        restored. Handles LLMRequest reconstruction with correct field types.
 
         """
+        state = ISO27001PrepareState.model_validate(raw["state"])
+        requests: list[DispatchRequest] = [
+            LLMRequest[SecurityEvidenceModel].model_validate(r)
+            for r in raw.get("requests", [])
+        ]
+        return PrepareResult(state=state, requests=requests)
+
+    # ── Processor (standalone fallback) ──────────────────────────────────
+
+    @override
+    def process(
+        self,
+        inputs: list[Message],
+        output_schema: Schema,
+    ) -> Message:
+        """Standalone fallback producing degraded (LLM-disabled) output.
+
+        Delegates to prepare/finalise with LLM forced off. In the executor,
+        the DistributedProcessor path is always used instead. This method
+        exists to satisfy the Processor abstract contract.
+
+        """
+        prepare_result = self.prepare(inputs, output_schema)
+        state = prepare_result.state.model_copy(update={"llm_enabled": False})
+        result = self.finalise(state, [], output_schema)
+        # finalise() with llm_enabled=False always returns Message (no multi-round)
+        return result  # pyright: ignore[reportReturnType]
+
+    # ── Private helpers ─────────────────────────────────────────────────
+
+    def _load_rule(self) -> ISO27001DomainsRule:
+        """Load the matching rule from the iso27001_domains ruleset."""
         ruleset = RulesetManager.get_ruleset(
             self._config.domain_ruleset, ISO27001DomainsRule
         )
@@ -187,13 +354,6 @@ class ISO27001Assessor(Analyser):
         3. Filter security_evidence by domain intersection
         4. Apply evidence_source filter (drop technical if not accepted, etc.)
         5. Filter document_context by domain intersection (cross-cutting always pass)
-
-        Args:
-            inputs: Raw input messages.
-            rule: The matched ISO 27001 rule for filtering.
-
-        Returns:
-            Tuple of (filtered_evidence, filtered_documents).
 
         """
         raw_evidence: list[SecurityEvidenceModel] = []
@@ -249,14 +409,6 @@ class ISO27001Assessor(Analyser):
         3. No evidence and no documents → insufficient_evidence
         4. Otherwise → automated
 
-        Args:
-            rule: The matched ISO 27001 rule.
-            evidence: Filtered security evidence items.
-            documents: Filtered document context items.
-
-        Returns:
-            The derived EvidenceStatus.
-
         """
         if rule.evidence_required:
             has_technical = len(evidence) > 0
@@ -273,109 +425,6 @@ class ISO27001Assessor(Analyser):
             return EvidenceStatus.INSUFFICIENT_EVIDENCE
 
         return EvidenceStatus.AUTOMATED
-
-    def _assess_with_llm(
-        self,
-        rule: ISO27001DomainsRule,
-        evidence: list[SecurityEvidenceModel],
-        documents: list[SecurityDocumentContextModel],
-        inputs: list[Message],
-        output_schema: Schema,
-    ) -> Message:
-        """Assess a control using the LLM service.
-
-        Orchestrates the LLM assessment flow:
-        1. Format document content and create prompt builder
-        2. Call LLMService.complete() via asyncio.run()
-        3. Parse response into assessment output
-        4. On failure, fall back to not_assessed
-
-        Args:
-            rule: The matched ISO 27001 rule.
-            evidence: Filtered security evidence items.
-            documents: Filtered document context items.
-            inputs: Original input messages (for run_id extraction).
-            output_schema: Schema for output validation.
-
-        Returns:
-            Validated output message with LLM-assessed verdict.
-
-        """
-        try:
-            doc_content = self._format_document_content(documents)
-            control = ControlContext(
-                guidance_text=rule.guidance_text,
-                control_type=rule.control_type,
-                cia=list(rule.cia),
-                cybersecurity_concept=rule.cybersecurity_concept,
-                operational_capability=rule.operational_capability,
-                iso_security_domain=rule.iso_security_domain,
-            )
-            prompt_builder = ISO27001PromptBuilder(control)
-
-            groups = [
-                ItemGroup(
-                    items=evidence,
-                    content=doc_content,
-                    group_id=rule.control_ref,
-                )
-            ]
-            run_id = inputs[0].run_id if inputs else "unknown"
-
-            result = asyncio.run(
-                self._llm_service.complete(
-                    groups,
-                    prompt_builder=prompt_builder,
-                    response_model=ISO27001LLMResponse,
-                    batching_mode=BatchingMode.INDEPENDENT,
-                    run_id=run_id or "unknown",
-                )
-            )
-
-            if not result.responses:
-                return self._result_builder.build_output_message(
-                    rule,
-                    verdict=AssessmentVerdict(
-                        status=ControlStatus.NOT_ASSESSED,
-                        evidence_status=EvidenceStatus.AUTOMATED,
-                        rationale="LLM assessment skipped — evidence exceeded context window.",
-                        gap_description=None,
-                    ),
-                    llm_enabled=False,
-                    output_schema=output_schema,
-                )
-
-            llm_response = result.responses[0]
-            return self._result_builder.build_output_message(
-                rule,
-                verdict=AssessmentVerdict(
-                    status=ControlStatus(llm_response.status),
-                    evidence_status=EvidenceStatus.AUTOMATED,
-                    rationale=llm_response.rationale,
-                    gap_description=llm_response.gap_description,
-                    recommended_actions=llm_response.recommended_actions,
-                ),
-                llm_enabled=True,
-                output_schema=output_schema,
-            )
-
-        except PendingBatchError:
-            raise
-        except Exception as e:
-            logger.error(
-                f"ISO27001Assessor [{rule.control_ref}]: LLM assessment failed: {e}"
-            )
-            return self._result_builder.build_output_message(
-                rule,
-                verdict=AssessmentVerdict(
-                    status=ControlStatus.NOT_ASSESSED,
-                    evidence_status=EvidenceStatus.AUTOMATED,
-                    rationale=f"LLM assessment failed: {e}",
-                    gap_description=None,
-                ),
-                llm_enabled=False,
-                output_schema=output_schema,
-            )
 
     def _format_document_content(
         self,

--- a/libs/waivern-iso27001-control-assessor/src/waivern_iso27001_control_assessor/types.py
+++ b/libs/waivern-iso27001-control-assessor/src/waivern_iso27001_control_assessor/types.py
@@ -1,7 +1,11 @@
-"""Configuration types for ISO 27001 control assessor."""
+"""Configuration and state types for ISO 27001 control assessor."""
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 from waivern_core import BaseComponentConfiguration
+from waivern_rulesets.iso27001_domains import ISO27001DomainsRule
+from waivern_schemas.iso27001_assessment import EvidenceStatus
+from waivern_schemas.security_document_context import SecurityDocumentContextModel
+from waivern_schemas.security_evidence import SecurityEvidenceModel
 
 
 class ISO27001AssessorConfig(BaseComponentConfiguration):
@@ -25,3 +29,19 @@ class ISO27001AssessorConfig(BaseComponentConfiguration):
         min_length=1,
         description="ISO 27001:2022 Annex A control reference (e.g. 'A.5.1')",
     )
+
+
+class ISO27001PrepareState(BaseModel):
+    """Intermediate state for the distributed processor prepare/finalise split.
+
+    Captures everything ``finalise()`` needs to produce the output message
+    after dispatch results arrive. The executor treats this as opaque and
+    persists it for batch-mode resume.
+    """
+
+    rule: ISO27001DomainsRule
+    evidence_status: EvidenceStatus
+    evidence: list[SecurityEvidenceModel]
+    documents: list[SecurityDocumentContextModel]
+    run_id: str
+    llm_enabled: bool

--- a/libs/waivern-iso27001-control-assessor/tests/waivern_iso27001_control_assessor/test_distributed.py
+++ b/libs/waivern-iso27001-control-assessor/tests/waivern_iso27001_control_assessor/test_distributed.py
@@ -1,0 +1,334 @@
+"""Tests for ISO27001Assessor DistributedProcessor implementation.
+
+Verifies the prepare/finalise/deserialise contract:
+- prepare() classifies evidence and builds LLMRequest when appropriate
+- finalise() interprets dispatch results into assessment verdicts
+- deserialise_prepare_result() round-trips through JSON serialisation
+"""
+
+from unittest.mock import Mock
+
+from waivern_llm import LLMService
+from waivern_llm.types import BatchingMode, LLMDispatchResult, LLMRequest
+from waivern_schemas.iso27001_assessment import (
+    ControlStatus,
+    EvidenceStatus,
+)
+
+from waivern_iso27001_control_assessor import ISO27001Assessor
+from waivern_iso27001_control_assessor.prompts.prompt_builder import (
+    ISO27001PromptBuilder,
+)
+from waivern_iso27001_control_assessor.prompts.response_model import (
+    ISO27001LLMResponse,
+)
+from waivern_iso27001_control_assessor.types import ISO27001AssessorConfig
+
+from .test_helpers import (
+    OUTPUT_SCHEMA,
+    make_evidence_finding,
+    make_evidence_message,
+    parse_output,
+)
+
+
+def _make_assessor(
+    control_ref: str,
+    *,
+    llm_service: LLMService | None = None,
+) -> ISO27001Assessor:
+    """Build an assessor with optional LLM service.
+
+    Args:
+        control_ref: ISO 27001 control reference (e.g. "A.8.24").
+        llm_service: LLM service instance. Pass None for LLM-disabled mode.
+            Defaults to a mock LLMService (LLM enabled).
+
+    """
+    config = ISO27001AssessorConfig.from_properties({"control_ref": control_ref})
+    if llm_service is None:
+        llm_service = Mock(spec=LLMService)
+    return ISO27001Assessor(config=config, llm_service=llm_service)
+
+
+def _make_assessor_without_llm(control_ref: str) -> ISO27001Assessor:
+    """Build an assessor with LLM disabled (llm_service=None)."""
+    config = ISO27001AssessorConfig.from_properties({"control_ref": control_ref})
+    return ISO27001Assessor(config=config, llm_service=None)
+
+
+# =============================================================================
+# Prepare
+# =============================================================================
+
+
+class TestPrepare:
+    """Tests for prepare() — evidence classification and request building."""
+
+    def test_no_evidence_returns_empty_requests(self) -> None:
+        """Empty findings → empty requests, evidence_status=INSUFFICIENT_EVIDENCE."""
+        assessor = _make_assessor("A.8.24")
+        evidence_msg = make_evidence_message([])
+
+        result = assessor.prepare(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
+
+        assert result.requests == []
+        assert result.state.evidence_status == EvidenceStatus.INSUFFICIENT_EVIDENCE
+
+    def test_requires_attestation_returns_empty_requests(self) -> None:
+        """evidence_required gate fails → empty requests, REQUIRES_ATTESTATION.
+
+        A.5.15 has evidence_required=[DOCUMENT]. Providing only technical
+        evidence fails the gate.
+        """
+        assessor = _make_assessor("A.5.15")
+        evidence_msg = make_evidence_message(
+            [make_evidence_finding(security_domain="access_control")]
+        )
+
+        result = assessor.prepare(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
+
+        assert result.requests == []
+        assert result.state.evidence_status == EvidenceStatus.REQUIRES_ATTESTATION
+
+    def test_automated_with_llm_builds_llm_request(self) -> None:
+        """Matching evidence + LLM enabled → LLMRequest with correct properties.
+
+        A.8.24 (cryptography) has security_domains=[encryption].
+        Providing matching evidence should produce an LLMRequest with
+        INDEPENDENT batching and the ISO27001PromptBuilder.
+        """
+        assessor = _make_assessor("A.8.24")
+        evidence_msg = make_evidence_message(
+            [make_evidence_finding(security_domain="encryption")]
+        )
+
+        result = assessor.prepare(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
+
+        assert len(result.requests) == 1
+        assert result.state.evidence_status == EvidenceStatus.AUTOMATED
+        assert result.state.llm_enabled is True
+
+        llm_request = result.requests[0]
+        assert isinstance(llm_request, LLMRequest)
+        assert llm_request.batching_mode == BatchingMode.INDEPENDENT
+        assert isinstance(llm_request.prompt_builder, ISO27001PromptBuilder)
+        assert llm_request.response_model is ISO27001LLMResponse
+        assert len(llm_request.groups) == 1
+        assert llm_request.groups[0].group_id == "A.8.24"
+
+    def test_automated_without_llm_returns_empty_requests(self) -> None:
+        """Matching evidence + LLM disabled → empty requests, llm_enabled=False.
+
+        Even though evidence is sufficient for automated assessment,
+        the absence of LLM service means no dispatch request is built.
+        """
+        assessor = _make_assessor_without_llm("A.8.24")
+        evidence_msg = make_evidence_message(
+            [make_evidence_finding(security_domain="encryption")]
+        )
+
+        result = assessor.prepare(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
+
+        assert result.requests == []
+        assert result.state.evidence_status == EvidenceStatus.AUTOMATED
+        assert result.state.llm_enabled is False
+
+
+# =============================================================================
+# Finalise
+# =============================================================================
+
+
+class TestFinalise:
+    """Tests for finalise() — verdict production from state and results."""
+
+    def test_insufficient_evidence_produces_not_assessed(self) -> None:
+        """INSUFFICIENT_EVIDENCE state → NOT_ASSESSED with correct rationale."""
+        assessor = _make_assessor("A.8.24")
+        evidence_msg = make_evidence_message([])
+
+        prepare_result = assessor.prepare(
+            inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA
+        )
+        result = assessor.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+
+        output = parse_output(result)
+        finding = output.findings[0]
+        assert finding.status == ControlStatus.NOT_ASSESSED
+        assert finding.evidence_status == EvidenceStatus.INSUFFICIENT_EVIDENCE
+        assert "No relevant evidence found" in finding.rationale
+
+    def test_requires_attestation_produces_not_assessed(self) -> None:
+        """REQUIRES_ATTESTATION state → NOT_ASSESSED with attestation rationale.
+
+        A.5.15 has evidence_required=[DOCUMENT]. Providing only technical
+        evidence fails the gate.
+        """
+        assessor = _make_assessor("A.5.15")
+        evidence_msg = make_evidence_message(
+            [make_evidence_finding(security_domain="access_control")]
+        )
+
+        prepare_result = assessor.prepare(
+            inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA
+        )
+        result = assessor.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+
+        output = parse_output(result)
+        finding = output.findings[0]
+        assert finding.status == ControlStatus.NOT_ASSESSED
+        assert finding.evidence_status == EvidenceStatus.REQUIRES_ATTESTATION
+        assert "Awaiting document evidence" in finding.rationale
+
+    def test_automated_without_llm_produces_not_assessed(self) -> None:
+        """AUTOMATED + llm_enabled=False → NOT_ASSESSED with LLM unavailable rationale."""
+        assessor = _make_assessor_without_llm("A.8.24")
+        evidence_msg = make_evidence_message(
+            [make_evidence_finding(security_domain="encryption")]
+        )
+
+        prepare_result = assessor.prepare(
+            inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA
+        )
+        result = assessor.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+
+        output = parse_output(result)
+        finding = output.findings[0]
+        assert finding.status == ControlStatus.NOT_ASSESSED
+        assert finding.evidence_status == EvidenceStatus.AUTOMATED
+        assert "LLM" in finding.rationale
+
+    def test_compliant_llm_result(self) -> None:
+        """AUTOMATED + compliant LLMDispatchResult → COMPLIANT verdict."""
+        assessor = _make_assessor("A.8.24")
+        evidence_msg = make_evidence_message(
+            [make_evidence_finding(security_domain="encryption")]
+        )
+
+        prepare_result = assessor.prepare(
+            inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA
+        )
+        llm_result = LLMDispatchResult(
+            request_id=prepare_result.requests[0].request_id,
+            model_name="claude-sonnet-4-5-20250929",
+            responses=[
+                {
+                    "status": "compliant",
+                    "rationale": "AES-256 encryption is correctly implemented.",
+                    "gap_description": None,
+                    "recommended_actions": [],
+                }
+            ],
+            skipped=[],
+        )
+
+        result = assessor.finalise(prepare_result.state, [llm_result], OUTPUT_SCHEMA)
+
+        output = parse_output(result)
+        finding = output.findings[0]
+        assert finding.status == ControlStatus.COMPLIANT
+        assert finding.evidence_status == EvidenceStatus.AUTOMATED
+        assert finding.gap_description is None
+        assert finding.rationale == "AES-256 encryption is correctly implemented."
+        assert output.summary.compliant_count == 1
+
+    def test_non_compliant_llm_result(self) -> None:
+        """AUTOMATED + non_compliant LLMDispatchResult → NON_COMPLIANT with gap."""
+        assessor = _make_assessor("A.8.24")
+        evidence_msg = make_evidence_message(
+            [make_evidence_finding(security_domain="encryption")]
+        )
+
+        prepare_result = assessor.prepare(
+            inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA
+        )
+        llm_result = LLMDispatchResult(
+            request_id=prepare_result.requests[0].request_id,
+            model_name="claude-sonnet-4-5-20250929",
+            responses=[
+                {
+                    "status": "non_compliant",
+                    "rationale": "MD5 is used for password hashing.",
+                    "gap_description": "Replace MD5 with bcrypt or Argon2.",
+                    "recommended_actions": [
+                        "Replace MD5 password hashing with bcrypt.",
+                        "Update cryptography policy.",
+                    ],
+                }
+            ],
+            skipped=[],
+        )
+
+        result = assessor.finalise(prepare_result.state, [llm_result], OUTPUT_SCHEMA)
+
+        output = parse_output(result)
+        finding = output.findings[0]
+        assert finding.status == ControlStatus.NON_COMPLIANT
+        assert finding.evidence_status == EvidenceStatus.AUTOMATED
+        assert finding.gap_description == "Replace MD5 with bcrypt or Argon2."
+        assert len(finding.recommended_actions) == 2
+        assert output.summary.non_compliant_count == 1
+
+    def test_empty_llm_responses_produces_not_assessed(self) -> None:
+        """AUTOMATED + LLMDispatchResult with no responses → NOT_ASSESSED."""
+        assessor = _make_assessor("A.8.24")
+        evidence_msg = make_evidence_message(
+            [make_evidence_finding(security_domain="encryption")]
+        )
+
+        prepare_result = assessor.prepare(
+            inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA
+        )
+        llm_result = LLMDispatchResult(
+            request_id=prepare_result.requests[0].request_id,
+            model_name="claude-sonnet-4-5-20250929",
+            responses=[],
+            skipped=[],
+        )
+
+        result = assessor.finalise(prepare_result.state, [llm_result], OUTPUT_SCHEMA)
+
+        output = parse_output(result)
+        finding = output.findings[0]
+        assert finding.status == ControlStatus.NOT_ASSESSED
+        assert finding.evidence_status == EvidenceStatus.AUTOMATED
+        assert "exceeded context window" in finding.rationale
+
+
+# =============================================================================
+# Deserialise
+# =============================================================================
+
+
+class TestDeserialise:
+    """Tests for deserialise_prepare_result() round-trip fidelity."""
+
+    def test_round_trip_serialisation(self) -> None:
+        """prepare() → model_dump → deserialise → equivalent state and requests.
+
+        Validates the resume path: the executor persists PrepareResult via
+        model_dump(mode="json") and restores it via deserialise_prepare_result().
+        State fields and request metadata must survive the round-trip.
+        """
+        assessor = _make_assessor("A.8.24")
+        evidence_msg = make_evidence_message(
+            [make_evidence_finding(security_domain="encryption")]
+        )
+
+        original = assessor.prepare(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
+        raw = original.model_dump(mode="json")
+        restored = assessor.deserialise_prepare_result(raw)
+
+        # State fields
+        assert restored.state.rule.control_ref == original.state.rule.control_ref
+        assert restored.state.evidence_status == original.state.evidence_status
+        assert restored.state.llm_enabled == original.state.llm_enabled
+        assert restored.state.run_id == original.state.run_id
+        assert len(restored.state.evidence) == len(original.state.evidence)
+
+        # Request metadata (prompt_builder/response_model are excluded from serialisation)
+        assert len(restored.requests) == len(original.requests)
+        assert restored.requests[0].request_id == original.requests[0].request_id
+        assert restored.requests[0].batching_mode == original.requests[0].batching_mode
+        assert restored.requests[0].run_id == original.requests[0].run_id

--- a/libs/waivern-iso27001-control-assessor/tests/waivern_iso27001_control_assessor/test_helpers.py
+++ b/libs/waivern-iso27001-control-assessor/tests/waivern_iso27001_control_assessor/test_helpers.py
@@ -1,0 +1,92 @@
+"""Shared test helpers for waivern-iso27001-control-assessor tests."""
+
+from waivern_core.message import Message
+from waivern_core.schemas import Schema
+from waivern_schemas.iso27001_assessment import ISO27001AssessmentOutput
+
+RUN_ID = "test-run-001"
+OUTPUT_SCHEMA = Schema("iso27001_assessment", "1.0.0")
+
+
+def make_evidence_message(
+    findings: list[dict[str, object]],
+) -> Message:
+    """Build a security_evidence/1.0.0 Message from finding dicts."""
+    return Message(
+        id="test_evidence",
+        content={
+            "findings": findings,
+            "summary": {
+                "total_findings": len(findings),
+                "domains_identified": 0,
+                "domains": [],
+            },
+            "analysis_metadata": {
+                "ruleset_used": "test",
+                "llm_validation_enabled": False,
+            },
+        },
+        schema=Schema("security_evidence", "1.0.0"),
+        run_id=RUN_ID,
+    )
+
+
+def make_document_message(
+    findings: list[dict[str, object]],
+) -> Message:
+    """Build a security_document_context/1.0.0 Message from finding dicts."""
+    return Message(
+        id="test_document",
+        content={
+            "findings": findings,
+            "summary": {
+                "total_documents": len(findings),
+                "cross_cutting_count": 0,
+                "domain_coverage": [],
+            },
+            "analysis_metadata": {
+                "ruleset_used": "test",
+                "llm_validation_enabled": False,
+            },
+        },
+        schema=Schema("security_document_context", "1.0.0"),
+        run_id=RUN_ID,
+    )
+
+
+def make_evidence_finding(
+    security_domain: str = "encryption",
+    evidence_type: str = "CODE",
+    require_review: bool | None = None,
+) -> dict[str, object]:
+    """Build a minimal SecurityEvidenceModel dict."""
+    return {
+        "id": "ev-1",
+        "metadata": {"source": "test.py"},
+        "evidence_type": evidence_type,
+        "security_domain": security_domain,
+        "polarity": "positive",
+        "confidence": 0.9,
+        "description": "Test evidence",
+        "require_review": require_review,
+    }
+
+
+def make_document_finding(
+    security_domains: list[str] | None = None,
+    filename: str = "policy.md",
+) -> dict[str, object]:
+    """Build a minimal SecurityDocumentContextModel dict."""
+    return {
+        "id": "doc-1",
+        "filename": filename,
+        "content": "Test document content",
+        "summary": "Test document summary",
+        "security_domains": security_domains or [],
+        "metadata": {"source": filename},
+    }
+
+
+def parse_output(result: Message) -> ISO27001AssessmentOutput:
+    """Parse an assessor output Message into the typed model."""
+    return ISO27001AssessmentOutput.model_validate(result.content)

--- a/libs/waivern-iso27001-control-assessor/tests/waivern_iso27001_control_assessor/test_process.py
+++ b/libs/waivern-iso27001-control-assessor/tests/waivern_iso27001_control_assessor/test_process.py
@@ -1,137 +1,37 @@
-"""Tests for ISO27001Assessor.process() — evidence filtering, status derivation, and LLM assessment."""
+"""Tests for ISO27001Assessor.process() — standalone degraded-mode fallback.
 
-from unittest.mock import AsyncMock, Mock
+process() delegates to prepare/finalise with LLM forced off. These tests
+verify the evidence filtering and status derivation logic still works
+correctly through the standalone path.
+"""
 
-from waivern_core.message import Message
-from waivern_core.schemas import Schema
-from waivern_llm import LLMCompletionResult, LLMService
 from waivern_schemas.iso27001_assessment import (
     CIAProperty,
     ControlStatus,
     ControlType,
     CybersecurityConcept,
     EvidenceStatus,
-    ISO27001AssessmentOutput,
     ISOSecurityDomain,
     OperationalCapability,
 )
 
 from waivern_iso27001_control_assessor import ISO27001Assessor
-from waivern_iso27001_control_assessor.prompts.response_model import (
-    ISO27001LLMResponse,
-)
 from waivern_iso27001_control_assessor.types import ISO27001AssessorConfig
 
-OUTPUT_SCHEMA = Schema("iso27001_assessment", "1.0.0")
-
-_DEFAULT_LLM_RESPONSE = ISO27001LLMResponse(
-    status="compliant",
-    rationale="Control is fully implemented.",
-    gap_description=None,
-    recommended_actions=[],
+from .test_helpers import (
+    OUTPUT_SCHEMA,
+    make_document_finding,
+    make_document_message,
+    make_evidence_finding,
+    make_evidence_message,
+    parse_output,
 )
 
 
-def _make_assessor(
-    control_ref: str,
-    llm_response: ISO27001LLMResponse = _DEFAULT_LLM_RESPONSE,
-) -> ISO27001Assessor:
-    """Build an assessor instance with a configured mock LLM.
-
-    The mock LLM returns the given response for any complete() call.
-    Tests that never reach the AUTOMATED path ignore this default.
-    """
+def _make_assessor(control_ref: str) -> ISO27001Assessor:
+    """Build an assessor without LLM service (standalone mode)."""
     config = ISO27001AssessorConfig.from_properties({"control_ref": control_ref})
-    llm_service = Mock(spec=LLMService)
-    llm_service.complete = AsyncMock(
-        return_value=LLMCompletionResult(
-            responses=[llm_response],
-            skipped=[],
-        )
-    )
-    return ISO27001Assessor(config=config, llm_service=llm_service)
-
-
-def _make_evidence_message(
-    findings: list[dict[str, object]],
-) -> Message:
-    """Build a security_evidence/1.0.0 Message from finding dicts."""
-    return Message(
-        id="test_evidence",
-        content={
-            "findings": findings,
-            "summary": {
-                "total_findings": len(findings),
-                "domains_identified": 0,
-                "domains": [],
-            },
-            "analysis_metadata": {
-                "ruleset_used": "test",
-                "llm_validation_enabled": False,
-            },
-        },
-        schema=Schema("security_evidence", "1.0.0"),
-    )
-
-
-def _make_document_message(
-    findings: list[dict[str, object]],
-) -> Message:
-    """Build a security_document_context/1.0.0 Message from finding dicts."""
-    return Message(
-        id="test_document",
-        content={
-            "findings": findings,
-            "summary": {
-                "total_documents": len(findings),
-                "cross_cutting_count": 0,
-                "domain_coverage": [],
-            },
-            "analysis_metadata": {
-                "ruleset_used": "test",
-                "llm_validation_enabled": False,
-            },
-        },
-        schema=Schema("security_document_context", "1.0.0"),
-    )
-
-
-def _make_evidence_finding(
-    security_domain: str = "encryption",
-    evidence_type: str = "CODE",
-    require_review: bool | None = None,
-) -> dict[str, object]:
-    """Build a minimal SecurityEvidenceModel dict."""
-    return {
-        "id": "ev-1",
-        "metadata": {"source": "test.py"},
-        "evidence_type": evidence_type,
-        "security_domain": security_domain,
-        "polarity": "positive",
-        "confidence": 0.9,
-        "description": "Test evidence",
-        "require_review": require_review,
-    }
-
-
-def _make_document_finding(
-    security_domains: list[str] | None = None,
-    filename: str = "policy.md",
-) -> dict[str, object]:
-    """Build a minimal SecurityDocumentContextModel dict."""
-    return {
-        "id": "doc-1",
-        "filename": filename,
-        "content": "Test document content",
-        "summary": "Test document summary",
-        "security_domains": security_domains or [],
-        "metadata": {"source": filename},
-    }
-
-
-def _parse_output(result: Message) -> ISO27001AssessmentOutput:
-    """Parse a process() output Message into the typed model."""
-    return ISO27001AssessmentOutput.model_validate(result.content)
+    return ISO27001Assessor(config=config)
 
 
 # =============================================================================
@@ -140,14 +40,16 @@ def _parse_output(result: Message) -> ISO27001AssessmentOutput:
 
 
 class TestEvidenceStatusDerivation:
-    """Tests for the evidence_status decision tree."""
+    """Tests for the evidence_status decision tree via process()."""
 
     def test_no_evidence_returns_insufficient_evidence(self) -> None:
-        """No inputs at all → insufficient_evidence, status=not_assessed."""
+        """Empty findings → insufficient_evidence, status=not_assessed."""
         assessor = _make_assessor("A.8.24")
-        result = assessor.process(inputs=[], output_schema=OUTPUT_SCHEMA)
+        evidence_msg = make_evidence_message([])
 
-        output = _parse_output(result)
+        result = assessor.process(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
+
+        output = parse_output(result)
         finding = output.findings[0]
 
         assert finding.evidence_status == EvidenceStatus.INSUFFICIENT_EVIDENCE
@@ -161,54 +63,46 @@ class TestEvidenceStatusDerivation:
         Providing only technical evidence fails the evidence_required gate.
         """
         assessor = _make_assessor("A.5.15")
-        evidence_msg = _make_evidence_message(
+        evidence_msg = make_evidence_message(
             [
-                _make_evidence_finding(security_domain="access_control"),
+                make_evidence_finding(security_domain="access_control"),
             ]
         )
 
         result = assessor.process(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
 
-        output = _parse_output(result)
+        output = parse_output(result)
         finding = output.findings[0]
 
         assert finding.evidence_status == EvidenceStatus.REQUIRES_ATTESTATION
         assert finding.status == ControlStatus.NOT_ASSESSED
 
-    def test_evidence_required_satisfied_returns_automated(self) -> None:
-        """evidence_required=[DOCUMENT] with both technical and document evidence → automated.
+    def test_automated_evidence_produces_not_assessed(self) -> None:
+        """Matching evidence → evidence_status=AUTOMATED but status=NOT_ASSESSED.
 
-        A.5.15 has evidence_required=[DOCUMENT]. Providing both types satisfies the gate.
-        """
-        assessor = _make_assessor("A.5.15")
-        evidence_msg = _make_evidence_message(
-            [
-                _make_evidence_finding(security_domain="access_control"),
-            ]
-        )
-        document_msg = _make_document_message(
-            [
-                _make_document_finding(security_domains=["access_control"]),
-            ]
-        )
-
-        result = assessor.process(
-            inputs=[evidence_msg, document_msg], output_schema=OUTPUT_SCHEMA
-        )
-
-        output = _parse_output(result)
-        assert output.findings[0].evidence_status == EvidenceStatus.AUTOMATED
-
-    def test_require_review_propagation_returns_requires_attestation(self) -> None:
-        """Evidence with require_review=True → requires_attestation regardless.
-
-        Even when evidence matches the domain, the require_review flag forces
-        requires_attestation to ensure human review.
+        process() forces LLM off, so AUTOMATED controls produce NOT_ASSESSED
+        with a degraded-mode rationale.
         """
         assessor = _make_assessor("A.8.24")
-        evidence_msg = _make_evidence_message(
+        evidence_msg = make_evidence_message(
             [
-                _make_evidence_finding(
+                make_evidence_finding(security_domain="encryption"),
+            ]
+        )
+
+        result = assessor.process(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
+
+        output = parse_output(result)
+        finding = output.findings[0]
+        assert finding.evidence_status == EvidenceStatus.AUTOMATED
+        assert finding.status == ControlStatus.NOT_ASSESSED
+
+    def test_require_review_propagation_returns_requires_attestation(self) -> None:
+        """Evidence with require_review=True → requires_attestation regardless."""
+        assessor = _make_assessor("A.8.24")
+        evidence_msg = make_evidence_message(
+            [
+                make_evidence_finding(
                     security_domain="encryption", require_review=True
                 ),
             ]
@@ -216,27 +110,9 @@ class TestEvidenceStatusDerivation:
 
         result = assessor.process(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
 
-        output = _parse_output(result)
+        output = parse_output(result)
         assert output.findings[0].evidence_status == EvidenceStatus.REQUIRES_ATTESTATION
         assert output.findings[0].status == ControlStatus.NOT_ASSESSED
-
-    def test_matching_evidence_returns_automated(self) -> None:
-        """Matching evidence for the control's domain → automated.
-
-        A.8.24 (cryptography) has security_domains=[encryption].
-        Providing encryption-domain evidence should result in automated.
-        """
-        assessor = _make_assessor("A.8.24")
-        evidence_msg = _make_evidence_message(
-            [
-                _make_evidence_finding(security_domain="encryption"),
-            ]
-        )
-
-        result = assessor.process(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
-
-        output = _parse_output(result)
-        assert output.findings[0].evidence_status == EvidenceStatus.AUTOMATED
 
 
 # =============================================================================
@@ -248,62 +124,51 @@ class TestEvidenceFiltering:
     """Tests for domain and evidence_source filtering effects on status."""
 
     def test_non_matching_domain_evidence_excluded(self) -> None:
-        """Evidence for a different domain is excluded → insufficient_evidence.
-
-        A.8.24 has security_domains=[encryption]. Providing access_control
-        evidence should be filtered out, leaving no evidence.
-        """
+        """Evidence for a different domain is excluded → insufficient_evidence."""
         assessor = _make_assessor("A.8.24")
-        evidence_msg = _make_evidence_message(
+        evidence_msg = make_evidence_message(
             [
-                _make_evidence_finding(security_domain="access_control"),
+                make_evidence_finding(security_domain="access_control"),
             ]
         )
 
         result = assessor.process(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
 
-        output = _parse_output(result)
+        output = parse_output(result)
         assert (
             output.findings[0].evidence_status == EvidenceStatus.INSUFFICIENT_EVIDENCE
         )
 
     def test_document_only_control_excludes_technical_evidence(self) -> None:
-        """evidence_source=[DOCUMENT] control drops all security_evidence items.
-
-        A.5.1 has evidence_source=[DOCUMENT]. Technical security_evidence
-        items should be dropped, leaving no evidence.
-        """
+        """evidence_source=[DOCUMENT] control drops all security_evidence items."""
         assessor = _make_assessor("A.5.1")
-        evidence_msg = _make_evidence_message(
+        evidence_msg = make_evidence_message(
             [
-                _make_evidence_finding(security_domain="governance"),
+                make_evidence_finding(security_domain="governance"),
             ]
         )
 
         result = assessor.process(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
 
-        output = _parse_output(result)
+        output = parse_output(result)
         assert (
             output.findings[0].evidence_status == EvidenceStatus.INSUFFICIENT_EVIDENCE
         )
 
-    def test_cross_cutting_document_reaches_any_control(self) -> None:
-        """Document with security_domains=[] passes through to any control.
-
-        A.8.24 is a technical control (encryption), but a cross-cutting
-        document (e.g. org-context.md) should still reach it as background.
-        """
+    def test_cross_cutting_document_produces_not_assessed(self) -> None:
+        """Cross-cutting document reaches AUTOMATED but process() produces NOT_ASSESSED."""
         assessor = _make_assessor("A.8.24")
-        document_msg = _make_document_message(
+        document_msg = make_document_message(
             [
-                _make_document_finding(security_domains=[], filename="org-context.md"),
+                make_document_finding(security_domains=[], filename="org-context.md"),
             ]
         )
 
         result = assessor.process(inputs=[document_msg], output_schema=OUTPUT_SCHEMA)
 
-        output = _parse_output(result)
+        output = parse_output(result)
         assert output.findings[0].evidence_status == EvidenceStatus.AUTOMATED
+        assert output.findings[0].status == ControlStatus.NOT_ASSESSED
 
 
 # =============================================================================
@@ -315,15 +180,13 @@ class TestOutputShape:
     """Tests for output message structure and attribute copying."""
 
     def test_output_copies_iso27001_attributes_from_rule(self) -> None:
-        """Five ISO 27001 attributes are copied verbatim from the matched rule.
-
-        A.8.24 (use of cryptography) has known attribute values in the ruleset.
-        These must appear in the output regardless of evidence_status.
-        """
+        """Five ISO 27001 attributes are copied verbatim from the matched rule."""
         assessor = _make_assessor("A.8.24")
-        result = assessor.process(inputs=[], output_schema=OUTPUT_SCHEMA)
+        evidence_msg = make_evidence_message([])
 
-        output = _parse_output(result)
+        result = assessor.process(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
+
+        output = parse_output(result)
         finding = output.findings[0]
 
         assert finding.control_type == ControlType.PREVENTIVE
@@ -334,101 +197,3 @@ class TestOutputShape:
             == OperationalCapability.SYSTEM_AND_NETWORK_PROTECTION
         )
         assert finding.iso_security_domain == ISOSecurityDomain.PROTECTION
-
-
-# =============================================================================
-# LLM Assessment Verdicts
-# =============================================================================
-
-
-class TestLLMAssessmentVerdicts:
-    """Tests for the LLM assessment path (evidence_status == automated)."""
-
-    def test_automated_compliant_has_no_gap_description(self) -> None:
-        """LLM returns compliant → gap_description=None, summary counts correct.
-
-        When the LLM assesses a control as compliant, the output must have
-        gap_description=None and summary.compliant_count=1 (not not_assessed).
-        """
-        assessor = _make_assessor(
-            "A.8.24",
-            llm_response=ISO27001LLMResponse(
-                status="compliant",
-                rationale="AES-256 encryption is correctly implemented.",
-                gap_description=None,
-                recommended_actions=[],
-            ),
-        )
-        evidence_msg = _make_evidence_message(
-            [_make_evidence_finding(security_domain="encryption")]
-        )
-
-        result = assessor.process(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
-
-        output = _parse_output(result)
-        finding = output.findings[0]
-
-        assert finding.status == ControlStatus.COMPLIANT
-        assert finding.evidence_status == EvidenceStatus.AUTOMATED
-        assert finding.gap_description is None
-        assert finding.recommended_actions == []
-        assert finding.rationale == "AES-256 encryption is correctly implemented."
-        assert output.summary.compliant_count == 1
-        assert output.summary.not_assessed_count == 0
-
-    def test_automated_non_compliant_has_gap_description(self) -> None:
-        """LLM returns non_compliant → gap_description populated.
-
-        When the LLM assesses a control as non_compliant, gap_description must
-        be present with actionable text. SecurityGapReporter depends on this.
-        """
-        assessor = _make_assessor(
-            "A.8.24",
-            llm_response=ISO27001LLMResponse(
-                status="non_compliant",
-                rationale="MD5 is used for password hashing instead of bcrypt.",
-                gap_description="Replace MD5 with bcrypt or Argon2.",
-                recommended_actions=[
-                    "Replace MD5 password hashing with bcrypt or Argon2.",
-                    "Update the cryptography policy to mandate approved algorithms.",
-                ],
-            ),
-        )
-        evidence_msg = _make_evidence_message(
-            [_make_evidence_finding(security_domain="encryption")]
-        )
-
-        result = assessor.process(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
-
-        output = _parse_output(result)
-        finding = output.findings[0]
-
-        assert finding.status == ControlStatus.NON_COMPLIANT
-        assert finding.evidence_status == EvidenceStatus.AUTOMATED
-        assert finding.gap_description == "Replace MD5 with bcrypt or Argon2."
-        assert len(finding.recommended_actions) == 2
-        assert "bcrypt or Argon2" in finding.recommended_actions[0]
-        assert output.summary.non_compliant_count == 1
-
-    def test_llm_failure_falls_back_to_not_assessed(self) -> None:
-        """LLM call raises → status=not_assessed, pipeline doesn't crash.
-
-        93 assessors run in parallel. One LLM failure should not kill the run.
-        The assessor should fall back to not_assessed with an error rationale.
-        """
-        assessor = _make_assessor("A.8.24")
-        assessor._llm_service.complete = AsyncMock(
-            side_effect=RuntimeError("LLM provider unavailable")
-        )
-        evidence_msg = _make_evidence_message(
-            [_make_evidence_finding(security_domain="encryption")]
-        )
-
-        result = assessor.process(inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA)
-
-        output = _parse_output(result)
-        finding = output.findings[0]
-
-        assert finding.status == ControlStatus.NOT_ASSESSED
-        assert finding.evidence_status == EvidenceStatus.AUTOMATED
-        assert "LLM provider unavailable" in finding.rationale

--- a/libs/waivern-llm/src/waivern_llm/dispatcher.py
+++ b/libs/waivern-llm/src/waivern_llm/dispatcher.py
@@ -143,7 +143,6 @@ class LLMDispatcher:
                 request_id=request.request_id,
                 name=request.name,
                 model_name=self._provider.model_name,
-                response_model_name=request.response_model.__name__,
                 responses=request_responses[request.request_id],
                 skipped=request_skipped.get(request.request_id, []),
             )
@@ -159,6 +158,12 @@ class LLMDispatcher:
         pending_batch_ids: list[str],
     ) -> None:
         """Phase A (first run): plan batches, build prompts, check cache."""
+        if request.prompt_builder is None or request.response_model is None:
+            raise ValueError(
+                "prompt_builder and response_model are required on first run "
+                f"(request_id={request.request_id})"
+            )
+
         max_payload = calculate_max_payload_tokens(self._provider.context_window)
         planner = BatchPlanner(max_payload_tokens=max_payload)
         plan = planner.plan(request.groups, request.batching_mode)

--- a/libs/waivern-llm/src/waivern_llm/types.py
+++ b/libs/waivern-llm/src/waivern_llm/types.py
@@ -255,15 +255,18 @@ class LLMRequest[T: Finding](DispatchRequest):
     groups: Sequence[ItemGroup[T]]
     """Processor-defined groupings of findings."""
 
-    prompt_builder: PromptBuilder[T] = Field(exclude=True)
-    """Domain-specific prompt builder. Excluded from serialisation."""
+    prompt_builder: PromptBuilder[T] | None = Field(default=None, exclude=True)
+    """Domain-specific prompt builder. Excluded from serialisation.
 
-    response_model: type[BaseModel] = Field(exclude=True)
+    Required on first run. ``None`` on resume (prompts already cached).
+    """
+
+    response_model: type[BaseModel] | None = Field(default=None, exclude=True)
     """Expected response shape for the LLM. Excluded from serialisation.
 
     Used by the dispatcher on first run to call
     ``provider.invoke_structured()`` (sync mode) or generate the JSON
-    schema for ``BatchRequest`` (batch mode). Not needed on resume.
+    schema for ``BatchRequest`` (batch mode). ``None`` on resume.
     """
 
     batching_mode: BatchingMode
@@ -288,10 +291,6 @@ class LLMDispatchResult(DispatchResult):
 
     model_name: str
     """LLM model that produced these responses (e.g. 'claude-sonnet-4-5-20250929')."""
-
-    response_model_name: str
-    """Name of the response model type (e.g. 'AssessmentResponse'). Used by
-    ``finalise()`` to match results to the correct deserialisation model."""
 
     responses: list[dict[str, JsonValue]]
     """Raw response dicts, one per batch processed."""

--- a/libs/waivern-llm/tests/waivern_llm/test_dispatcher.py
+++ b/libs/waivern-llm/tests/waivern_llm/test_dispatcher.py
@@ -53,12 +53,6 @@ class MockResponse(BaseModel):
     reason: str
 
 
-class MockClassification(BaseModel):
-    """Second mock response model for multi-request tests."""
-
-    category: str
-
-
 def _create_mock_provider(response: MockResponse) -> Mock:
     """Create a mock LLM provider that returns the given response."""
     provider = Mock()
@@ -118,7 +112,7 @@ class TestLLMDispatcherSyncFirstRun:
     """Tests for sync mode first-run dispatch."""
 
     async def test_single_request_returns_result_with_correct_metadata(self) -> None:
-        """Single request → result has matching request_id, model_name, name, and response_model_name."""
+        """Single request → result has matching request_id, model_name, and name."""
         store = AsyncInMemoryStore()
         response = MockResponse(valid=True, reason="ok")
         provider = _create_mock_provider(response)
@@ -132,7 +126,6 @@ class TestLLMDispatcherSyncFirstRun:
         assert results[0].request_id == request.request_id
         assert results[0].model_name == "test-model"
         assert results[0].name == ""
-        assert results[0].response_model_name == "MockResponse"
 
     async def test_cache_miss_calls_provider_and_returns_raw_response(self) -> None:
         """Cache miss → invoke_structured() called, response returned as raw dict."""
@@ -253,56 +246,6 @@ class TestLLMDispatcherSyncFirstRun:
 
         # Provider called twice (one per miss, consolidated via gather)
         assert provider.invoke_structured.call_count == 2
-
-    async def test_multiple_requests_carry_correct_response_model_names(self) -> None:
-        """Two requests with different response models → each result has the correct response_model_name."""
-        store = AsyncInMemoryStore()
-
-        async def invoke_side_effect(
-            prompt: str, response_model: type[BaseModel]
-        ) -> BaseModel:
-            if response_model is MockClassification:
-                return MockClassification(category="personal-data")
-            return MockResponse(valid=True, reason="ok")
-
-        provider = Mock()
-        provider.model_name = "test-model"
-        provider.context_window = 100_000
-        provider.invoke_structured = AsyncMock(side_effect=invoke_side_effect)
-
-        dispatcher = LLMDispatcher(provider=provider, store=store)
-
-        builder_a = Mock()
-        builder_a.build_prompt = Mock(return_value="prompt-A")
-        request_a = LLMRequest(
-            name="assessment",
-            groups=[ItemGroup(items=[MockFinding("f1")])],
-            prompt_builder=builder_a,
-            response_model=MockResponse,
-            batching_mode=BatchingMode.COUNT_BASED,
-            run_id="run-1",
-        )
-
-        builder_b = Mock()
-        builder_b.build_prompt = Mock(return_value="prompt-B")
-        request_b = LLMRequest(
-            name="classification",
-            groups=[ItemGroup(items=[MockFinding("f2")])],
-            prompt_builder=builder_b,
-            response_model=MockClassification,
-            batching_mode=BatchingMode.COUNT_BASED,
-            run_id="run-1",
-        )
-
-        results = await dispatcher.dispatch([request_a, request_b])
-
-        result_a = next(r for r in results if r.request_id == request_a.request_id)
-        result_b = next(r for r in results if r.request_id == request_b.request_id)
-
-        assert result_a.response_model_name == "MockResponse"
-        assert result_a.name == "assessment"
-        assert result_b.response_model_name == "MockClassification"
-        assert result_b.name == "classification"
 
     async def test_skipped_findings_included_in_result(self) -> None:
         """Request with oversized/missing-content groups → skipped findings in result."""


### PR DESCRIPTION
## Summary

- Implement `DistributedProcessor[ISO27001PrepareState]` on `ISO27001Assessor` with prepare/finalise/deserialise methods
- `prepare()` classifies evidence and builds `LLMRequest` for AUTOMATED path; returns empty requests for short-circuit or LLM-disabled paths
- `finalise()` interprets `LLMDispatchResult` into assessment verdicts with distinct rationale per evidence_status/llm_enabled combination
- `process()` refactored to thin degraded-mode wrapper delegating to prepare/finalise with LLM forced off — all `asyncio.run()` and `PendingBatchError` handling removed
- Remove `response_model_name` from `LLMDispatchResult` — processors derive response model from their own state
- Make `prompt_builder` and `response_model` optional on `LLMRequest` to support resume-path deserialisation