### PR TITLE
feat(llm): add configurable sync concurrency limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,11 @@ GOOGLE_MODEL=gemini-2.5-flash
 # When enabled, prompts are submitted in bulk; use `wct poll` to check status
 # WAIVERN_LLM_BATCH_MODE=true
 
+# LLM Sync Concurrency
+# Max concurrent LLM API calls in sync mode (default: unlimited)
+# Set to 1 to serialise calls, useful for low rate-limit tiers (e.g. 3 RPM)
+# WAIVERN_LLM_SYNC_CONCURRENCY=1
+
 # Artifact Store Configuration
 # Backend type: memory (default), filesystem, remote
 WAIVERN_STORE_TYPE=memory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,9 @@ artifacts:
 ## Development Commands
 
 ```bash
-# Quality checks (ALWAYS run before completing tasks)
-./scripts/dev-checks.sh             # All checks + tests
+# Quality checks
+./scripts/dev-checks-lite.sh        # Fast checks (use during development)
+./scripts/dev-checks.sh             # Full checks (use before committing)
 
 # Individual checks
 ./scripts/lint.sh && ./scripts/format.sh && ./scripts/type-check.sh
@@ -168,12 +169,11 @@ def process(self, inputs: list[Message], output_schema: Schema) -> Message: ...
 
 ## Task Completion
 
-**CRITICAL: Run `./scripts/dev-checks.sh` before marking ANY task completed.**
-
 1. Mark task `in_progress`
 2. Make changes
-3. Run `./scripts/dev-checks.sh`
-4. Only after checks pass → mark `completed`
+3. Run `./scripts/dev-checks-lite.sh` during development (after each RED-GREEN-REFACTOR cycle)
+4. Run `./scripts/dev-checks.sh` (full checks) before committing
+5. Only after full checks pass → mark `completed`
 
 ## DO NOT
 
@@ -190,7 +190,7 @@ def process(self, inputs: list[Message], output_schema: Schema) -> Message: ...
 - Remove unnecessary code after refactoring
 - Break large classes/functions into smaller ones
 - Use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`
-- Run dev-checks before each task completion
+- Run dev-checks-lite during development, full dev-checks before committing
 
 ## Git Requirements
 

--- a/libs/waivern-llm/src/waivern_llm/di/configuration.py
+++ b/libs/waivern-llm/src/waivern_llm/di/configuration.py
@@ -62,6 +62,11 @@ class LLMServiceConfiguration(BaseServiceConfiguration):
         default=False,
         description="Use batch API for LLM calls (async, lower cost)",
     )
+    sync_concurrency: int | None = Field(
+        default=None,
+        description="Max concurrent LLM calls in sync mode (None = unlimited)",
+        gt=0,
+    )
 
     @field_validator("provider")
     @classmethod
@@ -122,6 +127,7 @@ class LLMServiceConfiguration(BaseServiceConfiguration):
         - OPENAI_MODEL: Model for OpenAI
         - GOOGLE_MODEL: Model for Google
         - WAIVERN_LLM_BATCH_MODE: Enable batch API ("true"/"1"/"yes")
+        - WAIVERN_LLM_SYNC_CONCURRENCY: Max concurrent sync LLM calls (positive int)
 
         Args:
             properties: Configuration properties dictionary
@@ -185,6 +191,14 @@ class LLMServiceConfiguration(BaseServiceConfiguration):
         if "batch_mode" not in config_data:
             batch_env = os.getenv("WAIVERN_LLM_BATCH_MODE", "")
             config_data["batch_mode"] = batch_env.lower() in ("true", "1", "yes")
+
+        # Sync concurrency (positive integer or None)
+        if "sync_concurrency" not in config_data:
+            concurrency_env = os.getenv("WAIVERN_LLM_SYNC_CONCURRENCY", "")
+            try:
+                config_data["sync_concurrency"] = int(concurrency_env)
+            except ValueError:
+                pass  # Leave as None (default)
 
         return cls.model_validate(config_data)
 

--- a/libs/waivern-llm/src/waivern_llm/dispatcher.py
+++ b/libs/waivern-llm/src/waivern_llm/dispatcher.py
@@ -55,6 +55,7 @@ class LLMDispatcher:
         store: ArtifactStore,
         *,
         batch_mode: bool = False,
+        sync_concurrency: int | None = None,
     ) -> None:
         """Initialise the dispatcher.
 
@@ -62,12 +63,15 @@ class LLMDispatcher:
             provider: LLM provider for structured calls.
             store: Artifact store for caching and batch job persistence.
             batch_mode: Use batch API for async processing.
+            sync_concurrency: Max concurrent LLM calls in sync mode.
+                None means unlimited (all calls fire concurrently).
 
         """
         self._provider = provider
         self._store = store
         self._cache: LLMCache = cast("LLMCache", store)
         self._batch_mode = batch_mode
+        self._sync_concurrency = sync_concurrency
 
     @property
     def request_type(self) -> type[LLMRequest[Any]]:
@@ -253,12 +257,23 @@ class LLMDispatcher:
         request_responses: dict[str, list[dict[str, JsonValue]]],
         request_skipped: dict[str, list[SkippedFinding[Finding]]],
     ) -> None:
-        """Phase B (sync): execute all cache misses concurrently."""
+        """Phase B (sync): execute all cache misses with optional concurrency limit."""
+        semaphore = (
+            asyncio.Semaphore(self._sync_concurrency)
+            if self._sync_concurrency is not None
+            else None
+        )
 
         async def _invoke(miss: _CacheMiss) -> tuple[_CacheMiss, BaseModel]:
-            response = await self._provider.invoke_structured(
-                miss.prompt, miss.response_model
-            )
+            if semaphore is not None:
+                async with semaphore:
+                    response = await self._provider.invoke_structured(
+                        miss.prompt, miss.response_model
+                    )
+            else:
+                response = await self._provider.invoke_structured(
+                    miss.prompt, miss.response_model
+                )
             return miss, response
 
         results = await asyncio.gather(

--- a/libs/waivern-llm/src/waivern_llm/dispatcher_factory.py
+++ b/libs/waivern-llm/src/waivern_llm/dispatcher_factory.py
@@ -119,6 +119,7 @@ class LLMDispatcherFactory:
                 provider=provider,
                 store=store,
                 batch_mode=config.batch_mode,
+                sync_concurrency=config.sync_concurrency,
             )
 
         except Exception as e:

--- a/libs/waivern-llm/tests/di/test_configuration.py
+++ b/libs/waivern-llm/tests/di/test_configuration.py
@@ -13,6 +13,10 @@ from waivern_llm.di.configuration import LLMServiceConfiguration
 class TestLLMServiceConfiguration:
     """Test LLMServiceConfiguration class."""
 
+    # =================================================================
+    # Instantiation & Defaults
+    # =================================================================
+
     def test_configuration_can_be_instantiated_with_valid_provider_and_api_key(
         self,
     ) -> None:
@@ -24,6 +28,10 @@ class TestLLMServiceConfiguration:
         assert config.provider == "anthropic"
         assert config.api_key == "sk-test-key"
         assert config.model is None  # Optional field defaults to None
+
+    # =================================================================
+    # from_properties() — Environment Fallback
+    # =================================================================
 
     def test_from_properties_creates_configuration_from_valid_dictionary(self) -> None:
         """Test from_properties() factory method with explicit properties."""
@@ -90,6 +98,10 @@ class TestLLMServiceConfiguration:
             assert config.api_key == "explicit-anthropic-key"
             assert config.model == "claude-3-opus"
 
+    # =================================================================
+    # Validation
+    # =================================================================
+
     def test_validation_rejects_unsupported_provider(self) -> None:
         """Test only anthropic/openai/google accepted."""
         # Attempt to create configuration with unsupported provider
@@ -122,6 +134,10 @@ class TestLLMServiceConfiguration:
         except ValidationError as e:
             error_msg = str(e).lower()
             assert "api_key" in error_msg or "empty" in error_msg
+
+    # =================================================================
+    # Model & Default Model
+    # =================================================================
 
     def test_model_field_is_optional_with_provider_specific_defaults(self) -> None:
         """Test model has sensible defaults per provider."""
@@ -171,6 +187,10 @@ class TestLLMServiceConfiguration:
         assert config_google.model == "gemini-pro-vision"
         assert config_google.get_default_model() == "gemini-pro-vision"
 
+    # =================================================================
+    # Immutability
+    # =================================================================
+
     def test_configuration_is_immutable_inherits_from_base(self) -> None:
         """Test frozen behavior inherited correctly."""
         # Create configuration
@@ -214,6 +234,10 @@ class TestLLMServiceConfiguration:
         except ValidationError as e:
             error_msg = str(e).lower()
             assert "frozen" in error_msg or "immutable" in error_msg
+
+    # =================================================================
+    # Provider-Specific Environment Mapping
+    # =================================================================
 
     def test_from_properties_reads_provider_specific_api_key_from_environment(
         self,
@@ -295,6 +319,10 @@ class TestLLMServiceConfiguration:
             assert config.provider == "anthropic"
             assert config.base_url is None
 
+    # =================================================================
+    # Batch Mode
+    # =================================================================
+
     def test_batch_mode_defaults_to_false(self) -> None:
         """Test batch_mode field defaults to False when not specified."""
         config = LLMServiceConfiguration(provider="anthropic", api_key="test-key")
@@ -348,3 +376,69 @@ class TestLLMServiceConfiguration:
         ):
             config = LLMServiceConfiguration.from_properties({})
             assert config.batch_mode is False
+
+
+class TestSyncConcurrencyConfiguration:
+    """Tests for sync_concurrency configuration field."""
+
+    def test_sync_concurrency_defaults_to_none(self) -> None:
+        """sync_concurrency should default to None (unlimited) when not specified."""
+        config = LLMServiceConfiguration(provider="anthropic", api_key="test-key")
+
+        assert config.sync_concurrency is None
+
+    def test_sync_concurrency_can_be_set_explicitly(self) -> None:
+        """Explicit sync_concurrency value should be preserved."""
+        config = LLMServiceConfiguration(
+            provider="anthropic", api_key="test-key", sync_concurrency=3
+        )
+
+        assert config.sync_concurrency == 3
+
+    def test_sync_concurrency_validation_rejects_zero_and_negative_values(
+        self,
+    ) -> None:
+        """sync_concurrency=0 or negative should raise ValidationError."""
+        import pytest
+
+        with pytest.raises(ValidationError):
+            LLMServiceConfiguration(
+                provider="anthropic", api_key="test-key", sync_concurrency=0
+            )
+
+        with pytest.raises(ValidationError):
+            LLMServiceConfiguration(
+                provider="anthropic", api_key="test-key", sync_concurrency=-1
+            )
+
+    def test_from_properties_reads_sync_concurrency_from_environment(self) -> None:
+        """WAIVERN_LLM_SYNC_CONCURRENCY env var should be parsed as integer."""
+        with patch.dict(
+            os.environ,
+            {
+                "LLM_PROVIDER": "anthropic",
+                "ANTHROPIC_API_KEY": "test-key",
+                "WAIVERN_LLM_SYNC_CONCURRENCY": "2",
+            },
+            clear=True,
+        ):
+            config = LLMServiceConfiguration.from_properties({})
+
+            assert config.sync_concurrency == 2
+
+    def test_from_properties_ignores_non_numeric_sync_concurrency_env_var(
+        self,
+    ) -> None:
+        """Non-numeric WAIVERN_LLM_SYNC_CONCURRENCY should be treated as None."""
+        with patch.dict(
+            os.environ,
+            {
+                "LLM_PROVIDER": "anthropic",
+                "ANTHROPIC_API_KEY": "test-key",
+                "WAIVERN_LLM_SYNC_CONCURRENCY": "abc",
+            },
+            clear=True,
+        ):
+            config = LLMServiceConfiguration.from_properties({})
+
+            assert config.sync_concurrency is None

--- a/libs/waivern-llm/tests/waivern_llm/test_dispatcher.py
+++ b/libs/waivern-llm/tests/waivern_llm/test_dispatcher.py
@@ -687,3 +687,80 @@ class TestLLMDispatcherValidation:
 
         assert results == []
         provider.invoke_structured.assert_not_called()
+
+
+# =============================================================================
+# Sync Mode — Concurrency Limiting
+# =============================================================================
+
+
+class TestLLMDispatcherSyncConcurrency:
+    """Tests for sync_concurrency limiting in _execute_sync()."""
+
+    async def test_sync_concurrency_limits_concurrent_provider_calls(self) -> None:
+        """sync_concurrency=1 with multiple misses → max 1 call in-flight at any time."""
+        import asyncio
+
+        store = AsyncInMemoryStore()
+        peak_concurrency = 0
+        current_concurrency = 0
+
+        async def invoke_tracking(
+            _prompt: str, _response_model: type[MockResponse]
+        ) -> MockResponse:
+            nonlocal peak_concurrency, current_concurrency
+            current_concurrency += 1
+            peak_concurrency = max(peak_concurrency, current_concurrency)
+            await asyncio.sleep(0.01)  # Simulate work — lets event loop interleave
+            current_concurrency -= 1
+            return MockResponse(valid=True, reason="ok")
+
+        provider = Mock()
+        provider.model_name = "test-model"
+        provider.context_window = 4385  # 1 item per batch
+        provider.invoke_structured = AsyncMock(side_effect=invoke_tracking)
+
+        dispatcher = LLMDispatcher(provider=provider, store=store, sync_concurrency=1)
+        request = _create_request(item_count=3, run_id="run-1")
+        request.prompt_builder = _create_unique_prompt_builder()
+
+        results = await dispatcher.dispatch([request])
+
+        assert provider.invoke_structured.call_count == 3
+        assert len(results[0].responses) == 3
+        assert peak_concurrency == 1
+
+    async def test_sync_concurrency_none_allows_all_calls_concurrently(self) -> None:
+        """sync_concurrency=None → all calls fire concurrently (default behaviour)."""
+        import asyncio
+
+        store = AsyncInMemoryStore()
+        peak_concurrency = 0
+        current_concurrency = 0
+
+        async def invoke_tracking(
+            _prompt: str, _response_model: type[MockResponse]
+        ) -> MockResponse:
+            nonlocal peak_concurrency, current_concurrency
+            current_concurrency += 1
+            peak_concurrency = max(peak_concurrency, current_concurrency)
+            await asyncio.sleep(0.01)  # Simulate work — lets event loop interleave
+            current_concurrency -= 1
+            return MockResponse(valid=True, reason="ok")
+
+        provider = Mock()
+        provider.model_name = "test-model"
+        provider.context_window = 4385  # 1 item per batch
+        provider.invoke_structured = AsyncMock(side_effect=invoke_tracking)
+
+        dispatcher = LLMDispatcher(
+            provider=provider, store=store, sync_concurrency=None
+        )
+        request = _create_request(item_count=3, run_id="run-1")
+        request.prompt_builder = _create_unique_prompt_builder()
+
+        results = await dispatcher.dispatch([request])
+
+        assert provider.invoke_structured.call_count == 3
+        assert len(results[0].responses) == 3
+        assert peak_concurrency == 3


### PR DESCRIPTION
## Summary

- Add `WAIVERN_LLM_SYNC_CONCURRENCY` env var to control max concurrent LLM API calls in sync mode
- When set, wraps `asyncio.gather()` calls in `LLMDispatcher._execute_sync()` with an `asyncio.Semaphore`
- Default is `None` (unlimited), preserving existing behaviour
- Update `CLAUDE.md` to reference `dev-checks-lite` during development and full `dev-checks` before committing

## Test plan

- [x] 5 configuration tests: default, explicit value, validation (zero/negative rejected), env var parsing, non-numeric env var ignored
- [x] 2 dispatcher tests: concurrency=1 limits peak in-flight calls to 1; concurrency=None allows all calls concurrently
- [x] All 1923 existing tests pass with no regressions