### PR TITLE
feat(analysers-shared): add prepare/finalise split to LLM validation

### DIFF
--- a/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/__init__.py
+++ b/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/__init__.py
@@ -39,8 +39,13 @@ from waivern_analysers_shared.llm_validation.sampling import (
     SamplingResult,
     SamplingStrategy,
 )
-from waivern_analysers_shared.llm_validation.strategy import LLMValidationStrategy
+from waivern_analysers_shared.llm_validation.strategy import (
+    FilteringValidationStrategy,
+    LLMValidationStrategy,
+)
 from waivern_analysers_shared.llm_validation.validation_orchestrator import (
+    FallbackNeeded,
+    OrchestratorPrepareState,
     ValidationOrchestrator,
 )
 
@@ -74,10 +79,13 @@ __all__ = [
     "ConcernProvider",
     "SourceProvider",
     # Strategies
+    "FilteringValidationStrategy",
     "LLMValidationStrategy",
     # Orchestration
     "EnrichmentOrchestrator",
     "EnrichmentResult",
     "EnrichmentStrategy",
+    "FallbackNeeded",
+    "OrchestratorPrepareState",
     "ValidationOrchestrator",
 ]

--- a/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/models.py
+++ b/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/models.py
@@ -142,6 +142,11 @@ class ValidationResult[T: Finding]:
     - Sampled findings that passed LLM validation (TRUE_POSITIVE or not flagged)
     - Non-sampled findings from groups that weren't removed (kept by inference)
     - Skipped findings (conservative: kept but not validated)
+
+    Exception: when a group is removed wholesale because all its validated
+    samples were FALSE_POSITIVE, skipped findings in that group are also
+    removed. Once we are confident a whole group is false-positive, its
+    skipped members inherit the group-level judgement.
     """
 
     removed_findings: list[T]

--- a/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/strategy.py
+++ b/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/strategy.py
@@ -1,10 +1,23 @@
-"""Abstract base class for LLM validation strategies."""
+"""Abstract base classes for LLM validation strategies."""
 
+import logging
 from abc import ABC, abstractmethod
+from typing import override
 
 from waivern_core import Finding
+from waivern_core.types import JsonValue
+from waivern_llm import LLMDispatchResult, LLMRequest, SkippedFinding, SkipReason
 
+from waivern_analysers_shared.llm_validation.decision_engine import (
+    ValidationDecisionEngine,
+)
+from waivern_analysers_shared.llm_validation.models import (
+    LLMValidationOutcome,
+    LLMValidationResponseModel,
+)
 from waivern_analysers_shared.types import LLMValidationConfig
+
+logger = logging.getLogger(__name__)
 
 
 class LLMValidationStrategy[TFinding: Finding, TResult](ABC):
@@ -46,3 +59,161 @@ class LLMValidationStrategy[TFinding: Finding, TResult](ABC):
 
         """
         ...
+
+    @abstractmethod
+    def prepare_validation(
+        self,
+        findings: list[TFinding],
+        config: LLMValidationConfig,
+        run_id: str,
+    ) -> tuple[list[TFinding], LLMRequest[TFinding] | None]:
+        """Prepare an LLM request for dispatch.
+
+        Builds groups and constructs the LLMRequest without making any LLM calls.
+        The returned findings are the state passed back to finalise_validation().
+
+        Args:
+            findings: List of findings to validate.
+            config: LLM validation configuration.
+            run_id: Unique identifier for the current run, used for cache scoping.
+
+        Returns:
+            Tuple of (findings for finalise, LLMRequest or None if no dispatch needed).
+
+        """
+        ...
+
+    @abstractmethod
+    def finalise_validation(
+        self,
+        findings: list[TFinding],
+        result: LLMDispatchResult | None,
+    ) -> TResult:
+        """Interpret dispatch results and produce the strategy result.
+
+        Args:
+            findings: Original findings passed to prepare_validation.
+            result: Dispatch result from the executor, or None if no dispatch occurred.
+
+        Returns:
+            Strategy-specific result type.
+
+        """
+        ...
+
+
+class FilteringValidationStrategy[TFinding: Finding](
+    LLMValidationStrategy[TFinding, LLMValidationOutcome[TFinding]]
+):
+    """Base class for filtering strategies that produce LLMValidationOutcome.
+
+    Provides a default finalise_validation() implementation that handles the
+    standard deserialise -> categorise -> outcome flow used by all filtering
+    strategies. Concrete filtering strategies only need to implement
+    prepare_validation() (and retained validate_findings() during migration).
+    """
+
+    @override
+    def finalise_validation(
+        self,
+        findings: list[TFinding],
+        result: LLMDispatchResult | None,
+    ) -> LLMValidationOutcome[TFinding]:
+        """Deserialise responses, categorise findings, and produce outcome.
+
+        1. If result is None -> return all findings as skipped (BATCH_ERROR).
+        2. Deserialise raw dict responses to LLMValidationResponseModel.
+        3. Match skipped findings from result back to typed findings by ID.
+        4. Categorise: TRUE_POSITIVE -> kept, FALSE_POSITIVE -> removed,
+           unmentioned -> not_flagged (fail-safe).
+        """
+        if result is None:
+            return LLMValidationOutcome(
+                llm_validated_kept=[],
+                llm_validated_removed=[],
+                llm_not_flagged=[],
+                skipped=[
+                    SkippedFinding(finding=f, reason=SkipReason.BATCH_ERROR)
+                    for f in findings
+                ],
+            )
+
+        findings_by_id = {f.id: f for f in findings}
+
+        kept, removed, processed_ids = self._deserialise_and_categorise(
+            result.responses, findings_by_id
+        )
+        skipped_typed = self._match_skipped_to_typed(result.skipped, findings_by_id)
+        not_flagged = self._compute_not_flagged(
+            findings_by_id, processed_ids, skipped_typed
+        )
+
+        return LLMValidationOutcome(
+            llm_validated_kept=kept,
+            llm_validated_removed=removed,
+            llm_not_flagged=not_flagged,
+            skipped=skipped_typed,
+        )
+
+    def _deserialise_and_categorise(
+        self,
+        raw_responses: list[dict[str, JsonValue]],
+        findings_by_id: dict[str, TFinding],
+    ) -> tuple[list[TFinding], list[TFinding], set[str]]:
+        """Deserialise raw responses and split findings into kept/removed."""
+        kept: list[TFinding] = []
+        removed: list[TFinding] = []
+        processed_ids: set[str] = set()
+
+        for raw_response in raw_responses:
+            response = LLMValidationResponseModel.model_validate(raw_response)
+            for item in response.results:
+                finding = findings_by_id.get(item.finding_id)
+                if finding is None:
+                    logger.warning(f"Unknown finding_id from LLM: {item.finding_id}")
+                    continue
+
+                processed_ids.add(item.finding_id)
+                ValidationDecisionEngine.log_validation_decision(item, finding)
+
+                if ValidationDecisionEngine.should_keep_finding(item, finding):
+                    kept.append(finding)
+                else:
+                    removed.append(finding)
+
+        return kept, removed, processed_ids
+
+    def _match_skipped_to_typed(
+        self,
+        skipped: list[SkippedFinding[Finding]],
+        findings_by_id: dict[str, TFinding],
+    ) -> list[SkippedFinding[TFinding]]:
+        """Re-type SkippedFinding[Finding] entries by looking up by finding ID."""
+        matched: list[SkippedFinding[TFinding]] = []
+        for entry in skipped:
+            typed_finding = findings_by_id.get(entry.finding.id)
+            if typed_finding is None:
+                logger.warning(
+                    f"Skipped finding id {entry.finding.id} not in input findings"
+                )
+                continue
+            matched.append(SkippedFinding(finding=typed_finding, reason=entry.reason))
+        return matched
+
+    def _compute_not_flagged(
+        self,
+        findings_by_id: dict[str, TFinding],
+        processed_ids: set[str],
+        skipped: list[SkippedFinding[TFinding]],
+    ) -> list[TFinding]:
+        """Return findings LLM saw but didn't mention (kept via fail-safe)."""
+        skipped_ids = {s.finding.id for s in skipped}
+        not_flagged_ids = set(findings_by_id.keys()) - processed_ids - skipped_ids
+        not_flagged = [findings_by_id[fid] for fid in not_flagged_ids]
+
+        if not_flagged:
+            logger.debug(
+                f"{len(not_flagged)} findings not flagged by LLM, keeping as valid"
+            )
+
+        return not_flagged

--- a/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/validation_orchestrator.py
+++ b/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/validation_orchestrator.py
@@ -27,8 +27,10 @@ The orchestrator handles grouping and sampling; the LLMService handles batching.
 """
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from waivern_core import Finding
+from waivern_llm import LLMDispatchResult, LLMRequest
 
 from waivern_analysers_shared.llm_validation.decision_engine import (
     ValidationDecisionEngine,
@@ -44,6 +46,54 @@ from waivern_analysers_shared.llm_validation.models import (
 from waivern_analysers_shared.llm_validation.sampling import SamplingStrategy
 from waivern_analysers_shared.llm_validation.strategy import LLMValidationStrategy
 from waivern_analysers_shared.types import LLMValidationConfig
+
+
+@dataclass
+class OrchestratorPrepareState[T: Finding]:
+    """State captured by ValidationOrchestrator.prepare() for use in finalise().
+
+    Captures everything finalise() needs to produce the final ValidationResult,
+    including fallback round state for multi-round dispatch.
+    """
+
+    strategy_findings: list[T]
+    """Findings passed to the strategy's prepare_validation()."""
+
+    config: LLMValidationConfig
+    """LLM validation configuration for this run."""
+
+    run_id: str
+    """Run identifier for cache scoping (needed for fallback prepare)."""
+
+    groups: dict[str, list[T]] | None = None
+    """Groups from grouping strategy (None if no grouping)."""
+
+    sampled: dict[str, list[T]] | None = None
+    """Sampled findings per group (None if no grouping)."""
+
+    non_sampled: dict[str, list[T]] | None = None
+    """Non-sampled findings per group (None if no grouping)."""
+
+    primary_outcome: LLMValidationOutcome[T] | None = None
+    """Primary strategy outcome, set between fallback rounds."""
+
+    is_fallback_round: bool = False
+    """True when finalise is being called with fallback results."""
+
+
+@dataclass(frozen=True)
+class FallbackNeeded[T: Finding]:
+    """Signal returned from finalise() when a fallback dispatch round is needed.
+
+    The processor wraps this into a PrepareResult, triggering another
+    Phase 2 -> 3 cycle in the executor.
+    """
+
+    state: OrchestratorPrepareState[T]
+    """Updated state carrying primary_outcome and is_fallback_round=True."""
+
+    request: LLMRequest[T]
+    """LLMRequest for the fallback strategy."""
 
 
 class ValidationOrchestrator[T: Finding]:
@@ -100,6 +150,213 @@ class ValidationOrchestrator[T: Finding]:
         self._grouping_strategy = grouping_strategy
         self._sampling_strategy = sampling_strategy
         self._fallback_strategy = fallback_strategy
+
+    def prepare(
+        self,
+        findings: list[T],
+        config: LLMValidationConfig,
+        run_id: str,
+    ) -> tuple[OrchestratorPrepareState[T], LLMRequest[T] | None]:
+        """Prepare an LLM request for dispatch without making any LLM calls.
+
+        Orchestrates: group -> sample -> flatten -> strategy.prepare_validation().
+        Returns the captured state plus the LLMRequest for the executor to dispatch.
+
+        Args:
+            findings: List of findings to validate.
+            config: LLM validation configuration.
+            run_id: Unique identifier for the current run, used for cache scoping.
+
+        Returns:
+            Tuple of (state for finalise, LLMRequest or None if no dispatch needed).
+
+        """
+        if not findings:
+            return (
+                OrchestratorPrepareState(
+                    strategy_findings=[], config=config, run_id=run_id
+                ),
+                None,
+            )
+
+        if self._grouping_strategy is None:
+            strategy_findings, request = self._llm_strategy.prepare_validation(
+                findings, config, run_id
+            )
+            return (
+                OrchestratorPrepareState(
+                    strategy_findings=strategy_findings,
+                    config=config,
+                    run_id=run_id,
+                ),
+                request,
+            )
+
+        groups = self._grouping_strategy.group(findings)
+
+        if self._sampling_strategy is not None:
+            sampling_result = self._sampling_strategy.sample(groups)
+            sampled = sampling_result.sampled
+            non_sampled = sampling_result.non_sampled
+        else:
+            sampled = groups
+            non_sampled: dict[str, list[T]] = {key: [] for key in groups}
+
+        all_samples = [f for group_samples in sampled.values() for f in group_samples]
+
+        strategy_findings, request = self._llm_strategy.prepare_validation(
+            all_samples, config, run_id
+        )
+        return (
+            OrchestratorPrepareState(
+                strategy_findings=strategy_findings,
+                config=config,
+                run_id=run_id,
+                groups=groups,
+                sampled=sampled,
+                non_sampled=non_sampled,
+            ),
+            request,
+        )
+
+    def finalise(
+        self,
+        state: OrchestratorPrepareState[T],
+        result: LLMDispatchResult | None,
+        marker: Callable[[T], T] | None = None,
+    ) -> ValidationResult[T] | FallbackNeeded[T]:
+        """Finalise validation from dispatch results.
+
+        Round 1 (primary): interpret primary results, check fallback eligibility.
+            - If fallback needed -> returns FallbackNeeded for another round.
+            - Otherwise -> applies marker, group decisions -> ValidationResult.
+        Round 2 (fallback): merges primary + fallback outcomes, applies marker
+            and group decisions -> ValidationResult.
+
+        Args:
+            state: State captured by prepare().
+            result: Dispatch result for the strategy's LLMRequest, or None.
+            marker: Optional callback to mark validated findings.
+
+        Returns:
+            ValidationResult when complete, or FallbackNeeded when another round
+            of dispatch is required.
+
+        """
+        # Empty findings short-circuit (matches prepare with empty input)
+        if not state.strategy_findings:
+            return ValidationResult(
+                kept_findings=[],
+                removed_findings=[],
+                removed_groups=[],
+                samples_validated=0,
+                all_succeeded=True,
+                skipped_samples=[],
+            )
+
+        if state.is_fallback_round:
+            outcome = self._run_fallback_round(state, result)
+        else:
+            outcome = self._run_primary_round(state, result)
+            fallback_signal = self._build_fallback_request_if_needed(outcome, state)
+            if fallback_signal is not None:
+                return fallback_signal
+
+        if marker:
+            outcome = outcome.with_marked_findings(marker)
+
+        if state.groups is not None and self._grouping_strategy is not None:
+            return self._apply_group_decisions(
+                grouping_strategy=self._grouping_strategy,
+                groups=state.groups,
+                sampled=state.sampled or {},
+                non_sampled=state.non_sampled or {},
+                outcome=outcome,
+            )
+
+        # Ungrouped path: include skipped findings in kept_findings
+        # (conservative semantics — see ValidationResult.kept_findings docstring).
+        return ValidationResult(
+            kept_findings=outcome.kept_findings,
+            removed_findings=outcome.llm_validated_removed,
+            removed_groups=[],
+            samples_validated=len(state.strategy_findings),
+            all_succeeded=outcome.validation_succeeded,
+            skipped_samples=outcome.skipped,
+        )
+
+    def _run_primary_round(
+        self,
+        state: OrchestratorPrepareState[T],
+        result: LLMDispatchResult | None,
+    ) -> LLMValidationOutcome[T]:
+        """Delegate to the primary strategy's finalise_validation (round 1)."""
+        return self._llm_strategy.finalise_validation(state.strategy_findings, result)
+
+    def _run_fallback_round(
+        self,
+        state: OrchestratorPrepareState[T],
+        result: LLMDispatchResult | None,
+    ) -> LLMValidationOutcome[T]:
+        """Merge fallback outcome into primary outcome (round 2).
+
+        Precondition: ``state.is_fallback_round`` implies the fallback strategy
+        and primary outcome were set by ``_build_fallback_request_if_needed``.
+        """
+        fallback_strategy = self._fallback_strategy
+        primary_outcome = state.primary_outcome
+        if fallback_strategy is None or primary_outcome is None:
+            raise RuntimeError(
+                "is_fallback_round=True requires fallback_strategy and "
+                "primary_outcome to be set"
+            )
+        fallback_outcome = fallback_strategy.finalise_validation(
+            state.strategy_findings, result
+        )
+        ineligible_skipped = [
+            s
+            for s in primary_outcome.skipped
+            if s.reason not in FALLBACK_ELIGIBLE_SKIP_REASONS
+        ]
+        return self._merge_fallback_outcome(
+            primary_outcome, fallback_outcome, ineligible_skipped
+        )
+
+    def _build_fallback_request_if_needed(
+        self,
+        primary_outcome: LLMValidationOutcome[T],
+        state: OrchestratorPrepareState[T],
+    ) -> FallbackNeeded[T] | None:
+        """Build a FallbackNeeded signal if eligible skipped findings exist."""
+        fallback_strategy = self._fallback_strategy
+        if fallback_strategy is None:
+            return None
+
+        eligible = [
+            s.finding
+            for s in primary_outcome.skipped
+            if s.reason in FALLBACK_ELIGIBLE_SKIP_REASONS
+        ]
+        if not eligible:
+            return None
+
+        fallback_strategy_findings, fallback_request = (
+            fallback_strategy.prepare_validation(eligible, state.config, state.run_id)
+        )
+        if fallback_request is None:
+            return None
+
+        next_state = OrchestratorPrepareState(
+            strategy_findings=fallback_strategy_findings,
+            config=state.config,
+            run_id=state.run_id,
+            groups=state.groups,
+            sampled=state.sampled,
+            non_sampled=state.non_sampled,
+            primary_outcome=primary_outcome,
+            is_fallback_round=True,
+        )
+        return FallbackNeeded(state=next_state, request=fallback_request)
 
     def validate(
         self,
@@ -164,7 +421,7 @@ class ValidationOrchestrator[T: Finding]:
             outcome = outcome.with_marked_findings(marker)
 
         return ValidationResult(
-            kept_findings=outcome.llm_validated_kept + outcome.llm_not_flagged,
+            kept_findings=outcome.kept_findings,
             removed_findings=outcome.llm_validated_removed,
             removed_groups=[],  # No grouping = no group removal
             samples_validated=len(findings),
@@ -375,7 +632,11 @@ class ValidationOrchestrator[T: Finding]:
                     all_kept.extend(group_findings)
 
                 case "remove_group":
-                    # All validated samples are FALSE_POSITIVE - remove entire group
+                    # All validated samples are FALSE_POSITIVE - remove entire group,
+                    # including any skipped findings. Rationale: once we are confident
+                    # a whole group is false-positive, the skipped members of that
+                    # group inherit the group-level judgement. Conservative handling
+                    # of skipped findings only applies when the group is NOT removed.
                     all_removed.extend(group_findings)
                     removed_groups.append(
                         RemovedGroup(

--- a/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_orchestrator_prepare_finalise.py
+++ b/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_orchestrator_prepare_finalise.py
@@ -1,0 +1,458 @@
+"""Tests for ValidationOrchestrator's prepare() and finalise() methods.
+
+Business behaviour: The orchestrator's prepare/finalise split enables the
+executor-driven dispatch pattern. prepare() builds an LLMRequest without
+making LLM calls; finalise() interprets dispatch results and applies
+group-level decisions. Fallback is handled via multi-round dispatch.
+"""
+
+from unittest.mock import Mock
+
+from waivern_core.schemas.finding_types import (
+    BaseFindingEvidence,
+    BaseFindingMetadata,
+    BaseFindingModel,
+    PatternMatchDetail,
+)
+from waivern_core.types import JsonValue
+from waivern_llm import LLMDispatchResult, LLMRequest, SkippedFinding, SkipReason
+
+from waivern_analysers_shared.llm_validation.models import (
+    LLMValidationOutcome,
+    ValidationResult,
+)
+from waivern_analysers_shared.llm_validation.sampling import SamplingResult
+from waivern_analysers_shared.llm_validation.validation_orchestrator import (
+    FallbackNeeded,
+    OrchestratorPrepareState,
+    ValidationOrchestrator,
+)
+from waivern_analysers_shared.types import LLMValidationConfig
+
+
+class _Finding(BaseFindingModel[BaseFindingMetadata]):
+    """Simple finding with a group attribute for orchestrator tests."""
+
+    group: str
+
+
+def _make_finding(finding_id: str, group: str = "G") -> _Finding:
+    return _Finding(
+        id=finding_id,
+        group=group,
+        evidence=[BaseFindingEvidence(content=f"Evidence for {finding_id}")],
+        matched_patterns=[PatternMatchDetail(pattern="test_pattern", match_count=1)],
+        metadata=BaseFindingMetadata(source="test_source"),
+    )
+
+
+def _make_config() -> LLMValidationConfig:
+    return LLMValidationConfig(enable_llm_validation=True)
+
+
+class _GroupingByAttr:
+    """Grouping strategy keyed on the `group` attribute."""
+
+    @property
+    def concern_key(self) -> str:
+        return "group"
+
+    def group(self, findings: list[_Finding]) -> dict[str, list[_Finding]]:
+        groups: dict[str, list[_Finding]] = {}
+        for finding in findings:
+            groups.setdefault(finding.group, []).append(finding)
+        return groups
+
+
+class _FixedSampling:
+    """Sampling strategy returning preconfigured sampled/non_sampled."""
+
+    def __init__(
+        self,
+        sampled: dict[str, list[_Finding]],
+        non_sampled: dict[str, list[_Finding]],
+    ) -> None:
+        self._sampled = sampled
+        self._non_sampled = non_sampled
+
+    def sample(self, groups: dict[str, list[_Finding]]) -> SamplingResult[_Finding]:
+        return SamplingResult(sampled=self._sampled, non_sampled=self._non_sampled)
+
+
+_TEST_RUN_ID = "test-run-id"
+
+
+def _make_prepare_mock(
+    request: LLMRequest[_Finding] | None,
+    strategy_findings_override: list[_Finding] | None = None,
+) -> Mock:
+    """Mock LLMValidationStrategy whose prepare_validation returns fixed values.
+
+    By default the strategy echoes its received findings; pass
+    strategy_findings_override to return a different list.
+    """
+    strategy = Mock()
+
+    def _prepare(
+        findings: list[_Finding],
+        config: LLMValidationConfig,
+        run_id: str,
+    ) -> tuple[list[_Finding], LLMRequest[_Finding] | None]:
+        return (strategy_findings_override or findings, request)
+
+    strategy.prepare_validation.side_effect = _prepare
+    return strategy
+
+
+def _dispatch_result(
+    request_id: str = "test-request",
+    responses: list[dict[str, JsonValue]] | None = None,
+    skipped: list[SkippedFinding[_Finding]] | None = None,
+) -> LLMDispatchResult:
+    """Build an LLMDispatchResult with sensible defaults for tests."""
+    return LLMDispatchResult(
+        request_id=request_id,
+        model_name="test-model",
+        responses=responses or [],
+        skipped=list(skipped) if skipped else [],
+    )
+
+
+def _make_finalise_strategy(
+    outcome: LLMValidationOutcome[_Finding],
+) -> Mock:
+    """Mock strategy whose finalise_validation returns a fixed outcome."""
+    strategy = Mock()
+    strategy.finalise_validation.return_value = outcome
+    return strategy
+
+
+class TestOrchestratorPrepare:
+    """Tests for ValidationOrchestrator.prepare()."""
+
+    def test_prepare_returns_no_request_for_empty_findings(self) -> None:
+        """Empty input -> state with no LLMRequest."""
+        strategy = _make_prepare_mock(request=Mock(spec=LLMRequest))
+        orchestrator = ValidationOrchestrator(llm_strategy=strategy)
+
+        state, request = orchestrator.prepare([], _make_config(), _TEST_RUN_ID)
+
+        assert request is None
+        assert state.strategy_findings == []
+        assert state.groups is None
+        assert state.sampled is None
+        assert state.non_sampled is None
+        assert state.is_fallback_round is False
+        strategy.prepare_validation.assert_not_called()
+
+    def test_prepare_without_grouping_delegates_to_strategy(self) -> None:
+        """No grouping -> all findings passed to strategy.prepare_validation()."""
+        findings = [_make_finding("1"), _make_finding("2")]
+        sentinel_request = Mock(spec=LLMRequest)
+        strategy = _make_prepare_mock(request=sentinel_request)
+        orchestrator = ValidationOrchestrator(llm_strategy=strategy)
+
+        state, request = orchestrator.prepare(findings, _make_config(), _TEST_RUN_ID)
+
+        assert request is sentinel_request
+        strategy.prepare_validation.assert_called_once_with(
+            findings, _make_config(), _TEST_RUN_ID
+        )
+        assert state.strategy_findings == findings
+        assert state.groups is None
+
+    def test_prepare_with_grouping_and_sampling(self) -> None:
+        """Groups -> samples -> flattens -> passes samples to strategy."""
+        a1 = _make_finding("a1", "GroupA")
+        a2 = _make_finding("a2", "GroupA")
+        b1 = _make_finding("b1", "GroupB")
+        b2 = _make_finding("b2", "GroupB")
+        findings = [a1, a2, b1, b2]
+        sentinel_request = Mock(spec=LLMRequest)
+        strategy = _make_prepare_mock(request=sentinel_request)
+        sampling = _FixedSampling(
+            sampled={"GroupA": [a1], "GroupB": [b1]},
+            non_sampled={"GroupA": [a2], "GroupB": [b2]},
+        )
+
+        orchestrator = ValidationOrchestrator(
+            llm_strategy=strategy,
+            grouping_strategy=_GroupingByAttr(),
+            sampling_strategy=sampling,
+        )
+
+        state, request = orchestrator.prepare(findings, _make_config(), _TEST_RUN_ID)
+
+        assert request is sentinel_request
+        # Only sampled findings are sent to strategy (flattened)
+        (passed_findings, _config, _run) = strategy.prepare_validation.call_args.args
+        assert sorted(f.id for f in passed_findings) == ["a1", "b1"]
+        assert state.strategy_findings == passed_findings
+
+    def test_prepare_state_captures_groups_and_samples(self) -> None:
+        """OrchestratorPrepareState has correct groups/sampled/non_sampled."""
+        a1 = _make_finding("a1", "GroupA")
+        a2 = _make_finding("a2", "GroupA")
+        b1 = _make_finding("b1", "GroupB")
+        findings = [a1, a2, b1]
+        strategy = _make_prepare_mock(request=Mock(spec=LLMRequest))
+        sampling = _FixedSampling(
+            sampled={"GroupA": [a1], "GroupB": [b1]},
+            non_sampled={"GroupA": [a2], "GroupB": []},
+        )
+
+        orchestrator = ValidationOrchestrator(
+            llm_strategy=strategy,
+            grouping_strategy=_GroupingByAttr(),
+            sampling_strategy=sampling,
+        )
+
+        state, _ = orchestrator.prepare(findings, _make_config(), _TEST_RUN_ID)
+
+        assert state.groups == {"GroupA": [a1, a2], "GroupB": [b1]}
+        assert state.sampled == {"GroupA": [a1], "GroupB": [b1]}
+        assert state.non_sampled == {"GroupA": [a2], "GroupB": []}
+
+
+class TestOrchestratorFinalise:
+    """Tests for ValidationOrchestrator.finalise()."""
+
+    def test_finalise_without_grouping_returns_validation_result(self) -> None:
+        """Ungrouped path -> ValidationResult with correct kept/removed."""
+        kept = _make_finding("k")
+        removed = _make_finding("r")
+        strategy = _make_finalise_strategy(
+            LLMValidationOutcome(
+                llm_validated_kept=[kept],
+                llm_validated_removed=[removed],
+                llm_not_flagged=[],
+                skipped=[],
+            )
+        )
+        orchestrator = ValidationOrchestrator(llm_strategy=strategy)
+        state = OrchestratorPrepareState(
+            strategy_findings=[kept, removed],
+            config=_make_config(),
+            run_id=_TEST_RUN_ID,
+        )
+
+        result = orchestrator.finalise(state, _dispatch_result())
+
+        assert isinstance(result, ValidationResult)
+        assert result.kept_findings == [kept]
+        assert result.removed_findings == [removed]
+        assert result.removed_groups == []
+        assert result.all_succeeded is True
+
+    def test_finalise_with_grouping_applies_group_decisions(self) -> None:
+        """Grouped path -> group decisions (Case A/B/C) applied correctly."""
+        # GroupA: all samples FALSE_POSITIVE -> whole group removed
+        # GroupB: all kept -> whole group kept
+        a1 = _make_finding("a1", "GroupA")
+        a2_unsampled = _make_finding("a2", "GroupA")
+        b1 = _make_finding("b1", "GroupB")
+        b2_unsampled = _make_finding("b2", "GroupB")
+
+        strategy = _make_finalise_strategy(
+            LLMValidationOutcome(
+                llm_validated_kept=[b1],
+                llm_validated_removed=[a1],
+                llm_not_flagged=[],
+                skipped=[],
+            )
+        )
+        orchestrator = ValidationOrchestrator(
+            llm_strategy=strategy,
+            grouping_strategy=_GroupingByAttr(),
+        )
+        state = OrchestratorPrepareState(
+            strategy_findings=[a1, b1],
+            config=_make_config(),
+            run_id=_TEST_RUN_ID,
+            groups={"GroupA": [a1, a2_unsampled], "GroupB": [b1, b2_unsampled]},
+            sampled={"GroupA": [a1], "GroupB": [b1]},
+            non_sampled={"GroupA": [a2_unsampled], "GroupB": [b2_unsampled]},
+        )
+
+        result = orchestrator.finalise(state, _dispatch_result())
+
+        assert isinstance(result, ValidationResult)
+        # GroupA fully removed; GroupB fully kept
+        assert {f.id for f in result.removed_findings} == {"a1", "a2"}
+        assert {f.id for f in result.kept_findings} == {"b1", "b2"}
+        assert len(result.removed_groups) == 1
+        assert result.removed_groups[0].concern_value == "GroupA"
+
+    def test_finalise_applies_marker(self) -> None:
+        """Marker callback applied to validated findings, not skipped."""
+        validated = _make_finding("v")
+        skipped_finding = _make_finding("s")
+        strategy = _make_finalise_strategy(
+            LLMValidationOutcome(
+                llm_validated_kept=[validated],
+                llm_validated_removed=[],
+                llm_not_flagged=[],
+                skipped=[
+                    SkippedFinding(
+                        finding=skipped_finding, reason=SkipReason.BATCH_ERROR
+                    )
+                ],
+            )
+        )
+        orchestrator = ValidationOrchestrator(llm_strategy=strategy)
+        state = OrchestratorPrepareState(
+            strategy_findings=[validated, skipped_finding],
+            config=_make_config(),
+            run_id=_TEST_RUN_ID,
+        )
+
+        def _mark(f: _Finding) -> _Finding:
+            return f.model_copy(update={"group": "MARKED"})
+
+        result = orchestrator.finalise(state, _dispatch_result(), marker=_mark)
+
+        assert isinstance(result, ValidationResult)
+        # Conservative semantics: skipped findings are kept in output (not dropped)
+        kept_by_id = {f.id: f for f in result.kept_findings}
+        assert set(kept_by_id) == {"v", "s"}
+        # Marker applied to validated finding only
+        assert kept_by_id["v"].group == "MARKED"
+        # Skipped finding is NOT marked (never went through LLM)
+        assert kept_by_id["s"].group == "G"
+        # Skipped finding also appears in skipped_samples for transparency
+        assert [s.finding.id for s in result.skipped_samples] == ["s"]
+
+
+class TestOrchestratorFinaliseFallback:
+    """Tests for the multi-round fallback mechanism in finalise()."""
+
+    def test_finalise_returns_fallback_needed_for_eligible_skipped(self) -> None:
+        """Eligible skipped -> FallbackNeeded with fallback LLMRequest."""
+        validated = _make_finding("v")
+        oversized = _make_finding("o")
+        primary_outcome = LLMValidationOutcome(
+            llm_validated_kept=[validated],
+            llm_validated_removed=[],
+            llm_not_flagged=[],
+            skipped=[SkippedFinding(finding=oversized, reason=SkipReason.OVERSIZED)],
+        )
+        primary_strategy = _make_finalise_strategy(primary_outcome)
+        fallback_request = Mock(spec=LLMRequest)
+        fallback_strategy = _make_prepare_mock(request=fallback_request)
+        orchestrator = ValidationOrchestrator(
+            llm_strategy=primary_strategy,
+            fallback_strategy=fallback_strategy,
+        )
+        state = OrchestratorPrepareState(
+            strategy_findings=[validated, oversized],
+            config=_make_config(),
+            run_id=_TEST_RUN_ID,
+        )
+
+        returned = orchestrator.finalise(state, _dispatch_result())
+
+        assert isinstance(returned, FallbackNeeded)
+        assert returned.request is fallback_request
+        assert returned.state.is_fallback_round is True
+        assert returned.state.primary_outcome == primary_outcome
+        # Only the eligible skipped finding is sent to fallback
+        (fallback_findings, _config, _run) = (
+            fallback_strategy.prepare_validation.call_args.args
+        )
+        assert [f.id for f in fallback_findings] == ["o"]
+        assert [f.id for f in returned.state.strategy_findings] == ["o"]
+
+    def test_finalise_completes_fallback_round(self) -> None:
+        """Round 2 (is_fallback_round=True) -> merged ValidationResult."""
+        validated = _make_finding("v")
+        oversized = _make_finding("o")
+        primary_outcome = LLMValidationOutcome(
+            llm_validated_kept=[validated],
+            llm_validated_removed=[],
+            llm_not_flagged=[],
+            skipped=[SkippedFinding(finding=oversized, reason=SkipReason.OVERSIZED)],
+        )
+        # Fallback succeeds: oversized now validated as kept
+        fallback_outcome = LLMValidationOutcome(
+            llm_validated_kept=[oversized],
+            llm_validated_removed=[],
+            llm_not_flagged=[],
+            skipped=[],
+        )
+        # Primary strategy unused in round 2 — only fallback's finalise runs
+        primary_strategy = Mock()
+        fallback_strategy = _make_finalise_strategy(fallback_outcome)
+        orchestrator = ValidationOrchestrator(
+            llm_strategy=primary_strategy,
+            fallback_strategy=fallback_strategy,
+        )
+        round_two_state = OrchestratorPrepareState(
+            strategy_findings=[oversized],
+            config=_make_config(),
+            run_id=_TEST_RUN_ID,
+            primary_outcome=primary_outcome,
+            is_fallback_round=True,
+        )
+
+        result = orchestrator.finalise(round_two_state, _dispatch_result())
+
+        assert isinstance(result, ValidationResult)
+        assert {f.id for f in result.kept_findings} == {"v", "o"}
+        assert result.skipped_samples == []
+        assert result.all_succeeded is True
+        fallback_strategy.finalise_validation.assert_called_once()
+        primary_strategy.finalise_validation.assert_not_called()
+
+    def test_finalise_no_fallback_when_no_eligible_skipped(self) -> None:
+        """Fallback configured but no eligible skipped -> ValidationResult directly."""
+        validated = _make_finding("v")
+        batch_errored = _make_finding("b")
+        primary_outcome = LLMValidationOutcome(
+            llm_validated_kept=[validated],
+            llm_validated_removed=[],
+            llm_not_flagged=[],
+            # BATCH_ERROR is NOT in FALLBACK_ELIGIBLE_SKIP_REASONS
+            skipped=[
+                SkippedFinding(finding=batch_errored, reason=SkipReason.BATCH_ERROR)
+            ],
+        )
+        primary_strategy = _make_finalise_strategy(primary_outcome)
+        fallback_strategy = _make_prepare_mock(request=Mock(spec=LLMRequest))
+        orchestrator = ValidationOrchestrator(
+            llm_strategy=primary_strategy,
+            fallback_strategy=fallback_strategy,
+        )
+        state = OrchestratorPrepareState(
+            strategy_findings=[validated, batch_errored],
+            config=_make_config(),
+            run_id=_TEST_RUN_ID,
+        )
+
+        result = orchestrator.finalise(state, _dispatch_result())
+
+        assert isinstance(result, ValidationResult)
+        fallback_strategy.prepare_validation.assert_not_called()
+        assert [s.finding.id for s in result.skipped_samples] == ["b"]
+
+    def test_finalise_no_fallback_when_strategy_not_configured(self) -> None:
+        """No fallback strategy -> ValidationResult directly even with skipped."""
+        validated = _make_finding("v")
+        oversized = _make_finding("o")
+        primary_outcome = LLMValidationOutcome(
+            llm_validated_kept=[validated],
+            llm_validated_removed=[],
+            llm_not_flagged=[],
+            skipped=[SkippedFinding(finding=oversized, reason=SkipReason.OVERSIZED)],
+        )
+        primary_strategy = _make_finalise_strategy(primary_outcome)
+        orchestrator = ValidationOrchestrator(llm_strategy=primary_strategy)
+        state = OrchestratorPrepareState(
+            strategy_findings=[validated, oversized],
+            config=_make_config(),
+            run_id=_TEST_RUN_ID,
+        )
+
+        result = orchestrator.finalise(state, _dispatch_result())
+
+        assert isinstance(result, ValidationResult)
+        assert [s.finding.id for s in result.skipped_samples] == ["o"]

--- a/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_strategy_finalise_validation.py
+++ b/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_strategy_finalise_validation.py
@@ -1,0 +1,175 @@
+"""Tests for FilteringValidationStrategy's default finalise_validation().
+
+Business behaviour: Filtering strategies share identical response-to-outcome
+mapping. The default implementation on FilteringValidationStrategy deserialises
+raw dispatch responses, categorises findings, and handles skipped findings.
+"""
+
+from typing import override
+
+from waivern_core.schemas import (
+    BaseFindingEvidence,
+    BaseFindingMetadata,
+    BaseFindingModel,
+    PatternMatchDetail,
+)
+from waivern_core.types import JsonValue
+from waivern_llm import (
+    LLMDispatchResult,
+    LLMRequest,
+    SkippedFinding,
+    SkipReason,
+)
+
+from waivern_analysers_shared.llm_validation.models import LLMValidationOutcome
+from waivern_analysers_shared.llm_validation.strategy import (
+    FilteringValidationStrategy,
+)
+from waivern_analysers_shared.types import LLMValidationConfig
+
+_TestFinding = BaseFindingModel[BaseFindingMetadata]
+
+
+class _FilteringStrategyForTests(FilteringValidationStrategy[_TestFinding]):
+    """Concrete subclass — abstract methods unused by these tests."""
+
+    @override
+    def validate_findings(
+        self,
+        findings: list[_TestFinding],
+        config: LLMValidationConfig,
+        run_id: str,
+    ) -> LLMValidationOutcome[_TestFinding]:
+        raise NotImplementedError
+
+    @override
+    def prepare_validation(
+        self,
+        findings: list[_TestFinding],
+        config: LLMValidationConfig,
+        run_id: str,
+    ) -> tuple[list[_TestFinding], LLMRequest[_TestFinding] | None]:
+        raise NotImplementedError
+
+
+def _make_finding(finding_id: str) -> _TestFinding:
+    """Create a test finding with a deterministic ID."""
+    return BaseFindingModel(
+        id=finding_id,
+        evidence=[BaseFindingEvidence(content="test content")],
+        matched_patterns=[PatternMatchDetail(pattern="test", match_count=1)],
+        metadata=BaseFindingMetadata(source="test_source"),
+    )
+
+
+def _response_result(
+    finding_id: str,
+    validation_result: str = "TRUE_POSITIVE",
+    recommended_action: str = "keep",
+) -> dict[str, JsonValue]:
+    """Build a single raw response result dict."""
+    return {
+        "finding_id": finding_id,
+        "validation_result": validation_result,
+        "confidence": 0.9,
+        "reasoning": "test reasoning",
+        "recommended_action": recommended_action,
+    }
+
+
+def _dispatch_result(
+    responses: list[dict[str, JsonValue]],
+    skipped: list[SkippedFinding[_TestFinding]] | None = None,
+) -> LLMDispatchResult:
+    """Build an LLMDispatchResult with sensible defaults for tests."""
+    return LLMDispatchResult(
+        request_id="test-request",
+        model_name="test-model",
+        responses=responses,
+        skipped=list(skipped) if skipped else [],
+    )
+
+
+class TestDefaultFinaliseValidation:
+    """Tests for the default finalise_validation() on FilteringValidationStrategy."""
+
+    def test_deserialises_responses_and_categorises_findings(self) -> None:
+        """Raw dict responses -> TRUE_POSITIVE in kept, FALSE_POSITIVE in removed."""
+        strategy = _FilteringStrategyForTests()
+        kept_finding = _make_finding("kept")
+        removed_finding = _make_finding("removed")
+        dispatch_result = _dispatch_result(
+            responses=[
+                {
+                    "results": [
+                        _response_result("kept", "TRUE_POSITIVE", "keep"),
+                        _response_result("removed", "FALSE_POSITIVE", "discard"),
+                    ]
+                }
+            ],
+        )
+
+        outcome = strategy.finalise_validation(
+            [kept_finding, removed_finding], dispatch_result
+        )
+
+        assert outcome.llm_validated_kept == [kept_finding]
+        assert outcome.llm_validated_removed == [removed_finding]
+        assert outcome.llm_not_flagged == []
+        assert outcome.skipped == []
+
+    def test_findings_not_in_responses_are_not_flagged(self) -> None:
+        """Findings present in input but absent from LLM responses -> not_flagged."""
+        strategy = _FilteringStrategyForTests()
+        mentioned = _make_finding("mentioned")
+        missing_one = _make_finding("missing_one")
+        missing_two = _make_finding("missing_two")
+        dispatch_result = _dispatch_result(
+            responses=[{"results": [_response_result("mentioned")]}],
+        )
+
+        outcome = strategy.finalise_validation(
+            [mentioned, missing_one, missing_two], dispatch_result
+        )
+
+        assert outcome.llm_validated_kept == [mentioned]
+        assert outcome.llm_validated_removed == []
+        assert {f.id for f in outcome.llm_not_flagged} == {"missing_one", "missing_two"}
+        assert outcome.skipped == []
+
+    def test_matches_skipped_findings_to_typed_findings(self) -> None:
+        """SkippedFinding[Finding] from result -> SkippedFinding[TFinding] by ID."""
+        strategy = _FilteringStrategyForTests()
+        processed = _make_finding("processed")
+        skipped_finding = _make_finding("skipped")
+        dispatch_result = _dispatch_result(
+            responses=[{"results": [_response_result("processed")]}],
+            skipped=[
+                SkippedFinding(finding=skipped_finding, reason=SkipReason.OVERSIZED)
+            ],
+        )
+
+        outcome = strategy.finalise_validation(
+            [processed, skipped_finding], dispatch_result
+        )
+
+        assert outcome.llm_validated_kept == [processed]
+        assert outcome.llm_not_flagged == []
+        assert len(outcome.skipped) == 1
+        assert outcome.skipped[0].finding is skipped_finding
+        assert outcome.skipped[0].reason == SkipReason.OVERSIZED
+
+    def test_returns_all_skipped_when_result_is_none(self) -> None:
+        """None result -> all findings as SkippedFinding(BATCH_ERROR)."""
+        strategy = _FilteringStrategyForTests()
+        first = _make_finding("first")
+        second = _make_finding("second")
+
+        outcome = strategy.finalise_validation([first, second], None)
+
+        assert outcome.llm_validated_kept == []
+        assert outcome.llm_validated_removed == []
+        assert outcome.llm_not_flagged == []
+        assert len(outcome.skipped) == 2
+        assert all(s.reason == SkipReason.BATCH_ERROR for s in outcome.skipped)
+        assert {s.finding.id for s in outcome.skipped} == {"first", "second"}

--- a/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_validation_orchestrator.py
+++ b/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_validation_orchestrator.py
@@ -990,8 +990,8 @@ class TestFallbackValidation:
         assert (
             result.skipped_samples[0].reason == SkipReason.BATCH_ERROR
         )  # Fallback's reason
-        # Finding is still kept (conservative - skipped findings are kept)
-        assert len(result.kept_findings) == 0  # Without grouping, skipped not in kept
+        # Conservative semantics: skipped findings are kept in output
+        assert [f.id for f in result.kept_findings] == ["1"]
         assert result.all_succeeded is False
 
     def test_fallback_with_grouping_influences_group_decisions(self) -> None:
@@ -1133,6 +1133,7 @@ class TestFallbackValidation:
         assert result.skipped_samples[0].finding.id == "3"
         assert result.skipped_samples[0].reason == SkipReason.BATCH_ERROR
 
-        # Eligible findings are now kept
-        assert len(result.kept_findings) == 2
-        assert set(f.id for f in result.kept_findings) == {"1", "2"}
+        # Eligible findings are kept (validated by fallback); the BATCH_ERROR
+        # finding is also kept conservatively even though still skipped.
+        assert len(result.kept_findings) == 3
+        assert set(f.id for f in result.kept_findings) == {"1", "2", "3"}

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/llm_validation_strategy.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/llm_validation_strategy.py
@@ -11,11 +11,14 @@ from waivern_analysers_shared.llm_validation.models import (
     LLMValidationOutcome,
     LLMValidationResponseModel,
 )
-from waivern_analysers_shared.llm_validation.strategy import LLMValidationStrategy
+from waivern_analysers_shared.llm_validation.strategy import (
+    FilteringValidationStrategy,
+)
 from waivern_analysers_shared.types import LLMValidationConfig
 from waivern_llm import (
     BatchingMode,
     ItemGroup,
+    LLMRequest,
     LLMService,
     PendingBatchError,
     SkippedFinding,
@@ -29,9 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class DataSubjectValidationStrategy(
-    LLMValidationStrategy[
-        DataSubjectIndicatorModel, LLMValidationOutcome[DataSubjectIndicatorModel]
-    ]
+    FilteringValidationStrategy[DataSubjectIndicatorModel]
 ):
     """LLM validation strategy for data subject indicators.
 
@@ -47,6 +48,33 @@ class DataSubjectValidationStrategy(
 
         """
         self._llm_service = llm_service
+
+    @override
+    def prepare_validation(
+        self,
+        findings: list[DataSubjectIndicatorModel],
+        config: LLMValidationConfig,
+        run_id: str,
+    ) -> tuple[
+        list[DataSubjectIndicatorModel],
+        LLMRequest[DataSubjectIndicatorModel] | None,
+    ]:
+        """Build LLMRequest for data subject validation (COUNT_BASED)."""
+        if not findings:
+            return ([], None)
+
+        groups = [ItemGroup(items=findings, content=None)]
+        prompt_builder = DataSubjectPromptBuilder(
+            validation_mode=config.llm_validation_mode
+        )
+        request: LLMRequest[DataSubjectIndicatorModel] = LLMRequest(
+            groups=groups,
+            prompt_builder=prompt_builder,
+            response_model=LLMValidationResponseModel,
+            batching_mode=BatchingMode.COUNT_BASED,
+            run_id=run_id,
+        )
+        return (findings, request)
 
     @override
     def validate_findings(

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_llm_validation_strategy.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_llm_validation_strategy.py
@@ -17,6 +17,7 @@ from waivern_llm import (
     BatchingMode,
     ItemGroup,
     LLMCompletionResult,
+    LLMRequest,
     LLMService,
     SkipReason,
 )
@@ -80,6 +81,46 @@ class TestDataSubjectValidationStrategy:
                 "Employee", "employee_id", "mysql_database_(prod)_table_(employees)"
             ),
         ]
+
+    # =========================================================================
+    # prepare_validation (dispatcher-ready request construction)
+    # =========================================================================
+
+    def test_prepare_validation_builds_count_based_llm_request(
+        self,
+        mock_llm_service: Mock,
+        config: LLMValidationConfig,
+    ) -> None:
+        """prepare_validation returns an LLMRequest configured for COUNT_BASED batching."""
+        findings = [_make_finding("Customer"), _make_finding("Employee")]
+        strategy = DataSubjectValidationStrategy(mock_llm_service)
+
+        strategy_findings, request = strategy.prepare_validation(
+            findings, config, "test-run"
+        )
+
+        assert strategy_findings == findings
+        assert isinstance(request, LLMRequest)
+        assert request.batching_mode == BatchingMode.COUNT_BASED
+        assert request.run_id == "test-run"
+        assert isinstance(request.prompt_builder, DataSubjectPromptBuilder)
+        assert request.response_model == LLMValidationResponseModel
+        assert len(request.groups) == 1
+        assert isinstance(request.groups[0], ItemGroup)
+        assert list(request.groups[0].items) == findings
+
+    def test_prepare_validation_returns_no_request_for_empty_findings(
+        self,
+        mock_llm_service: Mock,
+        config: LLMValidationConfig,
+    ) -> None:
+        """Empty findings -> ([], None) so the orchestrator can skip dispatch."""
+        strategy = DataSubjectValidationStrategy(mock_llm_service)
+
+        strategy_findings, request = strategy.prepare_validation([], config, "test-run")
+
+        assert strategy_findings == []
+        assert request is None
 
     # =========================================================================
     # Core Validation Behaviour

--- a/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/llm_validation_strategy.py
+++ b/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/llm_validation_strategy.py
@@ -11,11 +11,14 @@ from waivern_analysers_shared.llm_validation.models import (
     LLMValidationOutcome,
     LLMValidationResponseModel,
 )
-from waivern_analysers_shared.llm_validation.strategy import LLMValidationStrategy
+from waivern_analysers_shared.llm_validation.strategy import (
+    FilteringValidationStrategy,
+)
 from waivern_analysers_shared.types import LLMValidationConfig
 from waivern_llm import (
     BatchingMode,
     ItemGroup,
+    LLMRequest,
     LLMService,
     PendingBatchError,
     SkippedFinding,
@@ -29,9 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class PersonalDataValidationStrategy(
-    LLMValidationStrategy[
-        PersonalDataIndicatorModel, LLMValidationOutcome[PersonalDataIndicatorModel]
-    ]
+    FilteringValidationStrategy[PersonalDataIndicatorModel]
 ):
     """LLM validation strategy for personal data indicators.
 
@@ -47,6 +48,33 @@ class PersonalDataValidationStrategy(
 
         """
         self._llm_service = llm_service
+
+    @override
+    def prepare_validation(
+        self,
+        findings: list[PersonalDataIndicatorModel],
+        config: LLMValidationConfig,
+        run_id: str,
+    ) -> tuple[
+        list[PersonalDataIndicatorModel],
+        LLMRequest[PersonalDataIndicatorModel] | None,
+    ]:
+        """Build LLMRequest for personal data validation (COUNT_BASED)."""
+        if not findings:
+            return ([], None)
+
+        groups = [ItemGroup(items=findings, content=None)]
+        prompt_builder = PersonalDataPromptBuilder(
+            validation_mode=config.llm_validation_mode
+        )
+        request: LLMRequest[PersonalDataIndicatorModel] = LLMRequest(
+            groups=groups,
+            prompt_builder=prompt_builder,
+            response_model=LLMValidationResponseModel,
+            batching_mode=BatchingMode.COUNT_BASED,
+            run_id=run_id,
+        )
+        return (findings, request)
 
     @override
     def validate_findings(

--- a/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_llm_validation_strategy.py
+++ b/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_llm_validation_strategy.py
@@ -17,6 +17,7 @@ from waivern_llm import (
     BatchingMode,
     ItemGroup,
     LLMCompletionResult,
+    LLMRequest,
     LLMService,
     SkipReason,
 )
@@ -74,6 +75,46 @@ class TestPersonalDataValidationStrategy:
                 "phone", "123-456-7890", "mysql_database_(prod)_table_(contacts)"
             ),
         ]
+
+    # =========================================================================
+    # prepare_validation (dispatcher-ready request construction)
+    # =========================================================================
+
+    def test_prepare_validation_builds_count_based_llm_request(
+        self,
+        mock_llm_service: Mock,
+        config: LLMValidationConfig,
+    ) -> None:
+        """prepare_validation returns an LLMRequest configured for COUNT_BASED batching."""
+        findings = [_make_finding("email"), _make_finding("phone")]
+        strategy = PersonalDataValidationStrategy(mock_llm_service)
+
+        strategy_findings, request = strategy.prepare_validation(
+            findings, config, "test-run"
+        )
+
+        assert strategy_findings == findings
+        assert isinstance(request, LLMRequest)
+        assert request.batching_mode == BatchingMode.COUNT_BASED
+        assert request.run_id == "test-run"
+        assert isinstance(request.prompt_builder, PersonalDataPromptBuilder)
+        assert request.response_model == LLMValidationResponseModel
+        assert len(request.groups) == 1
+        assert isinstance(request.groups[0], ItemGroup)
+        assert list(request.groups[0].items) == findings
+
+    def test_prepare_validation_returns_no_request_for_empty_findings(
+        self,
+        mock_llm_service: Mock,
+        config: LLMValidationConfig,
+    ) -> None:
+        """Empty findings -> ([], None) so the orchestrator can skip dispatch."""
+        strategy = PersonalDataValidationStrategy(mock_llm_service)
+
+        strategy_findings, request = strategy.prepare_validation([], config, "test-run")
+
+        assert strategy_findings == []
+        assert request is None
 
     # =========================================================================
     # Core Validation Behaviour

--- a/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/llm_validation_strategy.py
+++ b/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/llm_validation_strategy.py
@@ -11,11 +11,14 @@ from waivern_analysers_shared.llm_validation.models import (
     LLMValidationOutcome,
     LLMValidationResponseModel,
 )
-from waivern_analysers_shared.llm_validation.strategy import LLMValidationStrategy
+from waivern_analysers_shared.llm_validation.strategy import (
+    FilteringValidationStrategy,
+)
 from waivern_analysers_shared.types import LLMValidationConfig
 from waivern_llm import (
     BatchingMode,
     ItemGroup,
+    LLMRequest,
     LLMService,
     PendingBatchError,
     SkippedFinding,
@@ -29,10 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class ProcessingPurposeValidationStrategy(
-    LLMValidationStrategy[
-        ProcessingPurposeIndicatorModel,
-        LLMValidationOutcome[ProcessingPurposeIndicatorModel],
-    ]
+    FilteringValidationStrategy[ProcessingPurposeIndicatorModel]
 ):
     """LLM validation strategy for processing purpose indicators.
 
@@ -48,6 +48,33 @@ class ProcessingPurposeValidationStrategy(
 
         """
         self._llm_service = llm_service
+
+    @override
+    def prepare_validation(
+        self,
+        findings: list[ProcessingPurposeIndicatorModel],
+        config: LLMValidationConfig,
+        run_id: str,
+    ) -> tuple[
+        list[ProcessingPurposeIndicatorModel],
+        LLMRequest[ProcessingPurposeIndicatorModel] | None,
+    ]:
+        """Build LLMRequest for processing purpose validation (COUNT_BASED)."""
+        if not findings:
+            return ([], None)
+
+        groups = [ItemGroup(items=findings, content=None)]
+        prompt_builder = ProcessingPurposePromptBuilder(
+            validation_mode=config.llm_validation_mode
+        )
+        request: LLMRequest[ProcessingPurposeIndicatorModel] = LLMRequest(
+            groups=groups,
+            prompt_builder=prompt_builder,
+            response_model=LLMValidationResponseModel,
+            batching_mode=BatchingMode.COUNT_BASED,
+            run_id=run_id,
+        )
+        return (findings, request)
 
     @override
     def validate_findings(

--- a/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/validation/extended_context_strategy.py
+++ b/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/validation/extended_context_strategy.py
@@ -15,11 +15,14 @@ from waivern_analysers_shared.llm_validation.models import (
     LLMValidationOutcome,
     LLMValidationResponseModel,
 )
-from waivern_analysers_shared.llm_validation.strategy import LLMValidationStrategy
+from waivern_analysers_shared.llm_validation.strategy import (
+    FilteringValidationStrategy,
+)
 from waivern_analysers_shared.types import LLMValidationConfig
 from waivern_llm import (
     BatchingMode,
     ItemGroup,
+    LLMRequest,
     LLMService,
     PendingBatchError,
     SkippedFinding,
@@ -37,10 +40,7 @@ logger = logging.getLogger(__name__)
 
 
 class SourceCodeValidationStrategy(
-    LLMValidationStrategy[
-        ProcessingPurposeIndicatorModel,
-        LLMValidationOutcome[ProcessingPurposeIndicatorModel],
-    ]
+    FilteringValidationStrategy[ProcessingPurposeIndicatorModel]
 ):
     """Validation strategy for source_code schema findings.
 
@@ -63,6 +63,33 @@ class SourceCodeValidationStrategy(
         """
         self._llm_service = llm_service
         self._source_provider = source_provider
+
+    @override
+    def prepare_validation(
+        self,
+        findings: list[ProcessingPurposeIndicatorModel],
+        config: LLMValidationConfig,
+        run_id: str,
+    ) -> tuple[
+        list[ProcessingPurposeIndicatorModel],
+        LLMRequest[ProcessingPurposeIndicatorModel] | None,
+    ]:
+        """Build LLMRequest for source code validation (EXTENDED_CONTEXT)."""
+        if not findings:
+            return ([], None)
+
+        groups = self._create_groups_by_source(findings)
+        prompt_builder = SourceCodePromptBuilder(
+            validation_mode=config.llm_validation_mode
+        )
+        request: LLMRequest[ProcessingPurposeIndicatorModel] = LLMRequest(
+            groups=groups,
+            prompt_builder=prompt_builder,
+            response_model=LLMValidationResponseModel,
+            batching_mode=BatchingMode.EXTENDED_CONTEXT,
+            run_id=run_id,
+        )
+        return (findings, request)
 
     @override
     def validate_findings(

--- a/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_llm_validation_strategy.py
+++ b/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_llm_validation_strategy.py
@@ -17,6 +17,7 @@ from waivern_llm import (
     BatchingMode,
     ItemGroup,
     LLMCompletionResult,
+    LLMRequest,
     LLMService,
     SkippedFinding,
     SkipReason,
@@ -86,6 +87,49 @@ class TestProcessingPurposeValidationStrategy:
                 "User Analytics", "analytics", "mysql_database_(prod)_table_(events)"
             ),
         ]
+
+    # =========================================================================
+    # prepare_validation (dispatcher-ready request construction)
+    # =========================================================================
+
+    def test_prepare_validation_builds_count_based_llm_request(
+        self,
+        mock_llm_service: Mock,
+        config: LLMValidationConfig,
+    ) -> None:
+        """prepare_validation returns an LLMRequest configured for COUNT_BASED batching."""
+        findings = [
+            _make_finding("Payment Processing"),
+            _make_finding("User Analytics"),
+        ]
+        strategy = ProcessingPurposeValidationStrategy(mock_llm_service)
+
+        strategy_findings, request = strategy.prepare_validation(
+            findings, config, "test-run"
+        )
+
+        assert strategy_findings == findings
+        assert isinstance(request, LLMRequest)
+        assert request.batching_mode == BatchingMode.COUNT_BASED
+        assert request.run_id == "test-run"
+        assert isinstance(request.prompt_builder, ProcessingPurposePromptBuilder)
+        assert request.response_model == LLMValidationResponseModel
+        assert len(request.groups) == 1
+        assert isinstance(request.groups[0], ItemGroup)
+        assert list(request.groups[0].items) == findings
+
+    def test_prepare_validation_returns_no_request_for_empty_findings(
+        self,
+        mock_llm_service: Mock,
+        config: LLMValidationConfig,
+    ) -> None:
+        """Empty findings -> ([], None) so the orchestrator can skip dispatch."""
+        strategy = ProcessingPurposeValidationStrategy(mock_llm_service)
+
+        strategy_findings, request = strategy.prepare_validation([], config, "test-run")
+
+        assert strategy_findings == []
+        assert request is None
 
     # =========================================================================
     # Core Validation Behaviour
@@ -310,6 +354,56 @@ class TestSourceCodeValidationStrategy:
                 "/src/AnalyticsService.php",
             ),
         ]
+
+    # =========================================================================
+    # prepare_validation (dispatcher-ready request construction)
+    # =========================================================================
+
+    def test_prepare_validation_builds_extended_context_llm_request(
+        self,
+        mock_llm_service: Mock,
+        source_provider: SourceCodeSourceProvider,
+        config: LLMValidationConfig,
+        sample_findings: list[ProcessingPurposeIndicatorModel],
+    ) -> None:
+        """prepare_validation returns LLMRequest configured for EXTENDED_CONTEXT.
+
+        Groups are created per source file and carry the file content needed for
+        context-aware validation.
+        """
+        strategy = SourceCodeValidationStrategy(mock_llm_service, source_provider)
+
+        strategy_findings, request = strategy.prepare_validation(
+            sample_findings, config, "test-run"
+        )
+
+        assert strategy_findings == sample_findings
+        assert isinstance(request, LLMRequest)
+        assert request.batching_mode == BatchingMode.EXTENDED_CONTEXT
+        assert request.run_id == "test-run"
+        assert isinstance(request.prompt_builder, SourceCodePromptBuilder)
+        assert request.response_model == LLMValidationResponseModel
+        # One group per source file; content populated from the source provider
+        assert len(request.groups) == 2
+        assert {g.group_id for g in request.groups} == {
+            "/src/PaymentService.php",
+            "/src/AnalyticsService.php",
+        }
+        assert all(g.content is not None for g in request.groups)
+
+    def test_prepare_validation_returns_no_request_for_empty_findings(
+        self,
+        mock_llm_service: Mock,
+        source_provider: SourceCodeSourceProvider,
+        config: LLMValidationConfig,
+    ) -> None:
+        """Empty findings -> ([], None) so the orchestrator can skip dispatch."""
+        strategy = SourceCodeValidationStrategy(mock_llm_service, source_provider)
+
+        strategy_findings, request = strategy.prepare_validation([], config, "test-run")
+
+        assert strategy_findings == []
+        assert request is None
 
     # =========================================================================
     # Core Validation Behaviour


### PR DESCRIPTION
## Summary

- Add `prepare_validation` / `finalise_validation` on `LLMValidationStrategy` and `prepare()` / `finalise()` on `ValidationOrchestrator` to enable executor-driven dispatch. `prepare` builds an `LLMRequest` without making LLM calls; `finalise` interprets dispatch results and applies group-level decisions.
- Introduce `FilteringValidationStrategy` intermediate class with a default `finalise_validation` that deserialises raw responses, categorises findings, and re-types skipped findings by ID.
- Multi-round fallback is handled via a `FallbackNeeded` signal returned from `finalise()` when eligible skipped findings need a second dispatch round.
- Implement `prepare_validation` in the `PersonalData`, `DataSubject`, `ProcessingPurpose` (COUNT_BASED) and `SourceCode` (EXTENDED_CONTEXT) strategies. The existing `validate_findings` / `validate` path is retained during migration.
- Fix a pre-existing bug where skipped findings were silently dropped from `ValidationResult.kept_findings` in the ungrouped path, contradicting the documented conservative semantics. The intentional exception for the grouped `remove_group` case is now documented on both the `kept_findings` field and the orchestrator's group-decision code.

## Test plan

- [x] Unit tests for `FilteringValidationStrategy.finalise_validation()` default (4 tests)
- [x] Unit tests for `ValidationOrchestrator.prepare()` (4 tests)
- [x] Unit tests for `ValidationOrchestrator.finalise()` non-fallback path (3 tests)
- [x] Unit tests for `ValidationOrchestrator.finalise()` fallback rounds (4 tests)
- [x] `prepare_validation` tests for each concrete strategy (2 tests × 4 strategies)
- [x] Updated existing fallback tests to reflect the corrected conservative `kept_findings` semantics
- [x] `./scripts/dev-checks.sh` passes cleanly
- [x] Full repo test suite (2052 passed, 12 skipped, 26 deselected)