### PR TITLE
feat(testing): add slow marker and dev-checks-lite for faster iteration

### DIFF
--- a/apps/wct/tests/cli/test_cli_e2e.py
+++ b/apps/wct/tests/cli/test_cli_e2e.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 
+@pytest.mark.slow
 class TestWCTCLIE2E:
     """Test WCT CLI command execution and JSON file output generation."""
 

--- a/apps/wct/tests/cli/test_cli_runs.py
+++ b/apps/wct/tests/cli/test_cli_runs.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 
+@pytest.mark.slow
 class TestWCTRunsCommand:
     """Tests for 'wct runs' CLI command."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,4 +82,5 @@ addopts = [
 markers = [
     "integration: marks tests as integration tests requiring real API calls (deselect with '-m \"not integration\"')",
     "batch: marks tests that exercise async batch APIs — may take several minutes (deselect with '-m \"not batch\"')",
+    "slow: marks tests that spawn subprocesses or are otherwise slow (deselect with '-m \"not slow\"')",
 ]

--- a/scripts/dev-checks-lite.sh
+++ b/scripts/dev-checks-lite.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Lightweight development quality checks with auto-fix
+# Same as dev-checks.sh but skips slow tests (subprocess-based CLI tests)
+# Use this for fast iteration; run full dev-checks.sh before submitting PRs
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Format code (auto-fix)
+echo "Formatting code..."
+"$SCRIPT_DIR/format.sh"
+
+# Lint with auto-fix
+echo "Linting..."
+"$SCRIPT_DIR/lint.sh" --fix
+
+# Type check
+echo "Type checking..."
+"$SCRIPT_DIR/type-check.sh"
+
+# Basic file checks with auto-fix
+echo "File quality checks..."
+uv run --group dev pre-commit run check-yaml --all-files
+uv run --group dev pre-commit run check-toml --all-files
+uv run --group dev pre-commit run check-json --all-files
+uv run --group dev pre-commit run end-of-file-fixer --all-files
+uv run --group dev pre-commit run trailing-whitespace --all-files
+
+# Run tests (excluding slow subprocess-based CLI tests)
+echo "Running tests (skipping slow)..."
+"$SCRIPT_DIR/test.sh" -m "not integration and not batch and not slow"


### PR DESCRIPTION
## Summary

- Register a `slow` pytest marker for subprocess-based CLI tests (`TestWCTCLIE2E`, `TestWCTRunsCommand`) that account for ~38s of the ~46s test suite
- Add `scripts/dev-checks-lite.sh` that runs all quality checks but excludes `slow`, `integration`, and `batch` tests
- Default `dev-checks.sh` behaviour is unchanged — slow tests still run by default