### PR TITLE
feat(llm): add configurable max_retries for LLM SDK clients

### DIFF
--- a/libs/waivern-llm/src/waivern_llm/di/configuration.py
+++ b/libs/waivern-llm/src/waivern_llm/di/configuration.py
@@ -67,6 +67,11 @@ class LLMServiceConfiguration(BaseServiceConfiguration):
         description="Max concurrent LLM calls in sync mode (None = unlimited)",
         gt=0,
     )
+    max_retries: int = Field(
+        default=2,
+        description="Max retries for transient LLM API failures",
+        ge=0,
+    )
 
     @field_validator("provider")
     @classmethod
@@ -128,6 +133,7 @@ class LLMServiceConfiguration(BaseServiceConfiguration):
         - GOOGLE_MODEL: Model for Google
         - WAIVERN_LLM_BATCH_MODE: Enable batch API ("true"/"1"/"yes")
         - WAIVERN_LLM_SYNC_CONCURRENCY: Max concurrent sync LLM calls (positive int)
+        - WAIVERN_LLM_MAX_RETRIES: Max retries for transient API failures (non-negative int, default 2)
 
         Args:
             properties: Configuration properties dictionary
@@ -199,6 +205,14 @@ class LLMServiceConfiguration(BaseServiceConfiguration):
                 config_data["sync_concurrency"] = int(concurrency_env)
             except ValueError:
                 pass  # Leave as None (default)
+
+        # Max retries (non-negative integer, default 2)
+        if "max_retries" not in config_data:
+            retries_env = os.getenv("WAIVERN_LLM_MAX_RETRIES", "")
+            try:
+                config_data["max_retries"] = int(retries_env)
+            except ValueError:
+                pass  # Leave as default (2)
 
         return cls.model_validate(config_data)
 

--- a/libs/waivern-llm/src/waivern_llm/providers/__init__.py
+++ b/libs/waivern-llm/src/waivern_llm/providers/__init__.py
@@ -38,13 +38,24 @@ def create_provider(config: LLMServiceConfiguration) -> LLMProvider:
     """
     match config.provider:
         case "anthropic":
-            return AnthropicProvider(api_key=config.api_key, model=config.model)
+            return AnthropicProvider(
+                api_key=config.api_key,
+                model=config.model,
+                max_retries=config.max_retries,
+            )
         case "openai":
             return OpenAIProvider(
-                api_key=config.api_key, model=config.model, base_url=config.base_url
+                api_key=config.api_key,
+                model=config.model,
+                base_url=config.base_url,
+                max_retries=config.max_retries,
             )
         case "google":
-            return GoogleProvider(api_key=config.api_key, model=config.model)
+            return GoogleProvider(
+                api_key=config.api_key,
+                model=config.model,
+                max_retries=config.max_retries,
+            )
         case _:
             # LLMServiceConfiguration validates provider, so this is unreachable
             msg = f"Unsupported provider: {config.provider}"

--- a/libs/waivern-llm/src/waivern_llm/providers/anthropic.py
+++ b/libs/waivern-llm/src/waivern_llm/providers/anthropic.py
@@ -52,6 +52,7 @@ class AnthropicProvider:
         self,
         api_key: str | None = None,
         model: str | None = None,
+        max_retries: int = 2,
     ) -> None:
         """Initialise the Anthropic provider.
 
@@ -59,6 +60,7 @@ class AnthropicProvider:
             api_key: Anthropic API key. Falls back to ANTHROPIC_API_KEY env var.
             model: Model name. Falls back to ANTHROPIC_MODEL env var,
                    then defaults to claude-sonnet-4-5.
+            max_retries: Max retries for transient API failures.
 
         Raises:
             LLMConfigurationError: If API key is not provided or found in environment.
@@ -66,6 +68,7 @@ class AnthropicProvider:
         """
         self._model = model or os.getenv("ANTHROPIC_MODEL") or "claude-sonnet-4-5"
         self._api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+        self._max_retries = max_retries
 
         if not self._api_key:
             raise LLMConfigurationError(
@@ -80,6 +83,7 @@ class AnthropicProvider:
             temperature=0,  # Consistent responses for compliance analysis
             max_tokens_to_sample=self._capabilities.max_output_tokens,
             timeout=300,
+            max_retries=self._max_retries,
             stop=None,
         )
 
@@ -138,7 +142,9 @@ class AnthropicProvider:
         sync path is used.
         """
         if self._async_client is None:
-            self._async_client = AsyncAnthropic(api_key=self._api_key)
+            self._async_client = AsyncAnthropic(
+                api_key=self._api_key, max_retries=self._max_retries
+            )
         return self._async_client
 
     async def submit_batch(self, requests: list[BatchRequest]) -> BatchSubmission:

--- a/libs/waivern-llm/src/waivern_llm/providers/google.py
+++ b/libs/waivern-llm/src/waivern_llm/providers/google.py
@@ -9,6 +9,7 @@ import logging
 import os
 
 from google import genai
+from google.genai.types import HttpOptions, HttpRetryOptions
 from langchain_google_genai import ChatGoogleGenerativeAI
 from pydantic import BaseModel
 
@@ -40,6 +41,7 @@ class GoogleProvider:
         self,
         api_key: str | None = None,
         model: str | None = None,
+        max_retries: int = 2,
     ) -> None:
         """Initialise the Google provider.
 
@@ -47,6 +49,7 @@ class GoogleProvider:
             api_key: Google API key. Falls back to GOOGLE_API_KEY env var.
             model: Model name. Falls back to GOOGLE_MODEL env var,
                    then defaults to gemini-2.5-flash.
+            max_retries: Max retries for transient API failures.
 
         Raises:
             LLMConfigurationError: If API key is not provided or found in environment.
@@ -54,6 +57,7 @@ class GoogleProvider:
         """
         self._model = model or os.getenv("GOOGLE_MODEL") or "gemini-2.5-flash"
         self._api_key = api_key or os.getenv("GOOGLE_API_KEY")
+        self._max_retries = max_retries
 
         if not self._api_key:
             raise LLMConfigurationError(
@@ -68,6 +72,7 @@ class GoogleProvider:
             temperature=0,
             max_output_tokens=self._capabilities.max_output_tokens,
             timeout=300,
+            max_retries=self._max_retries,
         )
 
         logger.info(f"Initialised Google provider with model: {self._model}")
@@ -123,7 +128,12 @@ class GoogleProvider:
         only the sync path is used.
         """
         if self._genai_client is None:
-            self._genai_client = genai.Client(api_key=self._api_key)
+            self._genai_client = genai.Client(
+                api_key=self._api_key,
+                http_options=HttpOptions(
+                    retry_options=HttpRetryOptions(attempts=self._max_retries),
+                ),
+            )
         return self._genai_client
 
     async def submit_batch(self, requests: list[BatchRequest]) -> BatchSubmission:

--- a/libs/waivern-llm/src/waivern_llm/providers/openai.py
+++ b/libs/waivern-llm/src/waivern_llm/providers/openai.py
@@ -43,6 +43,7 @@ class OpenAIProvider:
         api_key: str | None = None,
         model: str | None = None,
         base_url: str | None = None,
+        max_retries: int = 2,
     ) -> None:
         """Initialise the OpenAI provider.
 
@@ -53,6 +54,7 @@ class OpenAIProvider:
                    then defaults to gpt-4o.
             base_url: Base URL for OpenAI-compatible APIs. Falls back to
                       OPENAI_BASE_URL env var.
+            max_retries: Max retries for transient API failures.
 
         Raises:
             LLMConfigurationError: If API key is not provided and base_url is not set.
@@ -61,6 +63,7 @@ class OpenAIProvider:
         self._model = model or os.getenv("OPENAI_MODEL") or "gpt-4o"
         self._base_url = base_url or os.getenv("OPENAI_BASE_URL")
         self._api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self._max_retries = max_retries
 
         if not self._api_key and not self._base_url:
             raise LLMConfigurationError(
@@ -81,6 +84,7 @@ class OpenAIProvider:
             temperature=self._capabilities.temperature,
             max_tokens=self._capabilities.max_output_tokens,  # type: ignore[reportCallIssue]
             timeout=300,
+            max_retries=self._max_retries,
         )
 
         logger.info(f"Initialised OpenAI provider with model: {self._model}")
@@ -140,6 +144,7 @@ class OpenAIProvider:
             self._async_client = AsyncOpenAI(
                 api_key=effective_api_key,
                 base_url=self._base_url,
+                max_retries=self._max_retries,
             )
         return self._async_client
 

--- a/libs/waivern-llm/tests/di/test_configuration.py
+++ b/libs/waivern-llm/tests/di/test_configuration.py
@@ -442,3 +442,60 @@ class TestSyncConcurrencyConfiguration:
             config = LLMServiceConfiguration.from_properties({})
 
             assert config.sync_concurrency is None
+
+
+class TestMaxRetriesConfiguration:
+    """Tests for max_retries configuration field."""
+
+    def test_max_retries_defaults_to_two(self) -> None:
+        """max_retries should default to 2 when not specified."""
+        config = LLMServiceConfiguration(provider="anthropic", api_key="test-key")
+
+        assert config.max_retries == 2
+
+    def test_max_retries_can_be_set_explicitly(self) -> None:
+        """Explicit max_retries value should be preserved."""
+        config = LLMServiceConfiguration(
+            provider="anthropic", api_key="test-key", max_retries=5
+        )
+
+        assert config.max_retries == 5
+
+    def test_max_retries_validation_rejects_negative_values(self) -> None:
+        """max_retries below 0 should raise ValidationError."""
+        import pytest
+
+        with pytest.raises(ValidationError):
+            LLMServiceConfiguration(
+                provider="anthropic", api_key="test-key", max_retries=-1
+            )
+
+    def test_from_properties_reads_max_retries_from_environment(self) -> None:
+        """WAIVERN_LLM_MAX_RETRIES env var should be parsed as integer."""
+        with patch.dict(
+            os.environ,
+            {
+                "LLM_PROVIDER": "anthropic",
+                "ANTHROPIC_API_KEY": "test-key",
+                "WAIVERN_LLM_MAX_RETRIES": "5",
+            },
+            clear=True,
+        ):
+            config = LLMServiceConfiguration.from_properties({})
+
+            assert config.max_retries == 5
+
+    def test_from_properties_ignores_non_numeric_max_retries_env_var(self) -> None:
+        """Non-numeric WAIVERN_LLM_MAX_RETRIES should fall back to default."""
+        with patch.dict(
+            os.environ,
+            {
+                "LLM_PROVIDER": "anthropic",
+                "ANTHROPIC_API_KEY": "test-key",
+                "WAIVERN_LLM_MAX_RETRIES": "abc",
+            },
+            clear=True,
+        ):
+            config = LLMServiceConfiguration.from_properties({})
+
+            assert config.max_retries == 2

--- a/libs/waivern-llm/tests/waivern_llm/providers/test_anthropic.py
+++ b/libs/waivern-llm/tests/waivern_llm/providers/test_anthropic.py
@@ -4,7 +4,7 @@ Business behaviour: Provides async LLM calls using Anthropic's Claude models
 via LangChain, satisfying the LLMProvider protocol.
 """
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -77,6 +77,13 @@ class TestAnthropicProviderInitialisation:
             AnthropicProvider()
 
         assert "ANTHROPIC_API_KEY" in str(exc_info.value)
+
+    def test_max_retries_forwarded_to_langchain_client(self) -> None:
+        """max_retries is passed to ChatAnthropic at construction."""
+        with patch("waivern_llm.providers.anthropic.ChatAnthropic") as mock_chat_cls:
+            AnthropicProvider(api_key="test-key", max_retries=5)
+
+            assert mock_chat_cls.call_args.kwargs["max_retries"] == 5
 
 
 # =============================================================================

--- a/libs/waivern-llm/tests/waivern_llm/providers/test_google.py
+++ b/libs/waivern-llm/tests/waivern_llm/providers/test_google.py
@@ -4,6 +4,8 @@ Business behaviour: Provides async LLM calls using Google's Gemini models
 via LangChain, satisfying the LLMProvider protocol.
 """
 
+from unittest.mock import patch
+
 import pytest
 from pydantic import BaseModel
 
@@ -75,6 +77,15 @@ class TestGoogleProviderInitialisation:
             GoogleProvider()
 
         assert "GOOGLE_API_KEY" in str(exc_info.value)
+
+    def test_max_retries_forwarded_to_langchain_client(self) -> None:
+        """max_retries is passed to ChatGoogleGenerativeAI at construction."""
+        with patch(
+            "waivern_llm.providers.google.ChatGoogleGenerativeAI"
+        ) as mock_chat_cls:
+            GoogleProvider(api_key="test-key", max_retries=5)
+
+            assert mock_chat_cls.call_args.kwargs["max_retries"] == 5
 
 
 # =============================================================================

--- a/libs/waivern-llm/tests/waivern_llm/providers/test_openai.py
+++ b/libs/waivern-llm/tests/waivern_llm/providers/test_openai.py
@@ -4,6 +4,8 @@ Business behaviour: Provides async LLM calls using OpenAI's models
 via LangChain, satisfying the LLMProvider protocol.
 """
 
+from unittest.mock import patch
+
 import pytest
 from pydantic import BaseModel
 from waivern_core import JsonValue
@@ -87,6 +89,13 @@ class TestOpenAIProviderInitialisation:
         provider = OpenAIProvider(base_url="http://localhost:8000")
 
         assert provider.model_name == "gpt-4o"
+
+    def test_max_retries_forwarded_to_langchain_client(self) -> None:
+        """max_retries is passed to ChatOpenAI at construction."""
+        with patch("waivern_llm.providers.openai.ChatOpenAI") as mock_chat_cls:
+            OpenAIProvider(api_key="test-key", max_retries=5)
+
+            assert mock_chat_cls.call_args.kwargs["max_retries"] == 5
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Add `max_retries` field to `LLMServiceConfiguration` with `WAIVERN_LLM_MAX_RETRIES` env var (default: 2)
- Pass `max_retries` through `create_provider()` to all three provider constructors (Anthropic, OpenAI, Google)
- Forward it to both LangChain wrappers (sync path) and direct SDK clients (batch path)
- Fix Google `genai.Client` batch path which previously had zero retries due to `retry_options=None` default

## Test plan

- [x] `TestMaxRetriesConfiguration`: default, explicit, validation, env var parsing
- [x] Provider init tests: verify `max_retries` forwarded to LangChain clients
- [x] `dev-checks-lite.sh`: 1917 passed, 0 type errors