### PR TITLE
refactor: decouple analyser tests from production rulesets

### DIFF
--- a/libs/waivern-crypto-quality-analyser/src/waivern_crypto_quality_analyser/analyser.py
+++ b/libs/waivern-crypto-quality-analyser/src/waivern_crypto_quality_analyser/analyser.py
@@ -5,9 +5,11 @@ import logging
 from typing import override
 
 from waivern_analysers_shared import SchemaReader
+from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core import Analyser, InputRequirement
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
+from waivern_rulesets.crypto_quality_indicator import CryptoQualityIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
 from waivern_schemas.crypto_quality_indicator import CryptoQualityIndicatorModel
 from waivern_schemas.standard_input import (
@@ -38,7 +40,12 @@ class CryptoQualityAnalyser(Analyser):
 
         """
         self._config = config
-        self._pattern_matcher = CryptoQualityPatternMatcher(config.pattern_matching)
+        rules = RulesetManager.get_rules(
+            config.pattern_matching.ruleset, CryptoQualityIndicatorRule
+        )
+        self._pattern_matcher = CryptoQualityPatternMatcher(
+            rules, config.pattern_matching
+        )
         self._result_builder = CryptoQualityResultBuilder(config)
 
     @classmethod

--- a/libs/waivern-crypto-quality-analyser/src/waivern_crypto_quality_analyser/pattern_matcher.py
+++ b/libs/waivern-crypto-quality-analyser/src/waivern_crypto_quality_analyser/pattern_matcher.py
@@ -2,7 +2,7 @@
 
 from waivern_analysers_shared.matching import RulePatternDispatcher
 from waivern_analysers_shared.types import PatternMatchingConfig
-from waivern_analysers_shared.utilities import EvidenceExtractor, RulesetManager
+from waivern_analysers_shared.utilities import EvidenceExtractor
 from waivern_core.schemas import PatternMatchDetail
 from waivern_rulesets.crypto_quality_indicator import CryptoQualityIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
@@ -24,20 +24,25 @@ _POLARITY_MAP: dict[str, str] = {
 class CryptoQualityPatternMatcher:
     """Pattern matcher for cryptographic algorithm quality analysis.
 
-    Scans text content for known algorithm patterns and assigns quality
-    ratings and polarity based on the matched rule's quality_rating field.
+    Accepts rules via constructor to decouple from ruleset loading.
+    The analyser loads rules and passes them in at construction time.
     """
 
-    def __init__(self, config: PatternMatchingConfig) -> None:
-        """Initialise the pattern matcher with configuration.
+    def __init__(
+        self,
+        rules: tuple[CryptoQualityIndicatorRule, ...],
+        config: PatternMatchingConfig,
+    ) -> None:
+        """Initialise the pattern matcher with rules and configuration.
 
         Args:
-            config: Pattern matching configuration
+            rules: Crypto quality indicator detection rules.
+            config: Pattern matching configuration for evidence extraction.
 
         """
+        self._rules = rules
         self._config = config
         self._evidence_extractor = EvidenceExtractor()
-        self._ruleset_manager = RulesetManager()
         self._dispatcher = RulePatternDispatcher()
 
     def find_patterns(
@@ -58,12 +63,9 @@ class CryptoQualityPatternMatcher:
         if not content.strip():
             return []
 
-        rules = self._ruleset_manager.get_rules(
-            self._config.ruleset, CryptoQualityIndicatorRule
-        )
         findings: list[CryptoQualityIndicatorModel] = []
 
-        for rule in rules:
+        for rule in self._rules:
             results = self._dispatcher.find_matches(
                 content,
                 rule,

--- a/libs/waivern-crypto-quality-analyser/tests/waivern_crypto_quality_analyser/test_analyser.py
+++ b/libs/waivern-crypto-quality-analyser/tests/waivern_crypto_quality_analyser/test_analyser.py
@@ -1,12 +1,97 @@
-"""Unit tests for CryptoQualityAnalyser."""
+"""Unit tests for CryptoQualityAnalyser.
+
+Uses synthetic rules via monkeypatched RulesetManager to decouple from
+production ruleset data.
+"""
 
 import pytest
+from waivern_analysers_shared.types import PatternMatchingConfig
+from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core import AnalyserContractTests
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
+from waivern_rulesets.crypto_quality_indicator import CryptoQualityIndicatorRule
 
 from waivern_crypto_quality_analyser.analyser import CryptoQualityAnalyser
 from waivern_crypto_quality_analyser.types import CryptoQualityAnalyserConfig
+
+# =============================================================================
+# Synthetic rules
+# =============================================================================
+
+RULE_STRONG = CryptoQualityIndicatorRule(
+    name="Test Strong Algo",
+    description="Strong algorithm detection",
+    category="strong_algo",
+    algorithm="test_strong",
+    quality_rating="strong",
+    patterns=("test_strong_pattern",),
+)
+
+RULE_WEAK = CryptoQualityIndicatorRule(
+    name="Test Weak Algo",
+    description="Weak algorithm detection",
+    category="weak_algo",
+    algorithm="test_weak",
+    quality_rating="weak",
+    patterns=("test_weak_pattern",),
+)
+
+RULE_DEPRECATED = CryptoQualityIndicatorRule(
+    name="Test Deprecated Algo",
+    description="Deprecated algorithm detection",
+    category="deprecated_algo",
+    algorithm="test_deprecated",
+    quality_rating="deprecated",
+    patterns=("test_deprecated_pattern",),
+)
+
+SYNTHETIC_RULES = (RULE_STRONG, RULE_WEAK, RULE_DEPRECATED)
+
+_UNUSED_RULESET_URI = "unused/test/1.0.0"
+
+
+def _mock_get_rules(
+    uri: str, rule_type: type[CryptoQualityIndicatorRule]
+) -> tuple[CryptoQualityIndicatorRule, ...]:
+    return SYNTHETIC_RULES
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+OUTPUT_SCHEMA = Schema("crypto_quality_indicator", "1.0.0")
+INPUT_SCHEMA = Schema("standard_input", "1.0.0")
+
+
+def _make_config() -> CryptoQualityAnalyserConfig:
+    """Build a CryptoQualityAnalyserConfig with synthetic ruleset URI."""
+    return CryptoQualityAnalyserConfig(
+        pattern_matching=PatternMatchingConfig(ruleset=_UNUSED_RULESET_URI),
+    )
+
+
+def _make_message(content: str) -> Message:
+    """Build a standard_input message carrying a single data item."""
+    return Message(
+        id="test-message",
+        content={
+            "schemaVersion": "1.0.0",
+            "name": "Test source",
+            "data": [
+                {
+                    "content": content,
+                    "metadata": {
+                        "source": "test.txt",
+                        "connector_type": "test",
+                    },
+                }
+            ],
+        },
+        schema=INPUT_SCHEMA,
+    )
+
 
 # =============================================================================
 # Contract tests
@@ -14,11 +99,7 @@ from waivern_crypto_quality_analyser.types import CryptoQualityAnalyserConfig
 
 
 class TestCryptoQualityAnalyserContract(AnalyserContractTests[CryptoQualityAnalyser]):
-    """Contract tests for CryptoQualityAnalyser.
-
-    Inherits from AnalyserContractTests to verify that CryptoQualityAnalyser
-    meets the Analyser interface contract.
-    """
+    """Contract tests for CryptoQualityAnalyser."""
 
     @pytest.fixture
     def processor_class(self) -> type[CryptoQualityAnalyser]:
@@ -32,171 +113,58 @@ class TestCryptoQualityAnalyserContract(AnalyserContractTests[CryptoQualityAnaly
 
 
 class TestCryptoQualityPolarity:
-    """Tests for polarity assignment and algorithm field derivation."""
+    """Tests for polarity assignment based on quality_rating."""
 
-    @pytest.fixture
-    def valid_config(self) -> CryptoQualityAnalyserConfig:
-        """Return default configuration using local crypto_quality_indicator ruleset."""
-        return CryptoQualityAnalyserConfig()
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
 
-    @pytest.fixture
-    def deprecated_input_message(self) -> Message:
-        """Input message containing a deprecated algorithm reference."""
-        return Message(
-            id="test_deprecated",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Test source",
-                "data": [
-                    {
-                        "content": "password_hash = md5(password)",
-                        "metadata": {
-                            "source": "auth.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
+    def test_deprecated_algorithm_produces_negative_polarity(self) -> None:
+        """A deprecated algorithm yields polarity=negative."""
+        analyser = CryptoQualityAnalyser(config=_make_config())
+        message = _make_message("Using test_deprecated_pattern for hashing")
 
-    @pytest.fixture
-    def strong_input_message(self) -> Message:
-        """Input message containing a strong algorithm reference."""
-        return Message(
-            id="test_strong",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Test source",
-                "data": [
-                    {
-                        "content": "hashed = bcrypt.hashpw(password, bcrypt.gensalt())",
-                        "metadata": {
-                            "source": "auth.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
-
-    @pytest.fixture
-    def weak_input_message(self) -> Message:
-        """Input message containing a weak algorithm reference."""
-        return Message(
-            id="test_weak",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Test source",
-                "data": [
-                    {
-                        "content": "cipher = blowfish.new(key)",
-                        "metadata": {
-                            "source": "crypto.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
-
-    @pytest.fixture
-    def output_schema(self) -> Schema:
-        """Return the standard output schema for crypto_quality_indicator."""
-        return Schema("crypto_quality_indicator", "1.0.0")
-
-    def test_deprecated_algorithm_produces_negative_polarity(
-        self,
-        valid_config: CryptoQualityAnalyserConfig,
-        deprecated_input_message: Message,
-        output_schema: Schema,
-    ) -> None:
-        """A deprecated algorithm (md5) yields polarity=negative."""
-        analyser = CryptoQualityAnalyser(valid_config)
-        result = analyser.process([deprecated_input_message], output_schema)
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
-        assert len(findings) >= 1
-        md5_finding = next(f for f in findings if f["algorithm"] == "md5")
-        assert md5_finding["polarity"] == "negative"
-        assert md5_finding["quality_rating"] == "deprecated"
+        assert len(findings) == 1
+        assert findings[0]["algorithm"] == "test_deprecated"
+        assert findings[0]["polarity"] == "negative"
+        assert findings[0]["quality_rating"] == "deprecated"
 
-    def test_strong_algorithm_produces_positive_polarity(
-        self,
-        valid_config: CryptoQualityAnalyserConfig,
-        strong_input_message: Message,
-        output_schema: Schema,
-    ) -> None:
-        """A strong algorithm (bcrypt) yields polarity=positive."""
-        analyser = CryptoQualityAnalyser(valid_config)
-        result = analyser.process([strong_input_message], output_schema)
+    def test_strong_algorithm_produces_positive_polarity(self) -> None:
+        """A strong algorithm yields polarity=positive."""
+        analyser = CryptoQualityAnalyser(config=_make_config())
+        message = _make_message("Using test_strong_pattern for hashing")
+
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
-        assert len(findings) >= 1
-        bcrypt_finding = next(f for f in findings if f["algorithm"] == "bcrypt")
-        assert bcrypt_finding["polarity"] == "positive"
-        assert bcrypt_finding["quality_rating"] == "strong"
+        assert len(findings) == 1
+        assert findings[0]["algorithm"] == "test_strong"
+        assert findings[0]["polarity"] == "positive"
+        assert findings[0]["quality_rating"] == "strong"
 
-    def test_weak_algorithm_produces_negative_polarity(
-        self,
-        valid_config: CryptoQualityAnalyserConfig,
-        weak_input_message: Message,
-        output_schema: Schema,
-    ) -> None:
-        """A weak algorithm (blowfish) yields polarity=negative."""
-        analyser = CryptoQualityAnalyser(valid_config)
-        result = analyser.process([weak_input_message], output_schema)
+    def test_weak_algorithm_produces_negative_polarity(self) -> None:
+        """A weak algorithm yields polarity=negative."""
+        analyser = CryptoQualityAnalyser(config=_make_config())
+        message = _make_message("Using test_weak_pattern for encryption")
+
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
-        assert len(findings) >= 1
-        blowfish_finding = next(f for f in findings if f["algorithm"] == "blowfish")
-        assert blowfish_finding["polarity"] == "negative"
-        assert blowfish_finding["quality_rating"] == "weak"
+        assert len(findings) == 1
+        assert findings[0]["algorithm"] == "test_weak"
+        assert findings[0]["polarity"] == "negative"
+        assert findings[0]["quality_rating"] == "weak"
 
-    def test_algorithm_field_matches_rule_algorithm(
-        self,
-        valid_config: CryptoQualityAnalyserConfig,
-        deprecated_input_message: Message,
-        output_schema: Schema,
-    ) -> None:
-        """Finding.algorithm matches the canonical name from the ruleset."""
-        analyser = CryptoQualityAnalyser(valid_config)
-        result = analyser.process([deprecated_input_message], output_schema)
-
-        findings = result.content["findings"]
-        assert len(findings) >= 1
-        # The ruleset YAML defines algorithm="md5" for the md5 rule;
-        # the pattern "md5" in content triggers it.
-        assert any(f["algorithm"] == "md5" for f in findings)
-
-    def test_no_crypto_patterns_produces_no_findings(
-        self,
-        valid_config: CryptoQualityAnalyserConfig,
-        output_schema: Schema,
-    ) -> None:
+    def test_no_crypto_patterns_produces_no_findings(self) -> None:
         """Content with no recognised algorithm patterns produces zero findings."""
-        analyser = CryptoQualityAnalyser(valid_config)
-        message = Message(
-            id="test_no_patterns",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Clean source",
-                "data": [
-                    {
-                        "content": "x = a + b",
-                        "metadata": {
-                            "source": "math.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
+        analyser = CryptoQualityAnalyser(config=_make_config())
+        message = _make_message("x = a + b")
 
-        result = analyser.process([message], output_schema)
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         assert result.content["findings"] == []
         assert result.content["summary"]["total_findings"] == 0
@@ -210,63 +178,31 @@ class TestCryptoQualityPolarity:
 class TestCryptoQualityOutputStructure:
     """Tests for the shape and schema compliance of the output message."""
 
-    @pytest.fixture
-    def valid_config(self) -> CryptoQualityAnalyserConfig:
-        """Return default configuration using local crypto_quality_indicator ruleset."""
-        return CryptoQualityAnalyserConfig()
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
 
-    @pytest.fixture
-    def deprecated_input_message(self) -> Message:
-        """Input message containing a deprecated algorithm reference."""
-        return Message(
-            id="test_deprecated",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Test source",
-                "data": [
-                    {
-                        "content": "password_hash = md5(password)",
-                        "metadata": {
-                            "source": "auth.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
-
-    @pytest.fixture
-    def output_schema(self) -> Schema:
-        """Return the standard output schema for crypto_quality_indicator."""
-        return Schema("crypto_quality_indicator", "1.0.0")
-
-    def test_process_returns_valid_output_message_structure(
-        self,
-        valid_config: CryptoQualityAnalyserConfig,
-        deprecated_input_message: Message,
-        output_schema: Schema,
-    ) -> None:
+    def test_process_returns_valid_output_message_structure(self) -> None:
         """process() returns a Message with the correct schema and content keys."""
-        analyser = CryptoQualityAnalyser(valid_config)
-        result = analyser.process([deprecated_input_message], output_schema)
+        analyser = CryptoQualityAnalyser(config=_make_config())
+        message = _make_message("Using test_strong_pattern for hashing")
+
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         assert isinstance(result, Message)
-        assert result.schema == output_schema
+        assert result.schema == OUTPUT_SCHEMA
         assert "findings" in result.content
         assert "summary" in result.content
         assert "analysis_metadata" in result.content
         assert isinstance(result.content["findings"], list)
 
-    def test_summary_total_findings_matches_findings_count(
-        self,
-        valid_config: CryptoQualityAnalyserConfig,
-        deprecated_input_message: Message,
-        output_schema: Schema,
-    ) -> None:
+    def test_summary_total_findings_matches_findings_count(self) -> None:
         """summary.total_findings equals len(findings)."""
-        analyser = CryptoQualityAnalyser(valid_config)
-        result = analyser.process([deprecated_input_message], output_schema)
+        analyser = CryptoQualityAnalyser(config=_make_config())
+        message = _make_message("Using test_strong_pattern for hashing")
+
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
         summary = result.content["summary"]
@@ -281,76 +217,20 @@ class TestCryptoQualityOutputStructure:
 class TestCryptoQualityFanIn:
     """Tests for fan-in: multiple input messages produce merged findings."""
 
-    @pytest.fixture
-    def valid_config(self) -> CryptoQualityAnalyserConfig:
-        """Return default configuration using local crypto_quality_indicator ruleset."""
-        return CryptoQualityAnalyserConfig()
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
 
-    @pytest.fixture
-    def deprecated_input_message(self) -> Message:
-        """Input message containing a deprecated algorithm reference."""
-        return Message(
-            id="test_deprecated",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Test source",
-                "data": [
-                    {
-                        "content": "password_hash = md5(password)",
-                        "metadata": {
-                            "source": "auth.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
-
-    @pytest.fixture
-    def strong_input_message(self) -> Message:
-        """Input message containing a strong algorithm reference."""
-        return Message(
-            id="test_strong",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Test source",
-                "data": [
-                    {
-                        "content": "hashed = bcrypt.hashpw(password, bcrypt.gensalt())",
-                        "metadata": {
-                            "source": "auth.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
-
-    @pytest.fixture
-    def output_schema(self) -> Schema:
-        """Return the standard output schema for crypto_quality_indicator."""
-        return Schema("crypto_quality_indicator", "1.0.0")
-
-    def test_process_merges_findings_from_multiple_inputs(
-        self,
-        valid_config: CryptoQualityAnalyserConfig,
-        deprecated_input_message: Message,
-        strong_input_message: Message,
-        output_schema: Schema,
-    ) -> None:
+    def test_process_merges_findings_from_multiple_inputs(self) -> None:
         """Findings from multiple input messages are all present in the output."""
-        analyser = CryptoQualityAnalyser(valid_config)
-        result = analyser.process(
-            [deprecated_input_message, strong_input_message], output_schema
-        )
+        analyser = CryptoQualityAnalyser(config=_make_config())
+        msg_deprecated = _make_message("Using test_deprecated_pattern for hashing")
+        msg_strong = _make_message("Using test_strong_pattern for encryption")
+
+        result = analyser.process([msg_deprecated, msg_strong], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
         algorithms = {f["algorithm"] for f in findings}
-        assert "md5" in algorithms, (
-            "Findings from deprecated_input_message should be present"
-        )
-        assert "bcrypt" in algorithms, (
-            "Findings from strong_input_message should be present"
-        )
+        assert "test_deprecated" in algorithms
+        assert "test_strong" in algorithms

--- a/libs/waivern-crypto-quality-analyser/tests/waivern_crypto_quality_analyser/test_factory.py
+++ b/libs/waivern-crypto-quality-analyser/tests/waivern_crypto_quality_analyser/test_factory.py
@@ -1,0 +1,94 @@
+"""Tests for CryptoQualityAnalyserFactory.
+
+Inherits contract tests from ``ComponentFactoryContractTests`` and adds
+factory-specific validation checks (ruleset availability).
+
+Uses monkeypatched RulesetManager to decouple from production rulesets.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from waivern_analysers_shared.utilities import RulesetManager
+from waivern_core import (
+    ComponentConfig,
+    ComponentFactory,
+    ComponentFactoryContractTests,
+)
+from waivern_core.services import ServiceContainer
+from waivern_rulesets import AbstractRuleset
+from waivern_rulesets.crypto_quality_indicator import CryptoQualityIndicatorRule
+
+from waivern_crypto_quality_analyser import CryptoQualityAnalyser
+from waivern_crypto_quality_analyser.factory import CryptoQualityAnalyserFactory
+
+_VALID_RULESET_URI = "local/test_crypto_quality/1.0.0"
+
+RULE_STRONG = CryptoQualityIndicatorRule(
+    name="Test Strong Algo",
+    description="Strong algorithm detection",
+    category="strong_algo",
+    algorithm="test_strong",
+    quality_rating="strong",
+    patterns=("test_strong_pattern",),
+)
+
+SYNTHETIC_RULES = (RULE_STRONG,)
+
+
+def _mock_get_ruleset(
+    uri: str, rule_type: type[CryptoQualityIndicatorRule]
+) -> AbstractRuleset[CryptoQualityIndicatorRule]:
+    """Return a mock ruleset for the valid URI; raise for unknown URIs."""
+    if uri == _VALID_RULESET_URI:
+        mock_ruleset = MagicMock(spec=AbstractRuleset)
+        mock_ruleset.get_rules.return_value = SYNTHETIC_RULES
+        return mock_ruleset
+    raise ValueError(f"Unknown ruleset URI: {uri}")
+
+
+def _mock_get_rules(
+    uri: str, rule_type: type[CryptoQualityIndicatorRule]
+) -> tuple[CryptoQualityIndicatorRule, ...]:
+    """Return synthetic rules for the valid URI; raise for unknown URIs."""
+    if uri == _VALID_RULESET_URI:
+        return SYNTHETIC_RULES
+    raise ValueError(f"Unknown ruleset URI: {uri}")
+
+
+class TestCryptoQualityAnalyserFactory(
+    ComponentFactoryContractTests[CryptoQualityAnalyser]
+):
+    """Contract compliance plus factory-specific ruleset validation."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject mock RulesetManager so factory tests don't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_ruleset", _mock_get_ruleset)
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
+
+    @pytest.fixture
+    def factory(self) -> ComponentFactory[CryptoQualityAnalyser]:
+        """Provide a factory wired with an empty ServiceContainer."""
+        return CryptoQualityAnalyserFactory(ServiceContainer())
+
+    @pytest.fixture
+    def valid_config(self) -> ComponentConfig:
+        """Provide a valid runbook configuration for create()/can_create()."""
+        return {
+            "pattern_matching": {
+                "ruleset": _VALID_RULESET_URI,
+                "evidence_context_size": "medium",
+                "maximum_evidence_count": 5,
+            },
+        }
+
+    def test_can_create_returns_false_for_nonexistent_ruleset(self) -> None:
+        """A missing ruleset surfaces through can_create(), not create()."""
+        factory = CryptoQualityAnalyserFactory(ServiceContainer())
+
+        config_with_nonexistent_ruleset = {
+            "pattern_matching": {"ruleset": "local/nonexistent/1.0.0"},
+        }
+
+        assert factory.can_create(config_with_nonexistent_ruleset) is False

--- a/libs/waivern-crypto-quality-analyser/tests/waivern_crypto_quality_analyser/test_pattern_matcher.py
+++ b/libs/waivern-crypto-quality-analyser/tests/waivern_crypto_quality_analyser/test_pattern_matcher.py
@@ -1,0 +1,211 @@
+"""Unit tests for CryptoQualityPatternMatcher.
+
+Uses synthetic rules injected into the matcher to decouple from
+production ruleset data. Tests pattern matching, polarity derivation,
+and proximity-based evidence collection independently of any specific ruleset.
+"""
+
+import pytest
+from waivern_analysers_shared.types import EvidenceContextSize, PatternMatchingConfig
+from waivern_rulesets.crypto_quality_indicator import CryptoQualityIndicatorRule
+from waivern_schemas.connector_types import BaseMetadata
+
+from waivern_crypto_quality_analyser.pattern_matcher import CryptoQualityPatternMatcher
+
+# =============================================================================
+# Synthetic rules for pattern matcher tests
+# =============================================================================
+
+RULE_STRONG = CryptoQualityIndicatorRule(
+    name="Test Strong Algo",
+    description="Strong algorithm detection",
+    category="strong_algo",
+    algorithm="test_strong",
+    quality_rating="strong",
+    patterns=("test_strong_pattern",),
+)
+
+RULE_WEAK = CryptoQualityIndicatorRule(
+    name="Test Weak Algo",
+    description="Weak algorithm detection",
+    category="weak_algo",
+    algorithm="test_weak",
+    quality_rating="weak",
+    patterns=("test_weak_pattern",),
+)
+
+RULE_DEPRECATED = CryptoQualityIndicatorRule(
+    name="Test Deprecated Algo",
+    description="Deprecated algorithm detection",
+    category="deprecated_algo",
+    algorithm="test_deprecated",
+    quality_rating="deprecated",
+    patterns=("test_deprecated_pattern",),
+)
+
+SYNTHETIC_RULES = (RULE_STRONG, RULE_WEAK, RULE_DEPRECATED)
+
+_UNUSED_RULESET_URI = "unused/test/1.0.0"
+
+
+def _make_config(
+    *,
+    evidence_context_size: EvidenceContextSize = EvidenceContextSize.MEDIUM,
+    maximum_evidence_count: int = 3,
+    evidence_proximity_threshold: int = 200,
+) -> PatternMatchingConfig:
+    """Build a PatternMatchingConfig with evidence extraction settings."""
+    return PatternMatchingConfig(
+        ruleset=_UNUSED_RULESET_URI,
+        evidence_context_size=evidence_context_size,
+        maximum_evidence_count=maximum_evidence_count,
+        evidence_proximity_threshold=evidence_proximity_threshold,
+    )
+
+
+class TestCryptoQualityPatternMatcher:
+    """Test suite for basic pattern matching behaviour."""
+
+    @pytest.fixture
+    def matcher(self) -> CryptoQualityPatternMatcher:
+        """Create a matcher with synthetic rules and default config."""
+        return CryptoQualityPatternMatcher(
+            rules=SYNTHETIC_RULES,
+            config=_make_config(),
+        )
+
+    @pytest.fixture
+    def metadata(self) -> BaseMetadata:
+        """Create sample metadata for testing."""
+        return BaseMetadata(source="test_file.txt", connector_type="test")
+
+    def test_find_patterns_returns_finding_for_matching_content(
+        self, matcher: CryptoQualityPatternMatcher, metadata: BaseMetadata
+    ) -> None:
+        """Matching content produces a finding with correct algorithm and category."""
+        content = "Using test_strong_pattern for hashing"
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert len(findings) == 1
+        assert findings[0].algorithm == "test_strong"
+        assert findings[0].quality_rating == "strong"
+
+    def test_find_patterns_returns_empty_list_for_no_matches(
+        self, matcher: CryptoQualityPatternMatcher, metadata: BaseMetadata
+    ) -> None:
+        """Content with no matching patterns produces an empty list."""
+        content = "This content has no crypto algorithm patterns"
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert findings == []
+
+    def test_polarity_derived_from_quality_rating(
+        self, matcher: CryptoQualityPatternMatcher, metadata: BaseMetadata
+    ) -> None:
+        """Strong -> positive, weak -> negative, deprecated -> negative."""
+        content = (
+            "test_strong_pattern and test_weak_pattern and test_deprecated_pattern"
+        )
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert len(findings) == 3
+        by_algorithm = {f.algorithm: f for f in findings}
+        assert by_algorithm["test_strong"].polarity == "positive"
+        assert by_algorithm["test_weak"].polarity == "negative"
+        assert by_algorithm["test_deprecated"].polarity == "negative"
+
+
+class TestProximityBasedEvidenceCollection:
+    """Tests for proximity-based evidence collection in CryptoQualityPatternMatcher."""
+
+    @pytest.fixture
+    def metadata(self) -> BaseMetadata:
+        """Create sample metadata for testing."""
+        return BaseMetadata(source="test_file.txt", connector_type="test")
+
+    def test_spread_matches_produce_multiple_evidence_items(
+        self, metadata: BaseMetadata
+    ) -> None:
+        """Spread matches produce multiple evidence items up to maximum_evidence_count."""
+        matcher = CryptoQualityPatternMatcher(
+            rules=(RULE_STRONG,),
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=3,
+                evidence_proximity_threshold=50,
+            ),
+        )
+
+        # Occurrences >50 chars apart -> distinct proximity groups
+        content = (
+            "Your test_strong_pattern is required"
+            + "x" * 100
+            + "Provide test_strong_pattern address"
+            + "x" * 100
+            + "Contact test_strong_pattern needed"
+        )
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert len(findings) == 1
+        assert findings[0].algorithm == "test_strong"
+        assert len(findings[0].evidence) > 1
+
+    def test_dense_matches_produce_single_evidence_item(
+        self, metadata: BaseMetadata
+    ) -> None:
+        """Dense matches of the same pattern produce single evidence item."""
+        matcher = CryptoQualityPatternMatcher(
+            rules=(RULE_STRONG,),
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=3,
+                evidence_proximity_threshold=200,
+            ),
+        )
+
+        # Same pattern repeated close together — all within 200 char threshold
+        content = "Your test_strong_pattern here and test_strong_pattern there and test_strong_pattern everywhere"
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert len(findings) == 1
+        pattern = next(
+            (
+                p
+                for p in findings[0].matched_patterns
+                if p.pattern == "test_strong_pattern"
+            ),
+            None,
+        )
+        assert pattern is not None
+        assert pattern.match_count == 3
+
+    def test_maximum_evidence_count_is_respected(self, metadata: BaseMetadata) -> None:
+        """Evidence collection respects maximum_evidence_count limit."""
+        matcher = CryptoQualityPatternMatcher(
+            rules=(RULE_STRONG,),
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=2,
+                evidence_proximity_threshold=50,
+            ),
+        )
+
+        content = (
+            "test_strong_pattern here"
+            + "x" * 100
+            + "test_strong_pattern there"
+            + "x" * 100
+            + "test_strong_pattern elsewhere"
+            + "x" * 100
+            + "test_strong_pattern again"
+        )
+
+        findings = matcher.find_patterns(content, metadata)
+
+        for finding in findings:
+            assert len(finding.evidence) <= 2

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/analyser.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/analyser.py
@@ -10,11 +10,13 @@ from waivern_analysers_shared.llm_validation import ValidationOrchestrator
 from waivern_analysers_shared.llm_validation.validation_orchestrator import (
     FallbackNeeded,
 )
+from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core import Analyser, InputRequirement
 from waivern_core.dispatch import DispatchRequest, DispatchResult, PrepareResult
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
 from waivern_llm.types import LLMDispatchResult, LLMRequest
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 from waivern_schemas.data_subject_indicator import DataSubjectIndicatorModel
 
 from .result_builder import DataSubjectResultBuilder
@@ -43,6 +45,9 @@ class DataSubjectAnalyser(Analyser):
 
         """
         self._config = config
+        self._rules = RulesetManager.get_rules(
+            config.pattern_matching.ruleset, DataSubjectIndicatorRule
+        )
         self._result_builder = DataSubjectResultBuilder(config)
         self._orchestrator: ValidationOrchestrator[DataSubjectIndicatorModel] = (
             create_validation_orchestrator(config.llm_validation)
@@ -258,7 +263,7 @@ class DataSubjectAnalyser(Analyser):
             if reader is None:
                 reader = self._load_reader(message.schema)
                 readers_by_schema[schema_key] = reader
-            handler = reader.create_handler(self._config)
+            handler = reader.create_handler(self._config, self._rules)
             input_data = reader.read(message.content)
             findings.extend(handler.analyse(input_data))
         return findings

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/analyser.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/analyser.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from types import ModuleType
 from typing import Any, override
 
+from waivern_analysers_shared import SchemaInputHandler
 from waivern_analysers_shared.llm_validation import ValidationOrchestrator
 from waivern_analysers_shared.llm_validation.validation_orchestrator import (
     FallbackNeeded,
@@ -244,9 +245,9 @@ class DataSubjectAnalyser(Analyser):
     ) -> list[DataSubjectIndicatorModel]:
         """Aggregate indicators across input messages (fan-in).
 
-        Loads the reader/handler once per schema and applies it to each
-        message with that schema. Supports mixed-schema fan-in (standard_input
-        and source_code messages in the same call).
+        Loads the reader and handler once per input schema and reuses them
+        for all messages with the same schema. Supports mixed-schema fan-in
+        (standard_input and source_code messages in the same call).
 
         Args:
             inputs: List of input messages (same or mixed schemas).
@@ -255,15 +256,20 @@ class DataSubjectAnalyser(Analyser):
             Flattened list of all indicators from all inputs.
 
         """
-        readers_by_schema: dict[tuple[str, str], ModuleType] = {}
+        # Cache (reader_module, handler) per schema to avoid redundant
+        # imports and object creation when multiple messages share a schema.
+        cache_by_schema: dict[
+            tuple[str, str],
+            tuple[ModuleType, SchemaInputHandler[DataSubjectIndicatorModel]],
+        ] = {}
         findings: list[DataSubjectIndicatorModel] = []
         for message in inputs:
             schema_key = (message.schema.name, message.schema.version)
-            reader = readers_by_schema.get(schema_key)
-            if reader is None:
+            if schema_key not in cache_by_schema:
                 reader = self._load_reader(message.schema)
-                readers_by_schema[schema_key] = reader
-            handler = reader.create_handler(self._config, self._rules)
+                handler = reader.create_handler(self._config, self._rules)
+                cache_by_schema[schema_key] = (reader, handler)
+            reader, handler = cache_by_schema[schema_key]
             input_data = reader.read(message.content)
             findings.extend(handler.analyse(input_data))
         return findings

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/pattern_matcher.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/pattern_matcher.py
@@ -11,7 +11,7 @@ to make intelligent decisions about whether matches are genuine data subject ind
 
 from waivern_analysers_shared.matching import RulePatternDispatcher
 from waivern_analysers_shared.types import PatternMatchingConfig, PatternMatchResult
-from waivern_analysers_shared.utilities import EvidenceExtractor, RulesetManager
+from waivern_analysers_shared.utilities import EvidenceExtractor
 from waivern_core.schemas import PatternMatchDetail
 from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
@@ -26,20 +26,26 @@ from .confidence_scorer import DataSubjectConfidenceScorer
 class DataSubjectPatternMatcher:
     """Pattern matcher for data subject classification.
 
-    This class provides pattern matching functionality specifically for data subject
-    detection, creating structured findings with confidence scoring.
+    Accepts pre-loaded rules via constructor for explicit dependency injection.
+    The analyser is responsible for loading rules from the ruleset manager
+    and passing them here.
     """
 
-    def __init__(self, config: PatternMatchingConfig) -> None:
-        """Initialise the pattern matcher with configuration.
+    def __init__(
+        self,
+        rules: tuple[DataSubjectIndicatorRule, ...],
+        config: PatternMatchingConfig,
+    ) -> None:
+        """Initialise the pattern matcher with rules and configuration.
 
         Args:
-            config: Pattern matching configuration
+            rules: Pre-loaded data subject indicator rules.
+            config: Pattern matching configuration.
 
         """
+        self._rules = rules
         self._config = config
         self._evidence_extractor = EvidenceExtractor()
-        self._ruleset_manager = RulesetManager()
         self._confidence_scorer = DataSubjectConfidenceScorer()
         self._dispatcher = RulePatternDispatcher()
 
@@ -59,9 +65,6 @@ class DataSubjectPatternMatcher:
         if not content.strip():
             return []
 
-        rules = self._ruleset_manager.get_rules(
-            self._config.ruleset, DataSubjectIndicatorRule
-        )
         indicators: list[DataSubjectIndicatorModel] = []
 
         # Group matched rules and results by subject category for confidence calculation
@@ -70,7 +73,7 @@ class DataSubjectPatternMatcher:
         ] = {}
 
         # Find all matching rules and track results
-        for rule in rules:
+        for rule in self._rules:
             results = self._dispatcher.find_matches(
                 content,
                 rule,

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/schema_readers/source_code_1_0_0.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/schema_readers/source_code_1_0_0.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from waivern_analysers_shared import SchemaInputHandler
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 from waivern_schemas.data_subject_indicator import DataSubjectIndicatorModel
 from waivern_schemas.source_code import SourceCodeDataModel
 
@@ -28,17 +29,20 @@ def read(content: dict[str, Any]) -> SourceCodeDataModel:
 
 def create_handler(
     config: DataSubjectAnalyserConfig,
+    rules: tuple[DataSubjectIndicatorRule, ...],
 ) -> SchemaInputHandler[DataSubjectIndicatorModel]:
     """Create handler for source_code schema.
 
     Args:
         config: Analyser configuration.
+        rules: Pre-loaded data subject indicator rules.
 
     Returns:
         Handler implementing SchemaInputHandler protocol.
 
     """
     return SourceCodeSchemaInputHandler(
+        rules=rules,
         config=config.pattern_matching,
         context_window=config.source_code_context_window,
     )

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/schema_readers/standard_input_1_0_0.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/schema_readers/standard_input_1_0_0.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from waivern_analysers_shared import SchemaInputHandler
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
 from waivern_schemas.data_subject_indicator import DataSubjectIndicatorModel
 from waivern_schemas.standard_input import StandardInputDataModel
@@ -32,14 +33,16 @@ def read(content: dict[str, Any]) -> StandardInputDataModel[BaseMetadata]:
 
 def create_handler(
     config: DataSubjectAnalyserConfig,
+    rules: tuple[DataSubjectIndicatorRule, ...],
 ) -> SchemaInputHandler[DataSubjectIndicatorModel]:
     """Create handler for standard_input schema.
 
     Args:
         config: Analyser configuration.
+        rules: Pre-loaded data subject indicator rules.
 
     Returns:
         Handler implementing SchemaInputHandler protocol.
 
     """
-    return StandardInputSchemaInputHandler(config.pattern_matching)
+    return StandardInputSchemaInputHandler(rules, config.pattern_matching)

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/source_code_schema_input_handler.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/source_code_schema_input_handler.py
@@ -7,7 +7,6 @@ from collections.abc import Generator, Sequence
 
 from waivern_analysers_shared.matching import WordBoundaryMatcher
 from waivern_analysers_shared.types import PatternMatchingConfig
-from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core.schemas import BaseFindingEvidence, PatternMatchDetail
 from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 from waivern_schemas.data_subject_indicator import (
@@ -37,21 +36,23 @@ class SourceCodeSchemaInputHandler:
 
     def __init__(
         self,
+        rules: tuple[DataSubjectIndicatorRule, ...],
         config: PatternMatchingConfig,
         context_window: SourceCodeContextWindow = "small",
     ) -> None:
-        """Initialise the handler with configuration.
+        """Initialise the handler with rules and configuration.
 
         Args:
-            config: Pattern matching configuration (contains ruleset path).
+            rules: Pre-loaded data subject indicator rules.
+            config: Pattern matching configuration.
             context_window: Size of context to include around matches.
                 'small' = ±3 lines, 'medium' = ±15 lines,
                 'large' = ±50 lines, 'full' = entire file.
 
         """
+        self._rules = rules
         self._config = config
         self._context_window: SourceCodeContextWindow = context_window
-        self._ruleset_manager = RulesetManager()
         self._confidence_scorer = DataSubjectConfidenceScorer()
         self._word_boundary_matcher = WordBoundaryMatcher()
 
@@ -98,11 +99,9 @@ class SourceCodeSchemaInputHandler:
         """Analyse a single source code file for data subject patterns.
 
         Orchestrates the analysis flow:
-        1. Load rules from ruleset
-        2. Filter rules to source_code context
-        3. Find pattern matches line-by-line
-        4. Group matches by category
-        5. Calculate confidence and create indicators
+        1. Find pattern matches line-by-line
+        2. Group matches by category
+        3. Calculate confidence and create indicators
 
         Args:
             file_data: Source code file data to analyse.
@@ -111,11 +110,6 @@ class SourceCodeSchemaInputHandler:
             List of data subject indicators for this file.
 
         """
-        # Load rules using config-driven ruleset
-        rules = self._ruleset_manager.get_rules(
-            self._config.ruleset, DataSubjectIndicatorRule
-        )
-
         lines = file_data.raw_content.splitlines()
         file_path = file_data.file_path
 
@@ -126,7 +120,7 @@ class SourceCodeSchemaInputHandler:
         ] = {}
 
         # Find pattern matches line-by-line
-        for rule in rules:
+        for rule in self._rules:
             for line_idx, pattern in self._find_pattern_matches(lines, rule.patterns):
                 category = rule.subject_category
                 line_number = line_idx + 1  # Convert to 1-based

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/standard_input_schema_input_handler.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/standard_input_schema_input_handler.py
@@ -6,6 +6,7 @@ Wraps the existing DataSubjectPatternMatcher for schema-handler consistency.
 from typing import cast
 
 from waivern_analysers_shared.types import PatternMatchingConfig
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
 from waivern_schemas.data_subject_indicator import DataSubjectIndicatorModel
 from waivern_schemas.standard_input import StandardInputDataModel
@@ -19,14 +20,19 @@ class StandardInputSchemaInputHandler:
     Wraps DataSubjectPatternMatcher to implement the SchemaInputHandler protocol.
     """
 
-    def __init__(self, config: PatternMatchingConfig) -> None:
-        """Initialise the handler with pattern matching configuration.
+    def __init__(
+        self,
+        rules: tuple[DataSubjectIndicatorRule, ...],
+        config: PatternMatchingConfig,
+    ) -> None:
+        """Initialise the handler with rules and pattern matching configuration.
 
         Args:
+            rules: Pre-loaded data subject indicator rules.
             config: Pattern matching configuration.
 
         """
-        self._pattern_matcher = DataSubjectPatternMatcher(config)
+        self._pattern_matcher = DataSubjectPatternMatcher(rules, config)
 
     def analyse(self, data: object) -> list[DataSubjectIndicatorModel]:
         """Analyse input data for data subject patterns.

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/schema_readers/test_source_code_1_0_0.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/schema_readers/test_source_code_1_0_0.py
@@ -1,6 +1,27 @@
-"""Tests for source_code v1.0.0 reader."""
+"""Tests for source_code v1.0.0 reader.
 
+Uses synthetic rules to decouple from production ruleset data.
+"""
+
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 from waivern_schemas.source_code import SourceCodeDataModel
+
+from waivern_data_subject_analyser.schema_readers import source_code_1_0_0
+from waivern_data_subject_analyser.source_code_schema_input_handler import (
+    SourceCodeSchemaInputHandler,
+)
+from waivern_data_subject_analyser.types import DataSubjectAnalyserConfig
+
+SYNTHETIC_RULES = (
+    DataSubjectIndicatorRule(
+        name="Test Rule",
+        description="Test",
+        subject_category="test_cat",
+        indicator_type="primary",
+        confidence_weight=45,
+        patterns=("test_kw",),
+    ),
+)
 
 
 class TestSourceCodeReader:
@@ -8,28 +29,14 @@ class TestSourceCodeReader:
 
     def test_create_handler_returns_schema_input_handler(self) -> None:
         """Test that create_handler returns a valid SchemaInputHandler."""
-        from waivern_data_subject_analyser.schema_readers import source_code_1_0_0
-        from waivern_data_subject_analyser.source_code_schema_input_handler import (
-            SourceCodeSchemaInputHandler,
-        )
-        from waivern_data_subject_analyser.types import DataSubjectAnalyserConfig
-
-        # Arrange
         config = DataSubjectAnalyserConfig.from_properties({})
 
-        # Act
-        handler = source_code_1_0_0.create_handler(config)
+        handler = source_code_1_0_0.create_handler(config, SYNTHETIC_RULES)
 
-        # Assert
         assert isinstance(handler, SourceCodeSchemaInputHandler)
 
     def test_read_returns_pydantic_model(self) -> None:
         """Test reader returns SourceCodeDataModel from dict input."""
-        from waivern_data_subject_analyser.schema_readers import (
-            source_code_1_0_0,
-        )
-
-        # Arrange: Valid source_code data as dict (from JSON schema validation)
         input_data = {
             "schemaVersion": "1.0.0",
             "name": "Test source code",
@@ -54,10 +61,8 @@ class TestSourceCodeReader:
             ],
         }
 
-        # Act
         result = source_code_1_0_0.read(input_data)
 
-        # Assert - result is Pydantic model with correct data
         assert isinstance(result, SourceCodeDataModel)
         assert result.schemaVersion == "1.0.0"
         assert result.name == "Test source code"

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/schema_readers/test_standard_input_1_0_0.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/schema_readers/test_standard_input_1_0_0.py
@@ -1,6 +1,27 @@
-"""Tests for standard_input v1.0.0 reader."""
+"""Tests for standard_input v1.0.0 reader.
 
+Uses synthetic rules to decouple from production ruleset data.
+"""
+
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 from waivern_schemas.standard_input import StandardInputDataModel
+
+from waivern_data_subject_analyser.schema_readers import standard_input_1_0_0
+from waivern_data_subject_analyser.standard_input_schema_input_handler import (
+    StandardInputSchemaInputHandler,
+)
+from waivern_data_subject_analyser.types import DataSubjectAnalyserConfig
+
+SYNTHETIC_RULES = (
+    DataSubjectIndicatorRule(
+        name="Test Rule",
+        description="Test",
+        subject_category="test_cat",
+        indicator_type="primary",
+        confidence_weight=45,
+        patterns=("test_kw",),
+    ),
+)
 
 
 class TestStandardInputReader:
@@ -8,28 +29,14 @@ class TestStandardInputReader:
 
     def test_create_handler_returns_schema_input_handler(self) -> None:
         """Test that create_handler returns a valid SchemaInputHandler."""
-        from waivern_data_subject_analyser.schema_readers import standard_input_1_0_0
-        from waivern_data_subject_analyser.standard_input_schema_input_handler import (
-            StandardInputSchemaInputHandler,
-        )
-        from waivern_data_subject_analyser.types import DataSubjectAnalyserConfig
-
-        # Arrange
         config = DataSubjectAnalyserConfig.from_properties({})
 
-        # Act
-        handler = standard_input_1_0_0.create_handler(config)
+        handler = standard_input_1_0_0.create_handler(config, SYNTHETIC_RULES)
 
-        # Assert
         assert isinstance(handler, StandardInputSchemaInputHandler)
 
     def test_read_validates_and_returns_typed_model(self) -> None:
         """Test reader validates input and returns StandardInputDataModel."""
-        from waivern_data_subject_analyser.schema_readers import (
-            standard_input_1_0_0,
-        )
-
-        # Arrange: Valid standard_input data
         input_data = {
             "schemaVersion": "1.0.0",
             "name": "Test data",
@@ -47,10 +54,8 @@ class TestStandardInputReader:
             ],
         }
 
-        # Act
         result = standard_input_1_0_0.read(input_data)
 
-        # Assert
         assert isinstance(result, StandardInputDataModel)
         assert result.schemaVersion == "1.0.0"
         assert result.name == "Test data"

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_analyser.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_analyser.py
@@ -34,16 +34,13 @@ def _mock_get_rules(
     return SYNTHETIC_RULES
 
 
-class TestDataSubjectAnalyserIdentity:
-    """DataSubjectAnalyser identity and construction."""
+class TestDataSubjectAnalyserConstruction:
+    """Tests that require analyser instantiation (and therefore rule loading)."""
 
     @pytest.fixture(autouse=True)
     def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Inject synthetic rules so the analyser doesn't need real rulesets."""
         monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
-
-    def test_get_name_returns_correct_identifier(self) -> None:
-        assert DataSubjectAnalyser.get_name() == "data_subject_analyser"
 
     def test_from_properties_creates_instance_with_defaults(self) -> None:
         config = DataSubjectAnalyserConfig.from_properties({})
@@ -54,7 +51,10 @@ class TestDataSubjectAnalyserIdentity:
 
 
 class TestDataSubjectAnalyserSchemaSupport:
-    """Static schema declarations."""
+    """Static schema declarations (no analyser instantiation needed)."""
+
+    def test_get_name_returns_correct_identifier(self) -> None:
+        assert DataSubjectAnalyser.get_name() == "data_subject_analyser"
 
     def test_get_input_requirements_includes_standard_input(self) -> None:
         input_requirements = DataSubjectAnalyser.get_input_requirements()

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_analyser.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_analyser.py
@@ -4,16 +4,43 @@ Behavioural coverage of the prepare/finalise distributed-processor contract
 lives in ``test_distributed.py``. Pattern-matching behaviour lives in
 ``test_pattern_matcher.py`` and schema-specific reading behaviour lives in
 the schema-reader test modules.
+
+Uses monkeypatched RulesetManager to decouple from production ruleset data.
 """
 
+import pytest
+from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core import InputRequirement
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 
 from waivern_data_subject_analyser.analyser import DataSubjectAnalyser
 from waivern_data_subject_analyser.types import DataSubjectAnalyserConfig
 
+SYNTHETIC_RULES = (
+    DataSubjectIndicatorRule(
+        name="Test Rule",
+        description="Test",
+        subject_category="test_cat",
+        indicator_type="primary",
+        confidence_weight=45,
+        patterns=("test_kw",),
+    ),
+)
+
+
+def _mock_get_rules(
+    uri: str, rule_type: type[DataSubjectIndicatorRule]
+) -> tuple[DataSubjectIndicatorRule, ...]:
+    return SYNTHETIC_RULES
+
 
 class TestDataSubjectAnalyserIdentity:
     """DataSubjectAnalyser identity and construction."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
 
     def test_get_name_returns_correct_identifier(self) -> None:
         assert DataSubjectAnalyser.get_name() == "data_subject_analyser"

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_distributed.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_distributed.py
@@ -4,10 +4,13 @@ Verifies the prepare/finalise/deserialise contract:
 - prepare() runs pattern matching and builds an LLMRequest when enabled
 - finalise() interprets dispatch results via the ValidationOrchestrator
 - deserialise_prepare_result() round-trips through JSON serialisation
+
+Uses monkeypatched RulesetManager to decouple from production ruleset data.
 """
 
 from typing import Any, cast
 
+import pytest
 from waivern_analysers_shared.llm_validation.models import (
     LLMValidationResponseModel,
     LLMValidationResultModel,
@@ -16,9 +19,11 @@ from waivern_analysers_shared.llm_validation.validation_orchestrator import (
     OrchestratorPrepareState,
 )
 from waivern_analysers_shared.types import LLMValidationConfig, PatternMatchingConfig
+from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
 from waivern_llm.types import BatchingMode, LLMDispatchResult, LLMRequest
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
 from waivern_schemas.data_subject_indicator import DataSubjectIndicatorModel
 from waivern_schemas.standard_input import (
@@ -35,22 +40,52 @@ from waivern_data_subject_analyser.types import (
     DataSubjectPrepareState,
 )
 
-OUTPUT_SCHEMA = Schema("data_subject_indicator", "1.0.0")
-INPUT_SCHEMA = Schema("standard_input", "1.0.0")
-RUN_ID = "test-run-id"
+# =============================================================================
+# Synthetic rules
+# =============================================================================
+
+RULE_EMPLOYEE = DataSubjectIndicatorRule(
+    name="Test Employee",
+    description="Employee indicator",
+    subject_category="test_employee",
+    indicator_type="primary",
+    confidence_weight=45,
+    patterns=("test_employee_kw",),
+)
+
+RULE_CUSTOMER = DataSubjectIndicatorRule(
+    name="Test Customer",
+    description="Customer indicator",
+    subject_category="test_customer",
+    indicator_type="primary",
+    confidence_weight=50,
+    patterns=("test_customer_kw",),
+)
+
+SYNTHETIC_RULES = (RULE_EMPLOYEE, RULE_CUSTOMER)
+
+_UNUSED_RULESET_URI = "unused/test/1.0.0"
+
+
+def _mock_get_rules(
+    uri: str, rule_type: type[DataSubjectIndicatorRule]
+) -> tuple[DataSubjectIndicatorRule, ...]:
+    return SYNTHETIC_RULES
 
 
 # =============================================================================
 # Helpers
 # =============================================================================
 
+OUTPUT_SCHEMA = Schema("data_subject_indicator", "1.0.0")
+INPUT_SCHEMA = Schema("standard_input", "1.0.0")
+RUN_ID = "test-run-id"
+
 
 def _make_config(enable_llm: bool = True) -> DataSubjectAnalyserConfig:
     """Build a DataSubjectAnalyserConfig for tests."""
     return DataSubjectAnalyserConfig(
-        pattern_matching=PatternMatchingConfig(
-            ruleset="local/data_subject_indicator/1.0.0"
-        ),
+        pattern_matching=PatternMatchingConfig(ruleset=_UNUSED_RULESET_URI),
         llm_validation=LLMValidationConfig(
             enable_llm_validation=enable_llm,
             llm_validation_mode="standard",
@@ -83,18 +118,18 @@ def _make_no_pattern_message() -> Message:
     )
 
 
-def _make_customer_employee_message() -> Message:
-    """Build a message with items containing customer and employee indicators."""
+def _make_employee_customer_message() -> Message:
+    """Build a message with items containing employee and customer indicators."""
     data = StandardInputDataModel(
         schemaVersion="1.0.0",
         name="test_data",
         data=[
             StandardInputDataItemModel(
-                content="customer_id field in database table",
+                content="test_customer_kw field in database table",
                 metadata=BaseMetadata(source="customer_source", connector_type="test"),
             ),
             StandardInputDataItemModel(
-                content="employee records with employee_id",
+                content="test_employee_kw records with identifiers",
                 metadata=BaseMetadata(source="employee_source", connector_type="test"),
             ),
         ],
@@ -147,6 +182,11 @@ def _build_llm_dispatch_result(
 class TestPrepare:
     """Tests for prepare() — pattern matching and request building."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
+
     def test_no_findings_returns_empty_requests(self) -> None:
         """No pattern matches → empty requests and orchestrator_state=None."""
         analyser = _make_analyser()
@@ -162,14 +202,14 @@ class TestPrepare:
     def test_findings_with_llm_enabled_builds_llm_request(self) -> None:
         """Findings + LLM enabled → LLMRequest with expected shape."""
         analyser = _make_analyser()
-        message = _make_customer_employee_message()
+        message = _make_employee_customer_message()
 
         result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
 
         assert len(result.requests) == 1
         assert result.state.llm_enabled is True
         assert result.state.orchestrator_state is not None
-        assert len(result.state.all_findings) >= 2  # at least customer + employee
+        assert len(result.state.all_findings) >= 2
 
         assert isinstance(result.requests[0], LLMRequest)
         llm_request = cast(LLMRequest[DataSubjectIndicatorModel], result.requests[0])
@@ -181,7 +221,7 @@ class TestPrepare:
     def test_findings_with_llm_disabled_returns_empty_requests(self) -> None:
         """Findings with ``enable_llm_validation=False`` yield no dispatch requests."""
         analyser = _make_analyser(enable_llm=False)
-        message = _make_customer_employee_message()
+        message = _make_employee_customer_message()
 
         result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
 
@@ -199,17 +239,21 @@ class TestPrepare:
 class TestFinalise:
     """Tests for finalise() — result interpretation and output building."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
+
     def test_llm_disabled_produces_output_without_validation_summary(self) -> None:
         """llm_enabled=False state → output message with no validation_summary."""
         analyser = _make_analyser(enable_llm=False)
-        message = _make_customer_employee_message()
+        message = _make_employee_customer_message()
 
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         result = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
 
         assert isinstance(result, Message)
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
-        # Findings preserved without filtering
         assert len(result.content["findings"]) == len(prepare_result.state.all_findings)
 
     def test_no_findings_produces_empty_output(self) -> None:
@@ -227,17 +271,13 @@ class TestFinalise:
     def test_llm_result_filters_false_positives_and_marks_kept(self) -> None:
         """LLM TRUE_POSITIVE/FALSE_POSITIVE verdicts → filtering + marking."""
         analyser = _make_analyser()
-        message = _make_customer_employee_message()
+        message = _make_employee_customer_message()
 
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         assert prepare_result.state.orchestrator_state is not None
         sampled = prepare_result.state.orchestrator_state.strategy_findings
         assert len(sampled) >= 2
 
-        # Verdicts: mark ALL sampled findings so every group has a decision.
-        # To exercise keep_partial (some kept, some removed) we need at least
-        # one group with a mix — DataSubjectAnalyser groups by subject_category,
-        # so we mark the first sampled finding per category as TRUE_POSITIVE.
         assert isinstance(prepare_result.requests[0], LLMRequest)
         llm_request = cast(
             LLMRequest[DataSubjectIndicatorModel], prepare_result.requests[0]
@@ -255,7 +295,6 @@ class TestFinalise:
         assert metadata["validation_summary"]["all_succeeded"] is True
 
         findings = result.content["findings"]
-        # All TRUE_POSITIVE → findings survive; sampled ones carry the marker
         sampled_ids = {f.id for f in sampled}
         for finding in findings:
             if finding["id"] in sampled_ids:
@@ -272,21 +311,17 @@ class TestFinalise:
         in validation_summary rather than being silently hidden.
         """
         analyser = _make_analyser()
-        message = _make_customer_employee_message()
+        message = _make_employee_customer_message()
 
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         original_count = len(prepare_result.state.all_findings)
 
-        # Empty results list: the orchestrator treats this as a failed dispatch
-        # and all strategy findings are categorised as skipped (BATCH_ERROR).
         result = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
 
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert metadata["validation_summary"]["all_succeeded"] is False
         assert metadata["validation_summary"]["skipped_count"] > 0
-        # Conservative keep: every original finding preserved via "keep_all"
-        # group decision (no validated samples -> keep entire group).
         assert len(result.content["findings"]) == original_count
 
 
@@ -298,6 +333,11 @@ class TestFinalise:
 class TestDeserialise:
     """Tests for deserialise_prepare_result() round-trip fidelity."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
+
     def test_round_trip_with_llm_request(self) -> None:
         """prepare() → model_dump → deserialise → equivalent state and request.
 
@@ -307,13 +347,12 @@ class TestDeserialise:
         must survive the round-trip.
         """
         analyser = _make_analyser()
-        message = _make_customer_employee_message()
+        message = _make_employee_customer_message()
 
         original = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         raw: dict[str, Any] = original.model_dump(mode="json")
         restored = analyser.deserialise_prepare_result(raw)
 
-        # State fields
         assert isinstance(restored.state, DataSubjectPrepareState)
         assert restored.state.run_id == original.state.run_id
         assert restored.state.llm_enabled == original.state.llm_enabled
@@ -321,7 +360,6 @@ class TestDeserialise:
         assert isinstance(restored.state.orchestrator_state, OrchestratorPrepareState)
         assert restored.state.orchestrator_state.run_id == RUN_ID
 
-        # Request metadata (prompt_builder/response_model are excluded)
         assert len(restored.requests) == len(original.requests)
         assert restored.requests[0].request_id == original.requests[0].request_id
         original_llm_request = original.requests[0]
@@ -334,7 +372,7 @@ class TestDeserialise:
     def test_round_trip_without_llm_request(self) -> None:
         """Round-trip when LLM disabled: orchestrator_state=None, no requests."""
         analyser = _make_analyser(enable_llm=False)
-        message = _make_customer_employee_message()
+        message = _make_employee_customer_message()
 
         original = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         raw: dict[str, Any] = original.model_dump(mode="json")

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_factory.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_factory.py
@@ -1,21 +1,71 @@
-"""Tests for DataSubjectAnalyserFactory."""
+"""Tests for DataSubjectAnalyserFactory.
+
+Inherits contract tests from ``ComponentFactoryContractTests`` and adds
+factory-specific validation checks (ruleset availability).
+
+Uses monkeypatched RulesetManager to decouple from production rulesets.
+"""
+
+from unittest.mock import MagicMock
 
 import pytest
+from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core import (
     ComponentConfig,
     ComponentFactory,
     ComponentFactoryContractTests,
 )
 from waivern_core.services import ServiceContainer
+from waivern_rulesets import AbstractRuleset
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 
 from waivern_data_subject_analyser import DataSubjectAnalyser
 from waivern_data_subject_analyser.factory import DataSubjectAnalyserFactory
+
+_VALID_RULESET_URI = "local/test_data_subject/1.0.0"
+
+RULE_EMPLOYEE = DataSubjectIndicatorRule(
+    name="Test Employee",
+    description="Employee indicator",
+    subject_category="test_employee",
+    indicator_type="primary",
+    confidence_weight=45,
+    patterns=("test_employee_kw",),
+)
+
+SYNTHETIC_RULES = (RULE_EMPLOYEE,)
+
+
+def _mock_get_ruleset(
+    uri: str, rule_type: type[DataSubjectIndicatorRule]
+) -> AbstractRuleset[DataSubjectIndicatorRule]:
+    """Return a mock ruleset for the valid URI; raise for unknown URIs."""
+    if uri == _VALID_RULESET_URI:
+        mock_ruleset = MagicMock(spec=AbstractRuleset)
+        mock_ruleset.get_rules.return_value = SYNTHETIC_RULES
+        return mock_ruleset
+    raise ValueError(f"Unknown ruleset URI: {uri}")
+
+
+def _mock_get_rules(
+    uri: str, rule_type: type[DataSubjectIndicatorRule]
+) -> tuple[DataSubjectIndicatorRule, ...]:
+    """Return synthetic rules for the valid URI; raise for unknown URIs."""
+    if uri == _VALID_RULESET_URI:
+        return SYNTHETIC_RULES
+    raise ValueError(f"Unknown ruleset URI: {uri}")
 
 
 class TestDataSubjectAnalyserFactory(
     ComponentFactoryContractTests[DataSubjectAnalyser]
 ):
     """Contract compliance plus factory-specific ruleset validation."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject mock RulesetManager so factory tests don't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_ruleset", _mock_get_ruleset)
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
 
     @pytest.fixture
     def factory(self) -> ComponentFactory[DataSubjectAnalyser]:
@@ -24,11 +74,12 @@ class TestDataSubjectAnalyserFactory(
     @pytest.fixture
     def valid_config(self) -> ComponentConfig:
         return {
-            "pattern_matching": {"ruleset": "local/data_subject_indicator/1.0.0"},
+            "pattern_matching": {"ruleset": _VALID_RULESET_URI},
             "llm_validation": {"enable_llm_validation": False},
         }
 
     def test_can_create_returns_false_for_nonexistent_ruleset(self) -> None:
+        """A missing ruleset surfaces through can_create(), not create()."""
         factory = DataSubjectAnalyserFactory(ServiceContainer())
 
         config_with_nonexistent_ruleset = {

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_pattern_matcher.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_pattern_matcher.py
@@ -1,199 +1,249 @@
 """Unit tests for DataSubjectPatternMatcher.
 
-This test module focuses on testing pattern matching and confidence scoring
-for data subject classification.
+Uses synthetic rules injected into the matcher to decouple from
+production ruleset data. Tests pattern matching, confidence scoring,
+category grouping, and proximity-based evidence collection independently
+of any specific ruleset.
 """
 
+import pytest
 from waivern_analysers_shared.types import EvidenceContextSize, PatternMatchingConfig
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
 
 from waivern_data_subject_analyser.pattern_matcher import (
     DataSubjectPatternMatcher,
 )
 
+# =============================================================================
+# Synthetic rules for pattern matcher tests
+# =============================================================================
+
+RULE_EMPLOYEE_PRIMARY = DataSubjectIndicatorRule(
+    name="Test Employee Primary",
+    description="Primary employee indicator",
+    subject_category="test_employee",
+    indicator_type="primary",
+    confidence_weight=45,
+    patterns=("test_employee_primary_kw",),
+)
+
+RULE_EMPLOYEE_SECONDARY = DataSubjectIndicatorRule(
+    name="Test Employee Secondary",
+    description="Secondary employee indicator",
+    subject_category="test_employee",
+    indicator_type="secondary",
+    confidence_weight=25,
+    patterns=("test_employee_secondary_kw",),
+)
+
+RULE_CUSTOMER_PRIMARY = DataSubjectIndicatorRule(
+    name="Test Customer Primary",
+    description="Primary customer indicator",
+    subject_category="test_customer",
+    indicator_type="primary",
+    confidence_weight=50,
+    patterns=("test_customer_primary_kw",),
+)
+
+SYNTHETIC_RULES = (
+    RULE_EMPLOYEE_PRIMARY,
+    RULE_EMPLOYEE_SECONDARY,
+    RULE_CUSTOMER_PRIMARY,
+)
+
+_UNUSED_RULESET_URI = "unused/test/1.0.0"
+
+
+def _make_config(
+    *,
+    evidence_context_size: EvidenceContextSize = EvidenceContextSize.MEDIUM,
+    maximum_evidence_count: int = 3,
+    evidence_proximity_threshold: int = 200,
+) -> PatternMatchingConfig:
+    """Build a PatternMatchingConfig with evidence extraction settings."""
+    return PatternMatchingConfig(
+        ruleset=_UNUSED_RULESET_URI,
+        evidence_context_size=evidence_context_size,
+        maximum_evidence_count=maximum_evidence_count,
+        evidence_proximity_threshold=evidence_proximity_threshold,
+    )
+
 
 class TestDataSubjectPatternMatcher:
     """Test suite for DataSubjectPatternMatcher."""
 
-    def test_pattern_matching_with_confidence_scoring(self) -> None:
-        """Test pattern matching produces correct confidence scores."""
-        # Arrange
-        config = PatternMatchingConfig(
-            ruleset="local/data_subject_indicator/1.0.0",
-            evidence_context_size=EvidenceContextSize.MEDIUM,
-            maximum_evidence_count=3,
-        )
-        pattern_matcher = DataSubjectPatternMatcher(config)
-        metadata = BaseMetadata(source="test_table", connector_type="mysql")
-
-        # Content with multiple employee patterns (should trigger multiple rules)
-        content = "employee staff member employee_id 12345 personnel database"
-
-        # Act
-        findings = pattern_matcher.find_patterns(content, metadata)
-
-        # Assert
-        assert isinstance(findings, list)
-        if len(findings) > 0:
-            finding = findings[0]
-            # Verify confidence scoring structure (strongly typed with Pydantic)
-            assert isinstance(finding.confidence_score, int)
-            assert 0 <= finding.confidence_score <= 100
-            assert isinstance(finding.matched_patterns, list)
-            assert len(finding.matched_patterns) > 0
-
-    def test_context_filtering_logic(self) -> None:
-        """Test that pattern matching respects applicable context filtering."""
-        # Arrange
-        config = PatternMatchingConfig(
-            ruleset="local/data_subject_indicator/1.0.0",
-            evidence_context_size=EvidenceContextSize.MEDIUM,
-            maximum_evidence_count=3,
-        )
-        pattern_matcher = DataSubjectPatternMatcher(config)
-
-        # Test with database context
-        db_metadata = BaseMetadata(source="employees_table", connector_type="mysql")
-
-        # Test with filesystem context
-        fs_metadata = BaseMetadata(
-            source="employee_file.txt", connector_type="filesystem"
+    @pytest.fixture
+    def matcher(self) -> DataSubjectPatternMatcher:
+        """Create a matcher with synthetic rules and default config."""
+        return DataSubjectPatternMatcher(
+            rules=SYNTHETIC_RULES,
+            config=_make_config(),
         )
 
-        content = "employee staff member"
+    @pytest.fixture
+    def metadata(self) -> BaseMetadata:
+        """Create sample metadata for testing."""
+        return BaseMetadata(source="test_table", connector_type="test")
 
-        # Act
-        db_findings = pattern_matcher.find_patterns(content, db_metadata)
-        fs_findings = pattern_matcher.find_patterns(content, fs_metadata)
+    def test_confidence_score_equals_sum_of_matched_rule_weights(
+        self, matcher: DataSubjectPatternMatcher, metadata: BaseMetadata
+    ) -> None:
+        """Confidence score for a category equals the sum of its matched rule weights."""
+        content = "test_employee_primary_kw and test_employee_secondary_kw found"
 
-        # Assert - both should find patterns but context affects which rules apply
-        assert isinstance(db_findings, list)
-        assert isinstance(fs_findings, list)
+        findings = matcher.find_patterns(content, metadata)
 
-        # Both contexts should find employee patterns, but different rules apply:
-        # mysql (database) context: employee_direct_role_fields + employee_hr_system_indicators
-        # filesystem context: only employee_hr_system_indicators
-        if len(db_findings) > 0 and len(fs_findings) > 0:
-            # Database context typically has more applicable rules
-            assert db_findings[0].subject_category == "employee"
-            assert fs_findings[0].subject_category == "employee"
+        employee_findings = [
+            f for f in findings if f.subject_category == "test_employee"
+        ]
+        assert len(employee_findings) == 1
+        assert employee_findings[0].confidence_score == 70  # 45 + 25
+
+    def test_single_rule_match_produces_single_category_finding(
+        self, matcher: DataSubjectPatternMatcher, metadata: BaseMetadata
+    ) -> None:
+        """A single rule match produces one finding for its category."""
+        content = "only test_customer_primary_kw here"
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert len(findings) == 1
+        assert findings[0].subject_category == "test_customer"
+        assert findings[0].confidence_score == 50
+
+    def test_no_matching_patterns_produces_empty_list(
+        self, matcher: DataSubjectPatternMatcher, metadata: BaseMetadata
+    ) -> None:
+        """Content with no matching patterns produces an empty list."""
+        content = "this content has no data subject patterns"
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert findings == []
+
+    def test_multiple_categories_produce_separate_findings(
+        self, matcher: DataSubjectPatternMatcher, metadata: BaseMetadata
+    ) -> None:
+        """Matches across categories produce one finding per category."""
+        content = "test_employee_primary_kw and test_customer_primary_kw together"
+
+        findings = matcher.find_patterns(content, metadata)
+
+        categories = {f.subject_category for f in findings}
+        assert categories == {"test_employee", "test_customer"}
 
 
 class TestProximityBasedEvidenceCollection:
     """Tests for proximity-based evidence collection in DataSubjectPatternMatcher."""
 
-    def test_spread_matches_produce_multiple_evidence_items(self) -> None:
+    @pytest.fixture
+    def metadata(self) -> BaseMetadata:
+        """Create sample metadata for testing."""
+        return BaseMetadata(source="test_table", connector_type="test")
+
+    def test_spread_matches_produce_multiple_evidence_items(
+        self, metadata: BaseMetadata
+    ) -> None:
         """Spread matches produce multiple evidence items up to maximum_evidence_count."""
-        config = PatternMatchingConfig(
-            ruleset="local/data_subject_indicator/1.0.0",
-            evidence_context_size=EvidenceContextSize.SMALL,
-            maximum_evidence_count=3,
-            evidence_proximity_threshold=50,  # 50 chars = distinct locations
+        matcher = DataSubjectPatternMatcher(
+            rules=(RULE_EMPLOYEE_PRIMARY,),
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=3,
+                evidence_proximity_threshold=50,
+            ),
         )
-        matcher = DataSubjectPatternMatcher(config)
-        metadata = BaseMetadata(source="test_table", connector_type="mysql")
 
-        # Create content with employee patterns spread far apart
-        # Use spaces around padding to maintain word boundaries for pattern matching
         content = (
-            "employee record here "
-            + "x " * 50
-            + "employee data there "
-            + "x " * 50
-            + "employee info elsewhere"
+            "test_employee_primary_kw here "
+            + "x " * 60
+            + "test_employee_primary_kw there "
+            + "x " * 60
+            + "test_employee_primary_kw elsewhere"
         )
 
         findings = matcher.find_patterns(content, metadata)
 
-        # Should have findings with multiple evidence items
-        assert len(findings) > 0, "Expected findings"
-        employee_findings = [f for f in findings if f.subject_category == "employee"]
-        assert len(employee_findings) > 0, "Expected employee category finding"
-        # With spread matches, should have multiple evidence items
-        assert len(employee_findings[0].evidence) > 1
+        assert len(findings) == 1
+        assert len(findings[0].evidence) > 1
 
-    def test_dense_matches_produce_fewer_evidence_items(self) -> None:
-        """Dense matches (within proximity threshold) produce fewer evidence items."""
-        config = PatternMatchingConfig(
-            ruleset="local/data_subject_indicator/1.0.0",
-            evidence_context_size=EvidenceContextSize.SMALL,
-            maximum_evidence_count=3,
-            evidence_proximity_threshold=200,  # Large threshold
+    def test_dense_matches_produce_single_evidence_item(
+        self, metadata: BaseMetadata
+    ) -> None:
+        """Dense matches of the same pattern produce single evidence item."""
+        matcher = DataSubjectPatternMatcher(
+            rules=(RULE_EMPLOYEE_PRIMARY,),
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=3,
+                evidence_proximity_threshold=200,
+            ),
         )
-        matcher = DataSubjectPatternMatcher(config)
-        metadata = BaseMetadata(source="test_table", connector_type="mysql")
 
-        # Create content with employee patterns close together
-        content = "employee staff member employee_id personnel"
+        content = "test_employee_primary_kw here and test_employee_primary_kw there and test_employee_primary_kw everywhere"
 
         findings = matcher.find_patterns(content, metadata)
 
-        # Should have findings
-        assert len(findings) > 0, "Expected findings"
-        employee_findings = [f for f in findings if f.subject_category == "employee"]
-        assert len(employee_findings) > 0, "Expected employee category finding"
-        # Dense matches typically produce single evidence item
-        assert len(employee_findings[0].evidence) >= 1
+        assert len(findings) == 1
+        assert (
+            "3 match(es)" in findings[0].matched_patterns[0].pattern
+            or len(findings[0].evidence) >= 1
+        )
 
-    def test_maximum_evidence_count_is_respected(self) -> None:
+    def test_maximum_evidence_count_is_respected(self, metadata: BaseMetadata) -> None:
         """Evidence collection respects maximum_evidence_count limit."""
-        config = PatternMatchingConfig(
-            ruleset="local/data_subject_indicator/1.0.0",
-            evidence_context_size=EvidenceContextSize.SMALL,
-            maximum_evidence_count=2,  # Limit to 2
-            evidence_proximity_threshold=50,  # Very small threshold
+        matcher = DataSubjectPatternMatcher(
+            rules=(RULE_EMPLOYEE_PRIMARY,),
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=2,
+                evidence_proximity_threshold=50,
+            ),
         )
-        matcher = DataSubjectPatternMatcher(config)
-        metadata = BaseMetadata(source="test_table", connector_type="mysql")
 
-        # Create content with many spread-out employee patterns (use spaces for word boundaries)
         content = (
-            "employee here "
-            + "x " * 50
-            + "employee there "
-            + "x " * 50
-            + "employee elsewhere "
-            + "x " * 50
-            + "employee again"
+            "test_employee_primary_kw here "
+            + "x " * 60
+            + "test_employee_primary_kw there "
+            + "x " * 60
+            + "test_employee_primary_kw elsewhere "
+            + "x " * 60
+            + "test_employee_primary_kw again"
         )
 
         findings = matcher.find_patterns(content, metadata)
 
-        # All findings should respect maximum_evidence_count
         for finding in findings:
             assert len(finding.evidence) <= 2
 
-    def test_match_count_reflects_total_occurrences(self) -> None:
+    def test_match_count_reflects_total_occurrences(
+        self, metadata: BaseMetadata
+    ) -> None:
         """match_count reflects total matches regardless of evidence count."""
-        config = PatternMatchingConfig(
-            ruleset="local/data_subject_indicator/1.0.0",
-            evidence_context_size=EvidenceContextSize.SMALL,
-            maximum_evidence_count=2,  # Limit evidence
-            evidence_proximity_threshold=50,
+        matcher = DataSubjectPatternMatcher(
+            rules=(RULE_EMPLOYEE_PRIMARY,),
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=2,
+                evidence_proximity_threshold=50,
+            ),
         )
-        matcher = DataSubjectPatternMatcher(config)
-        metadata = BaseMetadata(source="test_table", connector_type="mysql")
 
-        # Content with multiple employee mentions (use spaces to maintain word boundaries)
         content = (
-            "employee "
-            + "x " * 25
-            + "employee "
-            + "x " * 25
-            + "employee "
-            + "x " * 25
-            + "employee"
+            "test_employee_primary_kw "
+            + "x " * 30
+            + "test_employee_primary_kw "
+            + "x " * 30
+            + "test_employee_primary_kw "
+            + "x " * 30
+            + "test_employee_primary_kw"
         )
 
         findings = matcher.find_patterns(content, metadata)
 
-        assert len(findings) > 0, "Expected findings"
-        employee_findings = [f for f in findings if f.subject_category == "employee"]
-        assert len(employee_findings) > 0, "Expected employee category finding"
-
-        finding = employee_findings[0]
-        # Evidence limited
+        assert len(findings) > 0
+        finding = findings[0]
         assert len(finding.evidence) <= 2
-        # But match count reflects all occurrences
         total_matches = sum(p.match_count for p in finding.matched_patterns)
         assert total_matches >= len(finding.evidence)

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_pattern_matcher.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_pattern_matcher.py
@@ -171,7 +171,7 @@ class TestProximityBasedEvidenceCollection:
     def test_dense_matches_produce_single_evidence_item(
         self, metadata: BaseMetadata
     ) -> None:
-        """Dense matches of the same pattern produce single evidence item."""
+        """Dense matches within the proximity threshold produce a single evidence item."""
         matcher = DataSubjectPatternMatcher(
             rules=(RULE_EMPLOYEE_PRIMARY,),
             config=_make_config(
@@ -186,10 +186,10 @@ class TestProximityBasedEvidenceCollection:
         findings = matcher.find_patterns(content, metadata)
 
         assert len(findings) == 1
-        assert (
-            "3 match(es)" in findings[0].matched_patterns[0].pattern
-            or len(findings[0].evidence) >= 1
-        )
+        assert len(findings[0].evidence) == 1
+        # All three occurrences are counted despite single evidence item
+        total_matches = sum(p.match_count for p in findings[0].matched_patterns)
+        assert total_matches == 3
 
     def test_maximum_evidence_count_is_respected(self, metadata: BaseMetadata) -> None:
         """Evidence collection respects maximum_evidence_count limit."""

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_source_code_schema_input_handler.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_source_code_schema_input_handler.py
@@ -1,11 +1,95 @@
-"""Unit tests for SourceCodeSchemaInputHandler."""
+"""Unit tests for SourceCodeSchemaInputHandler.
+
+Uses synthetic rules injected via constructor to decouple from
+production ruleset data.
+"""
 
 import pytest
 from waivern_analysers_shared.types import PatternMatchingConfig
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
+from waivern_schemas.source_code import (
+    SourceCodeAnalysisMetadataModel,
+    SourceCodeDataModel,
+    SourceCodeFileDataModel,
+    SourceCodeFileMetadataModel,
+)
 
 from waivern_data_subject_analyser.source_code_schema_input_handler import (
     SourceCodeSchemaInputHandler,
 )
+
+# =============================================================================
+# Synthetic rules
+# =============================================================================
+
+RULE_EMPLOYEE_A = DataSubjectIndicatorRule(
+    name="Test Employee A",
+    description="Employee indicator A",
+    subject_category="test_employee",
+    indicator_type="primary",
+    confidence_weight=45,
+    patterns=("test_employee_a_kw",),
+)
+
+RULE_EMPLOYEE_B = DataSubjectIndicatorRule(
+    name="Test Employee B",
+    description="Employee indicator B",
+    subject_category="test_employee",
+    indicator_type="secondary",
+    confidence_weight=25,
+    patterns=("test_employee_b_kw",),
+)
+
+RULE_CUSTOMER = DataSubjectIndicatorRule(
+    name="Test Customer",
+    description="Customer indicator",
+    subject_category="test_customer",
+    indicator_type="primary",
+    confidence_weight=50,
+    patterns=("test_customer_kw",),
+)
+
+SYNTHETIC_RULES = (RULE_EMPLOYEE_A, RULE_EMPLOYEE_B, RULE_CUSTOMER)
+
+_UNUSED_RULESET_URI = "unused/test/1.0.0"
+
+_DEFAULT_FILE_METADATA = SourceCodeFileMetadataModel(
+    file_size=200, line_count=10, last_modified="2024-01-01T00:00:00Z"
+)
+
+_DEFAULT_ANALYSIS_METADATA = SourceCodeAnalysisMetadataModel(
+    total_files=1, total_lines=10, analysis_timestamp="2024-01-01T00:00:00Z"
+)
+
+
+def _make_handler() -> SourceCodeSchemaInputHandler:
+    """Create a handler with synthetic rules and default config."""
+    config = PatternMatchingConfig(ruleset=_UNUSED_RULESET_URI)
+    return SourceCodeSchemaInputHandler(SYNTHETIC_RULES, config)
+
+
+def _make_source_data(file_path: str, raw_content: str) -> SourceCodeDataModel:
+    """Create a SourceCodeDataModel with a single file."""
+    return SourceCodeDataModel(
+        schemaVersion="1.0.0",
+        name="Test source",
+        description="Test",
+        source="source_code",
+        metadata=_DEFAULT_ANALYSIS_METADATA,
+        data=[
+            SourceCodeFileDataModel(
+                file_path=file_path,
+                language="php",
+                raw_content=raw_content,
+                metadata=_DEFAULT_FILE_METADATA,
+            )
+        ],
+    )
+
+
+# =============================================================================
+# Tests
+# =============================================================================
 
 
 class TestSourceCodeSchemaInputHandler:
@@ -13,232 +97,69 @@ class TestSourceCodeSchemaInputHandler:
 
     def test_analyse_raises_type_error_for_invalid_input(self) -> None:
         """Test that analyse raises TypeError when given non-SourceCodeDataModel."""
-        # Arrange
-        config = PatternMatchingConfig(ruleset="local/data_subject_indicator/1.0.0")
-        handler = SourceCodeSchemaInputHandler(config)
+        handler = _make_handler()
         invalid_data = {"not": "a SourceCodeDataModel"}
 
-        # Act & Assert
         with pytest.raises(TypeError, match="Expected SourceCodeDataModel"):
             handler.analyse(invalid_data)
 
     def test_analyse_groups_findings_by_category(self) -> None:
-        """Test that findings are grouped by subject category (one per category per file).
-
-        Multiple matches of the same category in the same file should produce
-        ONE indicator, not multiple.
-        """
-        from waivern_schemas.source_code import (
-            SourceCodeAnalysisMetadataModel,
-            SourceCodeDataModel,
-            SourceCodeFileDataModel,
-            SourceCodeFileMetadataModel,
+        """Multiple matches of the same category in a file produce one indicator."""
+        handler = _make_handler()
+        source_data = _make_source_data(
+            "/src/Service.php",
+            "line with test_employee_a_kw\nline with test_employee_b_kw\n",
         )
 
-        # Arrange
-        config = PatternMatchingConfig(ruleset="local/data_subject_indicator/1.0.0")
-        handler = SourceCodeSchemaInputHandler(config)
-        # This file has multiple employee patterns - should produce ONE employee indicator
-        file_data = SourceCodeFileDataModel(
-            file_path="/src/EmployeeService.php",
-            language="php",
-            raw_content="""<?php
-class EmployeeService {
-    private $employee;
-    private $staff;
-    private $worker;
-
-    public function getEmployee() {
-        return $this->employee;
-    }
-}
-""",
-            metadata=SourceCodeFileMetadataModel(
-                file_size=200, line_count=10, last_modified="2024-01-01T00:00:00Z"
-            ),
-        )
-        source_data = SourceCodeDataModel(
-            schemaVersion="1.0.0",
-            name="Grouping test",
-            description="Test category grouping",
-            source="source_code",
-            metadata=SourceCodeAnalysisMetadataModel(
-                total_files=1, total_lines=10, analysis_timestamp="2024-01-01T00:00:00Z"
-            ),
-            data=[file_data],
-        )
-
-        # Act
         findings = handler.analyse(source_data)
 
-        # Assert - should have exactly ONE employee indicator, not multiple
-        employee_findings = [f for f in findings if f.subject_category == "employee"]
-        assert len(employee_findings) == 1, (
-            f"Expected 1 employee indicator (grouped), got {len(employee_findings)}"
-        )
-        # The grouped indicator should have multiple matched patterns
-        assert len(employee_findings[0].matched_patterns) >= 2, (
-            "Grouped indicator should contain multiple matched patterns"
-        )
+        employee_findings = [
+            f for f in findings if f.subject_category == "test_employee"
+        ]
+        assert len(employee_findings) == 1
+        assert len(employee_findings[0].matched_patterns) == 2
 
     def test_analyse_calculates_confidence(self) -> None:
-        """Test that confidence scores are calculated using the confidence scorer."""
-        from waivern_schemas.source_code import (
-            SourceCodeAnalysisMetadataModel,
-            SourceCodeDataModel,
-            SourceCodeFileDataModel,
-            SourceCodeFileMetadataModel,
+        """Confidence scores are calculated from matched rule weights."""
+        handler = _make_handler()
+        source_data = _make_source_data(
+            "/src/Service.php",
+            "test_employee_a_kw found here\n",
         )
 
-        # Arrange
-        config = PatternMatchingConfig(ruleset="local/data_subject_indicator/1.0.0")
-        handler = SourceCodeSchemaInputHandler(config)
-        file_data = SourceCodeFileDataModel(
-            file_path="/src/CustomerService.php",
-            language="php",
-            raw_content="""<?php
-class CustomerService {
-    private $customer;
-
-    public function getCustomer() {
-        return $this->customer;
-    }
-}
-""",
-            metadata=SourceCodeFileMetadataModel(
-                file_size=150, line_count=8, last_modified="2024-01-01T00:00:00Z"
-            ),
-        )
-        source_data = SourceCodeDataModel(
-            schemaVersion="1.0.0",
-            name="Confidence test",
-            description="Test confidence scoring",
-            source="source_code",
-            metadata=SourceCodeAnalysisMetadataModel(
-                total_files=1, total_lines=8, analysis_timestamp="2024-01-01T00:00:00Z"
-            ),
-            data=[file_data],
-        )
-
-        # Act
         findings = handler.analyse(source_data)
 
-        # Assert
-        assert len(findings) > 0, "Expected at least one finding"
-        for finding in findings:
-            assert isinstance(finding.confidence_score, int)
-            assert 0 <= finding.confidence_score <= 100
+        assert len(findings) == 1
+        assert findings[0].confidence_score == 45
 
     def test_analyse_deduplicates_matched_patterns(self) -> None:
-        """Test that matched_patterns contains unique patterns only.
-
-        When the same pattern (e.g., 'employee') matches multiple times
-        across different lines, it should appear only once in matched_patterns.
-        """
-        from waivern_schemas.source_code import (
-            SourceCodeAnalysisMetadataModel,
-            SourceCodeDataModel,
-            SourceCodeFileDataModel,
-            SourceCodeFileMetadataModel,
+        """Same pattern on multiple lines appears once in matched_patterns."""
+        handler = _make_handler()
+        source_data = _make_source_data(
+            "/src/Service.php",
+            "test_employee_a_kw on line 1\ntest_employee_a_kw on line 2\ntest_employee_a_kw on line 3\n",
         )
 
-        # Arrange
-        config = PatternMatchingConfig(ruleset="local/data_subject_indicator/1.0.0")
-        handler = SourceCodeSchemaInputHandler(config)
-        # This file has 'employee' appearing 4 times - should appear once in patterns
-        file_data = SourceCodeFileDataModel(
-            file_path="/src/EmployeeService.php",
-            language="php",
-            raw_content="""<?php
-class EmployeeService {
-    private $employee;
-
-    public function getEmployee() {
-        return $this->employee;
-    }
-
-    public function setEmployee($employee) {
-        $this->employee = $employee;
-    }
-}
-""",
-            metadata=SourceCodeFileMetadataModel(
-                file_size=250, line_count=12, last_modified="2024-01-01T00:00:00Z"
-            ),
-        )
-        source_data = SourceCodeDataModel(
-            schemaVersion="1.0.0",
-            name="Deduplication test",
-            description="Test pattern deduplication",
-            source="source_code",
-            metadata=SourceCodeAnalysisMetadataModel(
-                total_files=1, total_lines=12, analysis_timestamp="2024-01-01T00:00:00Z"
-            ),
-            data=[file_data],
-        )
-
-        # Act
         findings = handler.analyse(source_data)
 
-        # Assert
-        employee_findings = [f for f in findings if f.subject_category == "employee"]
-        assert len(employee_findings) == 1, "Expected exactly one employee indicator"
-
-        # Check that patterns are deduplicated
-        patterns = employee_findings[0].matched_patterns
-        pattern_strs = [p.pattern for p in patterns]
-        assert len(pattern_strs) == len(set(pattern_strs)), (
-            f"matched_patterns contains duplicates: {patterns}"
-        )
-
-        # Verify 'employee' appears exactly once despite multiple occurrences in code
-        employee_count = sum(1 for p in patterns if p.pattern.lower() == "employee")
-        assert employee_count == 1, (
-            f"'employee' should appear once, found {employee_count} times in {patterns}"
-        )
+        employee_findings = [
+            f for f in findings if f.subject_category == "test_employee"
+        ]
+        assert len(employee_findings) == 1
+        pattern_strs = [p.pattern for p in employee_findings[0].matched_patterns]
+        assert len(pattern_strs) == len(set(pattern_strs))
 
     def test_metadata_includes_file_path_and_line_number(self) -> None:
-        """Test that metadata contains file path and line number."""
-        from waivern_schemas.source_code import (
-            SourceCodeAnalysisMetadataModel,
-            SourceCodeDataModel,
-            SourceCodeFileDataModel,
-            SourceCodeFileMetadataModel,
+        """Finding metadata contains the file path and first match line number."""
+        handler = _make_handler()
+        source_data = _make_source_data(
+            "/src/Record.php",
+            "nothing here\ntest_customer_kw on line 2\n",
         )
 
-        # Arrange
-        config = PatternMatchingConfig(ruleset="local/data_subject_indicator/1.0.0")
-        handler = SourceCodeSchemaInputHandler(config)
-        file_data = SourceCodeFileDataModel(
-            file_path="/src/PatientRecord.php",
-            language="php",
-            raw_content="""<?php
-class PatientRecord {
-    private $patient;
-}
-""",
-            metadata=SourceCodeFileMetadataModel(
-                file_size=50, line_count=4, last_modified="2024-01-01T00:00:00Z"
-            ),
-        )
-        source_data = SourceCodeDataModel(
-            schemaVersion="1.0.0",
-            name="Metadata test",
-            description="Test metadata",
-            source="source_code",
-            metadata=SourceCodeAnalysisMetadataModel(
-                total_files=1, total_lines=4, analysis_timestamp="2024-01-01T00:00:00Z"
-            ),
-            data=[file_data],
-        )
-
-        # Act
         findings = handler.analyse(source_data)
 
-        # Assert
-        assert len(findings) > 0, "Expected at least one finding"
-        finding = findings[0]
-        assert finding.metadata is not None
-        assert finding.metadata.source == "/src/PatientRecord.php"
-        assert finding.metadata.line_number is not None
-        assert finding.metadata.line_number > 0
+        assert len(findings) == 1
+        assert findings[0].metadata is not None
+        assert findings[0].metadata.source == "/src/Record.php"
+        assert findings[0].metadata.line_number == 2

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_standard_input_schema_input_handler.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_standard_input_schema_input_handler.py
@@ -1,11 +1,29 @@
-"""Unit tests for StandardInputSchemaInputHandler."""
+"""Unit tests for StandardInputSchemaInputHandler.
+
+Uses synthetic rules injected via constructor to decouple from
+production ruleset data.
+"""
 
 import pytest
 from waivern_analysers_shared.types import PatternMatchingConfig
+from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
 
 from waivern_data_subject_analyser.standard_input_schema_input_handler import (
     StandardInputSchemaInputHandler,
 )
+
+RULE_EMPLOYEE = DataSubjectIndicatorRule(
+    name="Test Employee",
+    description="Employee indicator",
+    subject_category="test_employee",
+    indicator_type="primary",
+    confidence_weight=45,
+    patterns=("test_employee_kw",),
+)
+
+SYNTHETIC_RULES = (RULE_EMPLOYEE,)
+
+_UNUSED_RULESET_URI = "unused/test/1.0.0"
 
 
 class TestStandardInputSchemaInputHandler:
@@ -13,11 +31,9 @@ class TestStandardInputSchemaInputHandler:
 
     def test_analyse_raises_type_error_for_invalid_input(self) -> None:
         """Test that analyse raises TypeError when given non-StandardInputDataModel."""
-        # Arrange
-        config = PatternMatchingConfig(ruleset="local/data_subject_indicator/1.0.0")
-        handler = StandardInputSchemaInputHandler(config)
+        config = PatternMatchingConfig(ruleset=_UNUSED_RULESET_URI)
+        handler = StandardInputSchemaInputHandler(SYNTHETIC_RULES, config)
         invalid_data = {"not": "a StandardInputDataModel"}
 
-        # Act & Assert
         with pytest.raises(TypeError, match="Expected StandardInputDataModel"):
             handler.analyse(invalid_data)

--- a/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/analyser.py
+++ b/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/analyser.py
@@ -10,11 +10,13 @@ from waivern_analysers_shared.llm_validation import ValidationOrchestrator
 from waivern_analysers_shared.llm_validation.validation_orchestrator import (
     FallbackNeeded,
 )
+from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core import Analyser, InputRequirement
 from waivern_core.dispatch import DispatchRequest, DispatchResult, PrepareResult
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
 from waivern_llm.types import LLMDispatchResult, LLMRequest
+from waivern_rulesets.personal_data_indicator import PersonalDataIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
 from waivern_schemas.personal_data_indicator import PersonalDataIndicatorModel
 from waivern_schemas.standard_input import (
@@ -48,7 +50,12 @@ class PersonalDataAnalyser(Analyser):
 
         """
         self._config = config
-        self._pattern_matcher = PersonalDataPatternMatcher(config.pattern_matching)
+        rules = RulesetManager.get_rules(
+            config.pattern_matching.ruleset, PersonalDataIndicatorRule
+        )
+        self._pattern_matcher = PersonalDataPatternMatcher(
+            rules, config.pattern_matching
+        )
         self._result_builder = PersonalDataResultBuilder(config)
         self._orchestrator: ValidationOrchestrator[PersonalDataIndicatorModel] = (
             create_validation_orchestrator(config.llm_validation)

--- a/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/pattern_matcher.py
+++ b/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/pattern_matcher.py
@@ -2,7 +2,7 @@
 
 from waivern_analysers_shared.matching import RulePatternDispatcher
 from waivern_analysers_shared.types import PatternMatchingConfig
-from waivern_analysers_shared.utilities import EvidenceExtractor, RulesetManager
+from waivern_analysers_shared.utilities import EvidenceExtractor
 from waivern_core.schemas import PatternMatchDetail
 from waivern_rulesets.personal_data_indicator import PersonalDataIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
@@ -15,20 +15,25 @@ from waivern_schemas.personal_data_indicator import (
 class PersonalDataPatternMatcher:
     """Pattern matcher for personal data analysis.
 
-    This class provides pattern matching functionality specifically for personal data
-    detection, creating structured indicators for the PersonalDataAnalyser.
+    Accepts rules via constructor to decouple from ruleset loading.
+    The analyser loads rules and passes them in at construction time.
     """
 
-    def __init__(self, config: PatternMatchingConfig) -> None:
-        """Initialise the pattern matcher with configuration.
+    def __init__(
+        self,
+        rules: tuple[PersonalDataIndicatorRule, ...],
+        config: PatternMatchingConfig,
+    ) -> None:
+        """Initialise the pattern matcher with rules and configuration.
 
         Args:
-            config: Pattern matching configuration
+            rules: Personal data indicator detection rules.
+            config: Pattern matching configuration for evidence extraction.
 
         """
+        self._rules = rules
         self._config = config
         self._evidence_extractor = EvidenceExtractor()
-        self._ruleset_manager = RulesetManager()
         self._dispatcher = RulePatternDispatcher()
 
     def find_patterns(
@@ -49,12 +54,9 @@ class PersonalDataPatternMatcher:
         if not content.strip():
             return []
 
-        rules = self._ruleset_manager.get_rules(
-            self._config.ruleset, PersonalDataIndicatorRule
-        )
         findings: list[PersonalDataIndicatorModel] = []
 
-        for rule in rules:
+        for rule in self._rules:
             results = self._dispatcher.find_matches(
                 content,
                 rule,

--- a/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_distributed.py
+++ b/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_distributed.py
@@ -4,10 +4,14 @@ Verifies the prepare/finalise/deserialise contract:
 - prepare() runs pattern matching and builds an LLMRequest when enabled
 - finalise() interprets dispatch results via the ValidationOrchestrator
 - deserialise_prepare_result() round-trips through JSON serialisation
+
+Uses synthetic rules via monkeypatched RulesetManager to decouple from
+production ruleset data.
 """
 
 from typing import Any, cast
 
+import pytest
 from waivern_analysers_shared.llm_validation.models import (
     LLMValidationResponseModel,
     LLMValidationResultModel,
@@ -16,9 +20,11 @@ from waivern_analysers_shared.llm_validation.validation_orchestrator import (
     OrchestratorPrepareState,
 )
 from waivern_analysers_shared.types import LLMValidationConfig, PatternMatchingConfig
+from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
 from waivern_llm.types import BatchingMode, LLMDispatchResult, LLMRequest
+from waivern_rulesets.personal_data_indicator import PersonalDataIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
 from waivern_schemas.personal_data_indicator import PersonalDataIndicatorModel
 from waivern_schemas.standard_input import (
@@ -39,6 +45,34 @@ OUTPUT_SCHEMA = Schema("personal_data_indicator", "1.0.0")
 INPUT_SCHEMA = Schema("standard_input", "1.0.0")
 RUN_ID = "test-run-id"
 
+# =============================================================================
+# Synthetic rules
+# =============================================================================
+
+RULE_EMAIL = PersonalDataIndicatorRule(
+    name="Email Address",
+    description="Email address detection",
+    category="email",
+    patterns=("email",),
+)
+
+RULE_PHONE = PersonalDataIndicatorRule(
+    name="Phone Number",
+    description="Phone number detection",
+    category="phone",
+    patterns=("phone",),
+)
+
+SYNTHETIC_RULES = (RULE_EMAIL, RULE_PHONE)
+
+_UNUSED_RULESET_URI = "unused/test/1.0.0"
+
+
+def _mock_get_rules(
+    uri: str, rule_type: type[PersonalDataIndicatorRule]
+) -> tuple[PersonalDataIndicatorRule, ...]:
+    return SYNTHETIC_RULES
+
 
 # =============================================================================
 # Helpers
@@ -48,9 +82,7 @@ RUN_ID = "test-run-id"
 def _make_config(enable_llm: bool = True) -> PersonalDataAnalyserConfig:
     """Build a PersonalDataAnalyserConfig for tests."""
     return PersonalDataAnalyserConfig(
-        pattern_matching=PatternMatchingConfig(
-            ruleset="local/personal_data_indicator/1.0.0"
-        ),
+        pattern_matching=PatternMatchingConfig(ruleset=_UNUSED_RULESET_URI),
         llm_validation=LLMValidationConfig(
             enable_llm_validation=enable_llm,
             llm_validation_mode="standard",
@@ -152,6 +184,11 @@ def _build_llm_dispatch_result(
 class TestPrepare:
     """Tests for prepare() — pattern matching and request building."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
+
     def test_no_findings_returns_empty_requests(self) -> None:
         """No pattern matches → empty requests and orchestrator_state=None."""
         analyser = _make_analyser()
@@ -203,6 +240,11 @@ class TestPrepare:
 
 class TestFinalise:
     """Tests for finalise() — result interpretation and output building."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
 
     def test_llm_disabled_produces_output_without_validation_summary(self) -> None:
         """llm_enabled=False state → output message with no validation_summary."""
@@ -296,6 +338,11 @@ class TestFinalise:
 
 class TestDeserialise:
     """Tests for deserialise_prepare_result() round-trip fidelity."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
 
     def test_round_trip_with_llm_request(self) -> None:
         """prepare() → model_dump → deserialise → equivalent state and request.

--- a/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_factory.py
+++ b/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_factory.py
@@ -2,24 +2,68 @@
 
 Inherits contract tests from ``ComponentFactoryContractTests`` and adds
 factory-specific validation checks (ruleset availability).
+
+Uses monkeypatched RulesetManager to decouple from production rulesets.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
+from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core import (
     ComponentConfig,
     ComponentFactory,
     ComponentFactoryContractTests,
 )
 from waivern_core.services import ServiceContainer
+from waivern_rulesets import AbstractRuleset
+from waivern_rulesets.personal_data_indicator import PersonalDataIndicatorRule
 
 from waivern_personal_data_analyser import PersonalDataAnalyser
 from waivern_personal_data_analyser.factory import PersonalDataAnalyserFactory
+
+_VALID_RULESET_URI = "local/test_personal_data/1.0.0"
+
+RULE_EMAIL = PersonalDataIndicatorRule(
+    name="Email Address",
+    description="Email address detection",
+    category="email",
+    patterns=("email",),
+)
+
+SYNTHETIC_RULES = (RULE_EMAIL,)
+
+
+def _mock_get_ruleset(
+    uri: str, rule_type: type[PersonalDataIndicatorRule]
+) -> AbstractRuleset[PersonalDataIndicatorRule]:
+    """Return a mock ruleset for the valid URI; raise for unknown URIs."""
+    if uri == _VALID_RULESET_URI:
+        mock_ruleset = MagicMock(spec=AbstractRuleset)
+        mock_ruleset.get_rules.return_value = SYNTHETIC_RULES
+        return mock_ruleset
+    raise ValueError(f"Unknown ruleset URI: {uri}")
+
+
+def _mock_get_rules(
+    uri: str, rule_type: type[PersonalDataIndicatorRule]
+) -> tuple[PersonalDataIndicatorRule, ...]:
+    """Return synthetic rules for the valid URI; raise for unknown URIs."""
+    if uri == _VALID_RULESET_URI:
+        return SYNTHETIC_RULES
+    raise ValueError(f"Unknown ruleset URI: {uri}")
 
 
 class TestPersonalDataAnalyserFactory(
     ComponentFactoryContractTests[PersonalDataAnalyser]
 ):
     """Contract compliance plus factory-specific ruleset validation."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject mock RulesetManager so factory tests don't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_ruleset", _mock_get_ruleset)
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
 
     @pytest.fixture
     def factory(self) -> ComponentFactory[PersonalDataAnalyser]:
@@ -31,7 +75,7 @@ class TestPersonalDataAnalyserFactory(
         """Provide a valid runbook configuration for create()/can_create()."""
         return {
             "pattern_matching": {
-                "ruleset": "local/personal_data_indicator/1.0.0",
+                "ruleset": _VALID_RULESET_URI,
                 "evidence_context_size": "medium",
                 "maximum_evidence_count": 5,
             },

--- a/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_pattern_matcher.py
+++ b/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_pattern_matcher.py
@@ -1,28 +1,59 @@
 """Unit tests for PersonalDataPatternMatcher.
 
-This test module focuses on testing pattern matching and proximity-based
-evidence collection for personal data detection.
+Uses synthetic rules injected into the matcher to decouple from
+production ruleset data. This tests pattern matching and proximity-based
+evidence collection independently of any specific ruleset.
 """
 
 import pytest
 from waivern_analysers_shared.types import EvidenceContextSize, PatternMatchingConfig
+from waivern_rulesets.personal_data_indicator import PersonalDataIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
 
 from waivern_personal_data_analyser.pattern_matcher import PersonalDataPatternMatcher
+
+# =============================================================================
+# Synthetic rules for pattern matcher tests
+# =============================================================================
+
+RULE_EMAIL = PersonalDataIndicatorRule(
+    name="Email Address",
+    description="Email address detection",
+    category="email",
+    patterns=("email",),
+)
+
+SYNTHETIC_RULES = (RULE_EMAIL,)
+
+# PatternMatchingConfig requires a ruleset URI but it is unused by the matcher
+# after refactoring — the matcher receives rules via constructor instead.
+_UNUSED_RULESET_URI = "unused/test/1.0.0"
+
+
+def _make_config(
+    *,
+    evidence_context_size: EvidenceContextSize = EvidenceContextSize.MEDIUM,
+    maximum_evidence_count: int = 3,
+    evidence_proximity_threshold: int = 200,
+) -> PatternMatchingConfig:
+    """Build a PatternMatchingConfig with evidence extraction settings."""
+    return PatternMatchingConfig(
+        ruleset=_UNUSED_RULESET_URI,
+        evidence_context_size=evidence_context_size,
+        maximum_evidence_count=maximum_evidence_count,
+        evidence_proximity_threshold=evidence_proximity_threshold,
+    )
 
 
 class TestPersonalDataPatternMatcher:
     """Test suite for PersonalDataPatternMatcher."""
 
-    TEST_RULESET_URI = "local/personal_data_indicator/1.0.0"
-
     @pytest.fixture
-    def config(self) -> PatternMatchingConfig:
-        """Create a valid configuration for testing."""
-        return PatternMatchingConfig(
-            ruleset=self.TEST_RULESET_URI,
-            evidence_context_size=EvidenceContextSize.MEDIUM,
-            maximum_evidence_count=3,
+    def matcher(self) -> PersonalDataPatternMatcher:
+        """Create a matcher with synthetic rules and default config."""
+        return PersonalDataPatternMatcher(
+            rules=SYNTHETIC_RULES,
+            config=_make_config(),
         )
 
     @pytest.fixture
@@ -31,25 +62,20 @@ class TestPersonalDataPatternMatcher:
         return BaseMetadata(source="test_file.txt", connector_type="test")
 
     def test_find_patterns_returns_findings_for_email_pattern(
-        self, config: PatternMatchingConfig, metadata: BaseMetadata
+        self, matcher: PersonalDataPatternMatcher, metadata: BaseMetadata
     ) -> None:
-        """Test that find_patterns detects email patterns."""
-        matcher = PersonalDataPatternMatcher(config)
-        # Use the word "email" which matches the word-boundary pattern
+        """Matching content produces a finding with the correct category."""
         content = "Please provide your email address for contact"
 
         findings = matcher.find_patterns(content, metadata)
 
-        assert len(findings) > 0
-        # Find email-related finding
-        email_findings = [f for f in findings if f.category == "email"]
-        assert len(email_findings) > 0
+        assert len(findings) == 1
+        assert findings[0].category == "email"
 
     def test_find_patterns_returns_empty_list_for_no_matches(
-        self, config: PatternMatchingConfig, metadata: BaseMetadata
+        self, matcher: PersonalDataPatternMatcher, metadata: BaseMetadata
     ) -> None:
-        """Test that find_patterns returns empty list when no patterns match."""
-        matcher = PersonalDataPatternMatcher(config)
+        """Content with no matching patterns produces an empty list."""
         content = "This content has no personal data patterns"
 
         findings = matcher.find_patterns(content, metadata)
@@ -60,8 +86,6 @@ class TestPersonalDataPatternMatcher:
 class TestProximityBasedEvidenceCollection:
     """Tests for proximity-based evidence collection in PersonalDataPatternMatcher."""
 
-    TEST_RULESET_URI = "local/personal_data_indicator/1.0.0"
-
     @pytest.fixture
     def metadata(self) -> BaseMetadata:
         """Create sample metadata for testing."""
@@ -71,16 +95,16 @@ class TestProximityBasedEvidenceCollection:
         self, metadata: BaseMetadata
     ) -> None:
         """Spread matches produce multiple evidence items up to maximum_evidence_count."""
-        config = PatternMatchingConfig(
-            ruleset=self.TEST_RULESET_URI,
-            evidence_context_size=EvidenceContextSize.SMALL,
-            maximum_evidence_count=3,
-            evidence_proximity_threshold=50,  # 50 chars = distinct locations
+        matcher = PersonalDataPatternMatcher(
+            rules=SYNTHETIC_RULES,
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=3,
+                evidence_proximity_threshold=50,
+            ),
         )
-        matcher = PersonalDataPatternMatcher(config)
 
-        # Create content with "email" word-boundary pattern spread far apart
-        # Must be >50 chars between occurrences to be in different proximity groups
+        # "email" occurrences >50 chars apart → distinct proximity groups
         content = (
             "Your email is required"
             + "x" * 100
@@ -91,58 +115,48 @@ class TestProximityBasedEvidenceCollection:
 
         findings = matcher.find_patterns(content, metadata)
 
-        # Should have findings with multiple evidence items
-        assert len(findings) > 0
-        email_findings = [f for f in findings if f.category == "email"]
-        assert len(email_findings) > 0
-        # With spread matches (>50 chars apart), should have multiple evidence items
-        assert len(email_findings[0].evidence) > 1
+        assert len(findings) == 1
+        assert findings[0].category == "email"
+        assert len(findings[0].evidence) > 1
 
     def test_dense_matches_of_same_pattern_produce_single_evidence_item(
         self, metadata: BaseMetadata
     ) -> None:
         """Dense matches of the same pattern produce single evidence item."""
-        config = PatternMatchingConfig(
-            ruleset=self.TEST_RULESET_URI,
-            evidence_context_size=EvidenceContextSize.SMALL,
-            maximum_evidence_count=3,
-            evidence_proximity_threshold=200,  # 200 chars threshold
+        matcher = PersonalDataPatternMatcher(
+            rules=SYNTHETIC_RULES,
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=3,
+                evidence_proximity_threshold=200,
+            ),
         )
-        matcher = PersonalDataPatternMatcher(config)
 
-        # Create content with the SAME pattern repeated close together
-        # Note: different patterns (email, mail, email_address) each produce their
-        # own evidence, but the SAME pattern repeated within threshold = 1 evidence
+        # Same pattern repeated close together — all within 200 char threshold
         content = "Your email here and email there and email everywhere"
 
         findings = matcher.find_patterns(content, metadata)
 
-        # Should have findings
-        assert len(findings) > 0, "Expected findings for email pattern"
-        email_findings = [f for f in findings if f.category == "email"]
-        assert len(email_findings) > 0, "Expected email category finding"
+        assert len(findings) == 1, "Expected single finding for email category"
 
-        # With dense matches of same pattern, proximity grouping applies
-        # All "email" matches are within 200 chars so grouped together
-        # Check that match_count > 1 but evidence may be grouped
         email_pattern = next(
-            (p for p in email_findings[0].matched_patterns if p.pattern == "email"),
+            (p for p in findings[0].matched_patterns if p.pattern == "email"),
             None,
         )
         assert email_pattern is not None, "Expected 'email' pattern in matched_patterns"
-        assert email_pattern.match_count == 3  # 3 occurrences of "email"
+        assert email_pattern.match_count == 3
 
     def test_maximum_evidence_count_is_respected(self, metadata: BaseMetadata) -> None:
         """Evidence collection respects maximum_evidence_count limit."""
-        config = PatternMatchingConfig(
-            ruleset=self.TEST_RULESET_URI,
-            evidence_context_size=EvidenceContextSize.SMALL,
-            maximum_evidence_count=2,  # Limit to 2
-            evidence_proximity_threshold=50,  # 50 chars threshold
+        matcher = PersonalDataPatternMatcher(
+            rules=SYNTHETIC_RULES,
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=2,
+                evidence_proximity_threshold=50,
+            ),
         )
-        matcher = PersonalDataPatternMatcher(config)
 
-        # Create content with many spread-out email patterns
         content = (
             "email here"
             + "x" * 100
@@ -155,7 +169,6 @@ class TestProximityBasedEvidenceCollection:
 
         findings = matcher.find_patterns(content, metadata)
 
-        # All findings should respect maximum_evidence_count
         for finding in findings:
             assert len(finding.evidence) <= 2
 
@@ -163,25 +176,24 @@ class TestProximityBasedEvidenceCollection:
         self, metadata: BaseMetadata
     ) -> None:
         """Config evidence_proximity_threshold affects grouping behaviour."""
-        # Small threshold - more groups
-        config_small = PatternMatchingConfig(
-            ruleset=self.TEST_RULESET_URI,
-            evidence_context_size=EvidenceContextSize.SMALL,
-            maximum_evidence_count=5,
-            evidence_proximity_threshold=50,
+        matcher_small = PersonalDataPatternMatcher(
+            rules=SYNTHETIC_RULES,
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=5,
+                evidence_proximity_threshold=50,
+            ),
         )
-        # Large threshold - fewer groups
-        config_large = PatternMatchingConfig(
-            ruleset=self.TEST_RULESET_URI,
-            evidence_context_size=EvidenceContextSize.SMALL,
-            maximum_evidence_count=5,
-            evidence_proximity_threshold=500,
+        matcher_large = PersonalDataPatternMatcher(
+            rules=SYNTHETIC_RULES,
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=5,
+                evidence_proximity_threshold=500,
+            ),
         )
 
-        matcher_small = PersonalDataPatternMatcher(config_small)
-        matcher_large = PersonalDataPatternMatcher(config_large)
-
-        # Content with matches at varying distances (between 50 and 500 chars)
+        # Matches ~100 chars apart: distinct with threshold=50, grouped with threshold=500
         content = (
             "email here" + "x" * 100 + "email there" + "x" * 100 + "email elsewhere"
         )
@@ -189,33 +201,25 @@ class TestProximityBasedEvidenceCollection:
         findings_small = matcher_small.find_patterns(content, metadata)
         findings_large = matcher_large.find_patterns(content, metadata)
 
-        # Both should find patterns
-        assert len(findings_small) > 0
-        assert len(findings_large) > 0
+        assert len(findings_small) == 1
+        assert len(findings_large) == 1
 
-        email_small = [f for f in findings_small if f.category == "email"]
-        email_large = [f for f in findings_large if f.category == "email"]
-
-        assert len(email_small) > 0, "Expected email findings with small threshold"
-        assert len(email_large) > 0, "Expected email findings with large threshold"
-
-        # With small threshold (50), matches 100 chars apart are distinct
-        # With large threshold (500), they're in the same group
-        assert len(email_small[0].evidence) >= len(email_large[0].evidence)
+        # Small threshold → more evidence items; large threshold → fewer
+        assert len(findings_small[0].evidence) >= len(findings_large[0].evidence)
 
     def test_match_count_reflects_total_not_evidence_count(
         self, metadata: BaseMetadata
     ) -> None:
         """match_count in PatternMatchDetail reflects total matches, not evidence count."""
-        config = PatternMatchingConfig(
-            ruleset=self.TEST_RULESET_URI,
-            evidence_context_size=EvidenceContextSize.SMALL,
-            maximum_evidence_count=2,  # Limit evidence
-            evidence_proximity_threshold=50,  # Force separate groups
+        matcher = PersonalDataPatternMatcher(
+            rules=SYNTHETIC_RULES,
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=2,
+                evidence_proximity_threshold=50,
+            ),
         )
-        matcher = PersonalDataPatternMatcher(config)
 
-        # Create content with multiple matches of the same pattern
         content = (
             "email here"
             + "x" * 100
@@ -228,14 +232,10 @@ class TestProximityBasedEvidenceCollection:
 
         findings = matcher.find_patterns(content, metadata)
 
-        assert len(findings) > 0, "Expected findings"
-        email_findings = [f for f in findings if f.category == "email"]
-        assert len(email_findings) > 0, "Expected email category finding"
-
-        finding = email_findings[0]
+        assert len(findings) == 1, "Expected single finding for email category"
+        finding = findings[0]
         # Evidence is limited to max_evidence_count
         assert len(finding.evidence) <= 2
         # But total match count should reflect all matches
         total_match_count = sum(p.match_count for p in finding.matched_patterns)
-        # Total matches should be >= evidence count
         assert total_match_count >= len(finding.evidence)

--- a/libs/waivern-security-control-analyser/src/waivern_security_control_analyser/analyser.py
+++ b/libs/waivern-security-control-analyser/src/waivern_security_control_analyser/analyser.py
@@ -5,9 +5,11 @@ import logging
 from typing import override
 
 from waivern_analysers_shared import SchemaReader
+from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core import Analyser, InputRequirement
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
+from waivern_rulesets.security_control_indicator import SecurityControlIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
 from waivern_schemas.security_evidence import SecurityEvidenceModel
 from waivern_schemas.standard_input import (
@@ -43,7 +45,12 @@ class SecurityControlAnalyser(Analyser):
 
         """
         self._config = config
-        self._pattern_matcher = SecurityControlPatternMatcher(config.pattern_matching)
+        rules = RulesetManager.get_rules(
+            config.pattern_matching.ruleset, SecurityControlIndicatorRule
+        )
+        self._pattern_matcher = SecurityControlPatternMatcher(
+            rules, config.pattern_matching
+        )
         self._result_builder = SecurityControlResultBuilder(config)
 
     @classmethod

--- a/libs/waivern-security-control-analyser/src/waivern_security_control_analyser/pattern_matcher.py
+++ b/libs/waivern-security-control-analyser/src/waivern_security_control_analyser/pattern_matcher.py
@@ -2,7 +2,7 @@
 
 from waivern_analysers_shared.matching import RulePatternDispatcher
 from waivern_analysers_shared.types import PatternMatchingConfig
-from waivern_analysers_shared.utilities import EvidenceExtractor, RulesetManager
+from waivern_analysers_shared.utilities import EvidenceExtractor
 from waivern_rulesets.security_control_indicator import SecurityControlIndicatorRule
 from waivern_schemas.connector_types import BaseMetadata
 from waivern_schemas.security_evidence import (
@@ -14,23 +14,29 @@ from waivern_schemas.security_evidence import (
 class SecurityControlPatternMatcher:
     """Pattern matcher for security control analysis.
 
-    Scans text content for security control patterns and builds
-    SecurityEvidenceModel items directly from the rule's security_domain
-    and polarity. No intermediate indicator model is needed — unlike
-    CryptoQualityAnalyser, domain and polarity are already encoded on
-    each rule and require no further derivation.
+    Accepts rules via constructor to decouple from ruleset loading.
+    The analyser loads rules and passes them in at construction time.
+
+    Builds SecurityEvidenceModel items directly from the rule's
+    security_domain and polarity — no intermediate indicator model
+    or derivation map is needed.
     """
 
-    def __init__(self, config: PatternMatchingConfig) -> None:
-        """Initialise the pattern matcher with configuration.
+    def __init__(
+        self,
+        rules: tuple[SecurityControlIndicatorRule, ...],
+        config: PatternMatchingConfig,
+    ) -> None:
+        """Initialise the pattern matcher with rules and configuration.
 
         Args:
-            config: Pattern matching configuration
+            rules: Security control indicator detection rules.
+            config: Pattern matching configuration for evidence extraction.
 
         """
+        self._rules = rules
         self._config = config
         self._evidence_extractor = EvidenceExtractor()
-        self._ruleset_manager = RulesetManager()
         self._dispatcher = RulePatternDispatcher()
 
     def find_patterns(
@@ -51,12 +57,9 @@ class SecurityControlPatternMatcher:
         if not content.strip():
             return []
 
-        rules = self._ruleset_manager.get_rules(
-            self._config.ruleset, SecurityControlIndicatorRule
-        )
         findings: list[SecurityEvidenceModel] = []
 
-        for rule in rules:
+        for rule in self._rules:
             results = self._dispatcher.find_matches(
                 content,
                 rule,

--- a/libs/waivern-security-control-analyser/tests/waivern_security_control_analyser/test_analyser.py
+++ b/libs/waivern-security-control-analyser/tests/waivern_security_control_analyser/test_analyser.py
@@ -1,12 +1,89 @@
-"""Unit tests for SecurityControlAnalyser."""
+"""Unit tests for SecurityControlAnalyser.
+
+Uses synthetic rules via monkeypatched RulesetManager to decouple from
+production ruleset data.
+"""
 
 import pytest
+from waivern_analysers_shared.types import PatternMatchingConfig
+from waivern_analysers_shared.utilities import RulesetManager
 from waivern_core import AnalyserContractTests
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
+from waivern_rulesets.security_control_indicator import SecurityControlIndicatorRule
+from waivern_schemas.security_domain import SecurityDomain
 
 from waivern_security_control_analyser.analyser import SecurityControlAnalyser
 from waivern_security_control_analyser.types import SecurityControlAnalyserConfig
+
+# =============================================================================
+# Synthetic rules
+# =============================================================================
+
+RULE_POSITIVE = SecurityControlIndicatorRule(
+    name="Test Positive Auth",
+    description="Positive authentication control detection",
+    category="positive_auth",
+    security_domain=SecurityDomain.AUTHENTICATION,
+    polarity="positive",
+    patterns=("test_positive_auth_pattern",),
+)
+
+RULE_NEGATIVE = SecurityControlIndicatorRule(
+    name="Test Negative Network",
+    description="Negative network security control detection",
+    category="negative_network",
+    security_domain=SecurityDomain.NETWORK_SECURITY,
+    polarity="negative",
+    patterns=("test_negative_network_pattern",),
+)
+
+SYNTHETIC_RULES = (RULE_POSITIVE, RULE_NEGATIVE)
+
+_UNUSED_RULESET_URI = "unused/test/1.0.0"
+
+
+def _mock_get_rules(
+    uri: str, rule_type: type[SecurityControlIndicatorRule]
+) -> tuple[SecurityControlIndicatorRule, ...]:
+    return SYNTHETIC_RULES
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+OUTPUT_SCHEMA = Schema("security_evidence", "1.0.0")
+INPUT_SCHEMA = Schema("standard_input", "1.0.0")
+
+
+def _make_config() -> SecurityControlAnalyserConfig:
+    """Build a SecurityControlAnalyserConfig with synthetic ruleset URI."""
+    return SecurityControlAnalyserConfig(
+        pattern_matching=PatternMatchingConfig(ruleset=_UNUSED_RULESET_URI),
+    )
+
+
+def _make_message(content: str) -> Message:
+    """Build a standard_input message carrying a single data item."""
+    return Message(
+        id="test-message",
+        content={
+            "schemaVersion": "1.0.0",
+            "name": "Test source",
+            "data": [
+                {
+                    "content": content,
+                    "metadata": {
+                        "source": "test.php",
+                        "connector_type": "test",
+                    },
+                }
+            ],
+        },
+        schema=INPUT_SCHEMA,
+    )
+
 
 # =============================================================================
 # Contract tests
@@ -32,136 +109,41 @@ class TestSecurityControlAnalyserContract(
 class TestSecurityControlPolarity:
     """Tests for polarity and security_domain assignment."""
 
-    @pytest.fixture
-    def valid_config(self) -> SecurityControlAnalyserConfig:
-        """Return default configuration using local security_control_indicator ruleset."""
-        return SecurityControlAnalyserConfig()
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
 
-    @pytest.fixture
-    def output_schema(self) -> Schema:
-        """Return the standard output schema for security_evidence."""
-        return Schema("security_evidence", "1.0.0")
-
-    def test_positive_pattern_produces_positive_polarity(
-        self,
-        valid_config: SecurityControlAnalyserConfig,
-        output_schema: Schema,
-    ) -> None:
+    def test_positive_pattern_produces_positive_polarity(self) -> None:
         """A positive-polarity rule match yields polarity=positive in the finding."""
-        analyser = SecurityControlAnalyser(valid_config)
-        message = Message(
-            id="test_positive",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Test source",
-                "data": [
-                    {
-                        "content": "db.prepared_statement($query, [$id])",
-                        "metadata": {
-                            "source": "db.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
+        analyser = SecurityControlAnalyser(config=_make_config())
+        message = _make_message("Using test_positive_auth_pattern for login")
 
-        result = analyser.process([message], output_schema)
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
-        assert len(findings) >= 1
-        assert any(f["polarity"] == "positive" for f in findings)
+        assert len(findings) == 1
+        assert findings[0]["polarity"] == "positive"
+        assert findings[0]["security_domain"] == "authentication"
 
-    def test_negative_pattern_produces_negative_polarity(
-        self,
-        valid_config: SecurityControlAnalyserConfig,
-        output_schema: Schema,
-    ) -> None:
+    def test_negative_pattern_produces_negative_polarity(self) -> None:
         """A negative-polarity rule match yields polarity=negative in the finding."""
-        analyser = SecurityControlAnalyser(valid_config)
-        message = Message(
-            id="test_negative",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Test source",
-                "data": [
-                    {
-                        "content": "shell_exec($user_command)",
-                        "metadata": {
-                            "source": "exec.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
+        analyser = SecurityControlAnalyser(config=_make_config())
+        message = _make_message("Using test_negative_network_pattern in firewall")
 
-        result = analyser.process([message], output_schema)
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
-        assert len(findings) >= 1
-        assert any(f["polarity"] == "negative" for f in findings)
+        assert len(findings) == 1
+        assert findings[0]["polarity"] == "negative"
+        assert findings[0]["security_domain"] == "network_security"
 
-    def test_security_domain_taken_from_rule(
-        self,
-        valid_config: SecurityControlAnalyserConfig,
-        output_schema: Schema,
-    ) -> None:
-        """The security_domain in the finding matches the matched rule's domain."""
-        analyser = SecurityControlAnalyser(valid_config)
-        # audit_log is in the logging_monitoring domain (positive)
-        message = Message(
-            id="test_domain",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Test source",
-                "data": [
-                    {
-                        "content": "audit_log($user, $action)",
-                        "metadata": {
-                            "source": "audit.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
+    def test_no_matching_patterns_produces_no_findings(self) -> None:
+        """Content with no recognised patterns produces zero findings."""
+        analyser = SecurityControlAnalyser(config=_make_config())
+        message = _make_message("x = a + b")
 
-        result = analyser.process([message], output_schema)
-
-        findings = result.content["findings"]
-        assert len(findings) >= 1
-        assert any(f["security_domain"] == "logging_monitoring" for f in findings)
-
-    def test_no_matching_patterns_produces_no_findings(
-        self,
-        valid_config: SecurityControlAnalyserConfig,
-        output_schema: Schema,
-    ) -> None:
-        """Content with no ruleset patterns produces zero findings."""
-        analyser = SecurityControlAnalyser(valid_config)
-        message = Message(
-            id="test_no_patterns",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Clean source",
-                "data": [
-                    {
-                        "content": "x = a + b",
-                        "metadata": {
-                            "source": "math.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
-
-        result = analyser.process([message], output_schema)
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         assert result.content["findings"] == []
         assert result.content["summary"]["total_findings"] == 0
@@ -175,82 +157,38 @@ class TestSecurityControlPolarity:
 class TestSecurityControlOutputStructure:
     """Tests for the shape and schema compliance of the output message."""
 
-    @pytest.fixture
-    def valid_config(self) -> SecurityControlAnalyserConfig:
-        """Return default configuration using local security_control_indicator ruleset."""
-        return SecurityControlAnalyserConfig()
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
 
-    @pytest.fixture
-    def output_schema(self) -> Schema:
-        """Return the standard output schema for security_evidence."""
-        return Schema("security_evidence", "1.0.0")
-
-    def test_process_returns_valid_security_evidence_message(
-        self,
-        valid_config: SecurityControlAnalyserConfig,
-        output_schema: Schema,
-    ) -> None:
+    def test_process_returns_valid_security_evidence_message(self) -> None:
         """process() returns a Message with security_evidence/1.0.0 schema and required keys."""
-        analyser = SecurityControlAnalyser(valid_config)
-        message = Message(
-            id="test_structure",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Test source",
-                "data": [
-                    {
-                        "content": "bcrypt_hash($password)",
-                        "metadata": {
-                            "source": "auth.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
-        )
+        analyser = SecurityControlAnalyser(config=_make_config())
+        message = _make_message("Using test_positive_auth_pattern for login")
 
-        result = analyser.process([message], output_schema)
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         assert isinstance(result, Message)
-        assert result.schema == output_schema
+        assert result.schema == OUTPUT_SCHEMA
         assert "findings" in result.content
         assert "summary" in result.content
         assert "analysis_metadata" in result.content
         assert isinstance(result.content["findings"], list)
 
-    def test_summary_counts_domains_correctly(
-        self,
-        valid_config: SecurityControlAnalyserConfig,
-        output_schema: Schema,
-    ) -> None:
+    def test_summary_counts_domains_correctly(self) -> None:
         """summary.domains reflects the actual security domains found."""
-        analyser = SecurityControlAnalyser(valid_config)
-        # bcrypt → authentication; audit_log → logging_monitoring
-        message = Message(
-            id="test_summary",
-            content={
-                "schemaVersion": "1.0.0",
-                "name": "Test source",
-                "data": [
-                    {
-                        "content": "bcrypt_hash($pw); audit_log($user, $action)",
-                        "metadata": {
-                            "source": "app.php",
-                            "connector_type": "filesystem",
-                        },
-                    }
-                ],
-            },
-            schema=Schema("standard_input", "1.0.0"),
+        analyser = SecurityControlAnalyser(config=_make_config())
+        message = _make_message(
+            "test_positive_auth_pattern and test_negative_network_pattern"
         )
 
-        result = analyser.process([message], output_schema)
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         summary = result.content["summary"]
         domain_names = {d["security_domain"] for d in summary["domains"]}
         assert "authentication" in domain_names
-        assert "logging_monitoring" in domain_names
+        assert "network_security" in domain_names
         assert summary["domains_identified"] == len(summary["domains"])
 
 
@@ -262,23 +200,14 @@ class TestSecurityControlOutputStructure:
 class TestSecurityControlInputSchemas:
     """Tests for different input schema types."""
 
-    @pytest.fixture
-    def valid_config(self) -> SecurityControlAnalyserConfig:
-        """Return default configuration using local security_control_indicator ruleset."""
-        return SecurityControlAnalyserConfig()
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
 
-    @pytest.fixture
-    def output_schema(self) -> Schema:
-        """Return the standard output schema for security_evidence."""
-        return Schema("security_evidence", "1.0.0")
-
-    def test_accepts_source_code_schema_input(
-        self,
-        valid_config: SecurityControlAnalyserConfig,
-        output_schema: Schema,
-    ) -> None:
+    def test_accepts_source_code_schema_input(self) -> None:
         """A source_code/1.0.0 input message is processed successfully."""
-        analyser = SecurityControlAnalyser(valid_config)
+        analyser = SecurityControlAnalyser(config=_make_config())
         message = Message(
             id="test_source_code",
             content={
@@ -295,7 +224,7 @@ class TestSecurityControlInputSchemas:
                     {
                         "file_path": "auth/login.php",
                         "language": "php",
-                        "raw_content": "bcrypt_hash($password)",
+                        "raw_content": "test_positive_auth_pattern here",
                         "metadata": {
                             "file_size": 100,
                             "line_count": 1,
@@ -307,10 +236,37 @@ class TestSecurityControlInputSchemas:
             schema=Schema("source_code", "1.0.0"),
         )
 
-        result = analyser.process([message], output_schema)
+        result = analyser.process([message], OUTPUT_SCHEMA)
 
         assert isinstance(result, Message)
-        assert result.schema == output_schema
+        assert result.schema == OUTPUT_SCHEMA
         findings = result.content["findings"]
-        assert len(findings) >= 1
+        assert len(findings) == 1
         assert findings[0]["metadata"]["source"] == "auth/login.php"
+
+
+# =============================================================================
+# Fan-in (multiple input messages)
+# =============================================================================
+
+
+class TestSecurityControlFanIn:
+    """Tests for fan-in: multiple input messages produce merged findings."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject synthetic rules so the analyser doesn't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
+
+    def test_process_merges_findings_from_multiple_inputs(self) -> None:
+        """Findings from multiple input messages are all present in the output."""
+        analyser = SecurityControlAnalyser(config=_make_config())
+        msg_positive = _make_message("Using test_positive_auth_pattern for login")
+        msg_negative = _make_message("Using test_negative_network_pattern in firewall")
+
+        result = analyser.process([msg_positive, msg_negative], OUTPUT_SCHEMA)
+
+        findings = result.content["findings"]
+        polarities = {f["polarity"] for f in findings}
+        assert "positive" in polarities
+        assert "negative" in polarities

--- a/libs/waivern-security-control-analyser/tests/waivern_security_control_analyser/test_factory.py
+++ b/libs/waivern-security-control-analyser/tests/waivern_security_control_analyser/test_factory.py
@@ -1,0 +1,95 @@
+"""Tests for SecurityControlAnalyserFactory.
+
+Inherits contract tests from ``ComponentFactoryContractTests`` and adds
+factory-specific validation checks (ruleset availability).
+
+Uses monkeypatched RulesetManager to decouple from production rulesets.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from waivern_analysers_shared.utilities import RulesetManager
+from waivern_core import (
+    ComponentConfig,
+    ComponentFactory,
+    ComponentFactoryContractTests,
+)
+from waivern_core.services import ServiceContainer
+from waivern_rulesets import AbstractRuleset
+from waivern_rulesets.security_control_indicator import SecurityControlIndicatorRule
+from waivern_schemas.security_domain import SecurityDomain
+
+from waivern_security_control_analyser import SecurityControlAnalyser
+from waivern_security_control_analyser.factory import SecurityControlAnalyserFactory
+
+_VALID_RULESET_URI = "local/test_security_control/1.0.0"
+
+RULE_POSITIVE = SecurityControlIndicatorRule(
+    name="Test Positive Auth",
+    description="Positive authentication control detection",
+    category="positive_auth",
+    security_domain=SecurityDomain.AUTHENTICATION,
+    polarity="positive",
+    patterns=("test_positive_auth_pattern",),
+)
+
+SYNTHETIC_RULES = (RULE_POSITIVE,)
+
+
+def _mock_get_ruleset(
+    uri: str, rule_type: type[SecurityControlIndicatorRule]
+) -> AbstractRuleset[SecurityControlIndicatorRule]:
+    """Return a mock ruleset for the valid URI; raise for unknown URIs."""
+    if uri == _VALID_RULESET_URI:
+        mock_ruleset = MagicMock(spec=AbstractRuleset)
+        mock_ruleset.get_rules.return_value = SYNTHETIC_RULES
+        return mock_ruleset
+    raise ValueError(f"Unknown ruleset URI: {uri}")
+
+
+def _mock_get_rules(
+    uri: str, rule_type: type[SecurityControlIndicatorRule]
+) -> tuple[SecurityControlIndicatorRule, ...]:
+    """Return synthetic rules for the valid URI; raise for unknown URIs."""
+    if uri == _VALID_RULESET_URI:
+        return SYNTHETIC_RULES
+    raise ValueError(f"Unknown ruleset URI: {uri}")
+
+
+class TestSecurityControlAnalyserFactory(
+    ComponentFactoryContractTests[SecurityControlAnalyser]
+):
+    """Contract compliance plus factory-specific ruleset validation."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_ruleset_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject mock RulesetManager so factory tests don't need real rulesets."""
+        monkeypatch.setattr(RulesetManager, "get_ruleset", _mock_get_ruleset)
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
+
+    @pytest.fixture
+    def factory(self) -> ComponentFactory[SecurityControlAnalyser]:
+        """Provide a factory wired with an empty ServiceContainer."""
+        return SecurityControlAnalyserFactory(ServiceContainer())
+
+    @pytest.fixture
+    def valid_config(self) -> ComponentConfig:
+        """Provide a valid runbook configuration for create()/can_create()."""
+        return {
+            "pattern_matching": {
+                "ruleset": _VALID_RULESET_URI,
+                "evidence_context_size": "medium",
+                "maximum_evidence_count": 5,
+            },
+        }
+
+    def test_can_create_returns_false_for_nonexistent_ruleset(self) -> None:
+        """A missing ruleset surfaces through can_create(), not create()."""
+        factory = SecurityControlAnalyserFactory(ServiceContainer())
+
+        config_with_nonexistent_ruleset = {
+            "pattern_matching": {"ruleset": "local/nonexistent/1.0.0"},
+        }
+
+        assert factory.can_create(config_with_nonexistent_ruleset) is False

--- a/libs/waivern-security-control-analyser/tests/waivern_security_control_analyser/test_pattern_matcher.py
+++ b/libs/waivern-security-control-analyser/tests/waivern_security_control_analyser/test_pattern_matcher.py
@@ -1,0 +1,203 @@
+"""Unit tests for SecurityControlPatternMatcher.
+
+Uses synthetic rules injected into the matcher to decouple from
+production ruleset data. Tests pattern matching, polarity/domain
+assignment, and proximity-based evidence collection independently
+of any specific ruleset.
+"""
+
+import pytest
+from waivern_analysers_shared.types import EvidenceContextSize, PatternMatchingConfig
+from waivern_rulesets.security_control_indicator import SecurityControlIndicatorRule
+from waivern_schemas.connector_types import BaseMetadata
+from waivern_schemas.security_domain import SecurityDomain
+
+from waivern_security_control_analyser.pattern_matcher import (
+    SecurityControlPatternMatcher,
+)
+
+# =============================================================================
+# Synthetic rules for pattern matcher tests
+# =============================================================================
+
+RULE_POSITIVE = SecurityControlIndicatorRule(
+    name="Test Positive Auth",
+    description="Positive authentication control detection",
+    category="positive_auth",
+    security_domain=SecurityDomain.AUTHENTICATION,
+    polarity="positive",
+    patterns=("test_positive_auth_pattern",),
+)
+
+RULE_NEGATIVE = SecurityControlIndicatorRule(
+    name="Test Negative Network",
+    description="Negative network security control detection",
+    category="negative_network",
+    security_domain=SecurityDomain.NETWORK_SECURITY,
+    polarity="negative",
+    patterns=("test_negative_network_pattern",),
+)
+
+SYNTHETIC_RULES = (RULE_POSITIVE, RULE_NEGATIVE)
+
+_UNUSED_RULESET_URI = "unused/test/1.0.0"
+
+
+def _make_config(
+    *,
+    evidence_context_size: EvidenceContextSize = EvidenceContextSize.MEDIUM,
+    maximum_evidence_count: int = 3,
+    evidence_proximity_threshold: int = 200,
+) -> PatternMatchingConfig:
+    """Build a PatternMatchingConfig with evidence extraction settings."""
+    return PatternMatchingConfig(
+        ruleset=_UNUSED_RULESET_URI,
+        evidence_context_size=evidence_context_size,
+        maximum_evidence_count=maximum_evidence_count,
+        evidence_proximity_threshold=evidence_proximity_threshold,
+    )
+
+
+class TestSecurityControlPatternMatcher:
+    """Test suite for basic pattern matching behaviour."""
+
+    @pytest.fixture
+    def matcher(self) -> SecurityControlPatternMatcher:
+        """Create a matcher with synthetic rules and default config."""
+        return SecurityControlPatternMatcher(
+            rules=SYNTHETIC_RULES,
+            config=_make_config(),
+        )
+
+    @pytest.fixture
+    def metadata(self) -> BaseMetadata:
+        """Create sample metadata for testing."""
+        return BaseMetadata(source="test_file.php", connector_type="test")
+
+    def test_find_patterns_returns_finding_for_positive_rule_match(
+        self, matcher: SecurityControlPatternMatcher, metadata: BaseMetadata
+    ) -> None:
+        """Positive-polarity rule match produces finding with correct polarity and domain."""
+        content = "Using test_positive_auth_pattern for login"
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert len(findings) == 1
+        assert findings[0].polarity == "positive"
+        assert findings[0].security_domain == SecurityDomain.AUTHENTICATION
+
+    def test_find_patterns_returns_finding_for_negative_rule_match(
+        self, matcher: SecurityControlPatternMatcher, metadata: BaseMetadata
+    ) -> None:
+        """Negative-polarity rule match produces finding with correct polarity and domain."""
+        content = "Using test_negative_network_pattern in firewall"
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert len(findings) == 1
+        assert findings[0].polarity == "negative"
+        assert findings[0].security_domain == SecurityDomain.NETWORK_SECURITY
+
+    def test_find_patterns_returns_empty_list_for_no_matches(
+        self, matcher: SecurityControlPatternMatcher, metadata: BaseMetadata
+    ) -> None:
+        """Content with no matching patterns produces an empty list."""
+        content = "This content has no security control patterns"
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert findings == []
+
+    def test_description_includes_rule_name_and_match_count(
+        self, matcher: SecurityControlPatternMatcher, metadata: BaseMetadata
+    ) -> None:
+        """Finding description includes the rule name and total match count."""
+        content = "test_positive_auth_pattern here and test_positive_auth_pattern there"
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert len(findings) == 1
+        assert "Test Positive Auth" in findings[0].description
+        assert "2 match(es)" in findings[0].description
+
+
+class TestProximityBasedEvidenceCollection:
+    """Tests for proximity-based evidence collection in SecurityControlPatternMatcher."""
+
+    @pytest.fixture
+    def metadata(self) -> BaseMetadata:
+        """Create sample metadata for testing."""
+        return BaseMetadata(source="test_file.php", connector_type="test")
+
+    def test_spread_matches_produce_multiple_evidence_items(
+        self, metadata: BaseMetadata
+    ) -> None:
+        """Spread matches produce multiple evidence items up to maximum_evidence_count."""
+        matcher = SecurityControlPatternMatcher(
+            rules=(RULE_POSITIVE,),
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=3,
+                evidence_proximity_threshold=50,
+            ),
+        )
+
+        content = (
+            "Your test_positive_auth_pattern is required"
+            + "x" * 100
+            + "Provide test_positive_auth_pattern here"
+            + "x" * 100
+            + "Contact test_positive_auth_pattern needed"
+        )
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert len(findings) == 1
+        assert findings[0].polarity == "positive"
+        assert len(findings[0].evidence) > 1
+
+    def test_dense_matches_produce_single_evidence_item(
+        self, metadata: BaseMetadata
+    ) -> None:
+        """Dense matches of the same pattern produce single evidence item."""
+        matcher = SecurityControlPatternMatcher(
+            rules=(RULE_POSITIVE,),
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=3,
+                evidence_proximity_threshold=200,
+            ),
+        )
+
+        content = "Your test_positive_auth_pattern here and test_positive_auth_pattern there and test_positive_auth_pattern everywhere"
+
+        findings = matcher.find_patterns(content, metadata)
+
+        assert len(findings) == 1
+        assert "3 match(es)" in findings[0].description
+
+    def test_maximum_evidence_count_is_respected(self, metadata: BaseMetadata) -> None:
+        """Evidence collection respects maximum_evidence_count limit."""
+        matcher = SecurityControlPatternMatcher(
+            rules=(RULE_POSITIVE,),
+            config=_make_config(
+                evidence_context_size=EvidenceContextSize.SMALL,
+                maximum_evidence_count=2,
+                evidence_proximity_threshold=50,
+            ),
+        )
+
+        content = (
+            "test_positive_auth_pattern here"
+            + "x" * 100
+            + "test_positive_auth_pattern there"
+            + "x" * 100
+            + "test_positive_auth_pattern elsewhere"
+            + "x" * 100
+            + "test_positive_auth_pattern again"
+        )
+
+        findings = matcher.find_patterns(content, metadata)
+
+        for finding in findings:
+            assert len(finding.evidence) <= 2


### PR DESCRIPTION
## Summary

- Refactor all four pattern-matching analysers (personal-data, crypto-quality, security-control, data-subject) to accept rules via constructor injection instead of loading them internally via `RulesetManager`
- Each analyser now loads rules eagerly in `__init__` and passes them down to pattern matchers and handlers
- All tests use synthetic rules injected directly (unit tests) or via monkeypatched `RulesetManager` (integration-level tests), decoupling them from production ruleset files
- Cache handler per schema in data-subject-analyser's `_merge_input_findings()` to avoid redundant object creation

## Test plan

- [x] All 1916 tests pass via `./scripts/dev-checks.sh`
- [x] Type checking passes (basedpyright strict mode) across all packages
- [x] Lint and format checks pass
- [x] Verify ruleset file changes don't break tests (the whole point of this refactoring)