### PR TITLE
fix: confine pre-commit hooks to pre-commit stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_stages: [pre-commit]
+
 repos:
   # Basic file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Summary

Add `default_stages: [pre-commit]` so existing format, lint, type-check and file-check hooks stay confined to the pre-commit stage. Without this, installing the new post-checkout hook from #377 caused every `git checkout` to trigger the full pre-commit suite — slow and unnecessary.

The `setup-worktree` hook is unaffected because it explicitly declares `stages: [post-checkout]`.