### PR TITLE
refactor: consolidate CLAUDE.md and add post-checkout worktree hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,14 @@ repos:
         language: system
         types: [python]
         pass_filenames: true
+
+      # Post-checkout: symlink gitignored local files and Claude memory into
+      # newly-created worktrees. Activate with:
+      #   uv run pre-commit install --hook-type post-checkout
+      - id: setup-worktree
+        name: symlink local files into new worktree
+        entry: bash scripts/post-checkout-setup-worktree.sh
+        language: system
+        stages: [post-checkout]
+        always_run: true
+        pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,6 @@ uv run wct poll <run-id>            # Poll batch job status
 uv run wct connectors               # List connectors
 uv run wct processors               # List processors
 uv run wct validate-runbook <file>  # Validate runbook
-uv run wct test-llm                 # Test LLM config
 ```
 
 ## UV Monorepo Workspace
@@ -167,21 +166,52 @@ def process(self, inputs: list[Message], output_schema: Schema) -> Message: ...
 - **British English** spelling
 - **Python 3.12+:** Use PEP 695 generics (`def func[T](...)`), pattern matching where appropriate
 
+## Documentation Style
+
+For complex orchestration functions, document the high-level steps as a numbered list in the docstring. This makes the function's flow clear at a glance. Example:
+
+```python
+def validate_findings_with_file_content(...) -> ...:
+    """Validate findings using file-based batching.
+
+    Orchestrates the complete validation flow:
+    1. Group findings by source file
+    2. Create token-aware batches
+    3. For each batch, generate prompt with full file content and call LLM
+    4. Parse responses and filter findings
+
+    Args:
+        ...
+    """
+```
+
+Use this pattern sparingly — only for functions that orchestrate multiple steps or have complex control flow. Don't use it for simple functions.
+
+## Follow Established Patterns
+
+**Consistency is critical.** Before writing any code:
+
+1. **Read existing similar code** — Find similar implementations in the codebase and follow the same patterns
+2. **Match the style** — Use the same structure, naming conventions, docstring format, test patterns
+3. **Don't invent new patterns** — If there's an established way to do something, use it
+4. **Check test patterns** — Look at how existing tests are written (e.g., use `monkeypatch` for env vars, not `patch.dict`)
+
+If you believe an existing pattern is suboptimal, raise it with the user BEFORE implementing something different.
+
 ## Task Completion
 
 1. Mark task `in_progress`
 2. Make changes
 3. Run `./scripts/dev-checks-lite.sh` during development (after each RED-GREEN-REFACTOR cycle)
-4. Run `./scripts/dev-checks.sh` (full checks) before committing
+4. Run `./scripts/dev-checks.sh` (full checks) before committing — fix failures one by one; don't suppress, skip, or bypass
 5. Only after full checks pass → mark `completed`
+
+**Skip dev-checks** when changes are markdown, comments, or docstrings only — these don't affect runtime behaviour.
 
 ## DO NOT
 
-- Commit directly to `main`/`master` - use feature branches
 - Create backwards compatibility layers unless asked
 - Preserve old context in comments during refactoring
-- Bypass quality checks
-- Mark tasks completed without running dev-checks
 - **Add `__init__.py` to test directories** - causes type checker to resolve test package instead of source package
 
 ## DO
@@ -190,7 +220,6 @@ def process(self, inputs: list[Message], output_schema: Schema) -> Message: ...
 - Remove unnecessary code after refactoring
 - Break large classes/functions into smaller ones
 - Use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`
-- Run dev-checks-lite during development, full dev-checks before committing
 
 ## Git Requirements
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,17 @@ uv run wct test-llm
 **Note:** The `.env` file lives at the workspace root (same level as `pyproject.toml`).
 All commands (`uv run wct`, `uv run pytest`, etc.) should be run from the workspace root.
 
+## Git Hooks
+
+Pre-commit manages all git hooks for this repo. After cloning, run:
+
+```bash
+uv run pre-commit install
+uv run pre-commit install --hook-type post-checkout
+```
+
+The post-checkout hook (`scripts/post-checkout-setup-worktree.sh`) symlinks gitignored local files (`.env`, `.local/`, `.claude/settings.local.json`) and the per-project Claude memory directory from the main worktree into newly-created worktrees. Symlinking (rather than copying) means edits propagate both ways and survive `git worktree remove`.
+
 ## Adding New Packages
 
 1. Create directory in `libs/` or `apps/` with `pyproject.toml`

--- a/scripts/post-checkout-setup-worktree.sh
+++ b/scripts/post-checkout-setup-worktree.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Post-checkout hook: set up a newly-created git worktree by symlinking
+# gitignored local files (env, local plans, Claude settings) and the per-project
+# Claude memory directory from the main worktree. Symlinks (not copies) so that
+# edits propagate both ways and survive `git worktree remove`.
+#
+# Fires only on fresh worktree creation:
+#   - prev_HEAD is all zeros (no previous checkout in this worktree)
+#   - branch_flag is 1 (branch checkout, not file checkout)
+#   - we're inside a worktree, not the main repo
+#
+# Wired in via .pre-commit-config.yaml. Activate on a new clone with:
+#   pre-commit install --hook-type post-checkout
+
+set -euo pipefail
+
+prev_head="${PRE_COMMIT_FROM_REF:-${1:-}}"
+branch_flag="${PRE_COMMIT_CHECKOUT_TYPE:-${3:-}}"
+
+[[ "${branch_flag}" == "1" ]] || exit 0
+[[ "${prev_head}" =~ ^0+$ ]] || exit 0
+
+main_worktree="$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')"
+current_worktree="$(git rev-parse --show-toplevel)"
+
+[[ "${main_worktree}" != "${current_worktree}" ]] || exit 0
+
+echo "post-checkout: setting up worktree at ${current_worktree}"
+
+paths_to_symlink=(
+  ".env"
+  ".local"
+  ".claude/settings.local.json"
+)
+
+for path in "${paths_to_symlink[@]}"; do
+  src="${main_worktree}/${path}"
+  dst="${current_worktree}/${path}"
+  if [[ -e "${src}" && ! -e "${dst}" ]]; then
+    mkdir -p "$(dirname "${dst}")"
+    ln -s "${src}" "${dst}"
+    echo "  symlinked ${path}"
+  fi
+done
+
+encode_path() {
+  printf '%s' "$1" | tr '/' '-'
+}
+
+main_memory_dir="${HOME}/.claude/projects/$(encode_path "${main_worktree}")/memory"
+worktree_memory_dir="${HOME}/.claude/projects/$(encode_path "${current_worktree}")/memory"
+
+if [[ -d "${main_memory_dir}" && ! -e "${worktree_memory_dir}" ]]; then
+  mkdir -p "$(dirname "${worktree_memory_dir}")"
+  ln -s "${main_memory_dir}" "${worktree_memory_dir}"
+  echo "  symlinked Claude memory -> ${main_memory_dir}"
+fi
+
+echo "post-checkout: done"


### PR DESCRIPTION
## Summary

- Consolidate CLAUDE.md: remove duplicate workflow rules (dev-checks scattered across DO/DO NOT/Task Completion), add `Documentation Style`, `Follow Established Patterns`, and `Git Hooks` sections, fold "fix failures one by one" into Task Completion step 4.
- Add `scripts/post-checkout-setup-worktree.sh` that symlinks gitignored local files (`.env`, `.local/`, `.claude/settings.local.json`) and the per-project Claude memory directory from the main worktree into newly-created worktrees. Symlinking (not copying) means edits propagate both ways and survive `git worktree remove`.
- Wire the hook into `.pre-commit-config.yaml` under the `post-checkout` stage. Per-machine activation: `uv run pre-commit install --hook-type post-checkout`.