### PR TITLE
feat: persist removed-findings audit trail as sidecar artifacts

### DIFF
--- a/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/__init__.py
+++ b/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/__init__.py
@@ -16,14 +16,10 @@ from waivern_analysers_shared.llm_validation.grouping import (
 from waivern_analysers_shared.llm_validation.models import (
     FALLBACK_ELIGIBLE_SKIP_REASONS,
     LLMValidationOutcome,
-    LLMValidationResponseModel,
-    LLMValidationResultModel,
-    RecommendedActionType,
     RemovedGroup,
     SkippedFinding,
     SkipReason,
     ValidationResult,
-    ValidationResultType,
 )
 from waivern_analysers_shared.llm_validation.protocols import (
     ConcernProvider,
@@ -53,14 +49,10 @@ __all__ = [
     # Models
     "FALLBACK_ELIGIBLE_SKIP_REASONS",
     "LLMValidationOutcome",
-    "LLMValidationResponseModel",
-    "LLMValidationResultModel",
-    "RecommendedActionType",
     "RemovedGroup",
     "SkippedFinding",
     "SkipReason",
     "ValidationResult",
-    "ValidationResultType",
     # Protocols
     "ConcernProvider",
     "SourceProvider",

--- a/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/decision_engine.py
+++ b/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/decision_engine.py
@@ -8,9 +8,7 @@ Centralises all decision logic for LLM validation:
 import logging
 from typing import Literal
 
-from waivern_core import Finding
-
-from .models import LLMValidationResultModel
+from waivern_core import Finding, LLMValidationResultModel
 
 logger = logging.getLogger(__name__)
 

--- a/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/models.py
+++ b/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/models.py
@@ -1,85 +1,31 @@
 """Shared models and constants for LLM validation.
 
-This module defines the result types for the LLM validation layer stack:
+This module defines:
 
-    LLM Response Models     → What the LLM returns (Pydantic for parsing)
     Strategy Results        → What strategies return to orchestrator
     Orchestration Results   → What orchestrator returns to caller
 
+The structured LLM response types (``LLMValidationResultModel``,
+``LLMValidationResponseModel`` and their literal aliases) live in
+``waivern_core.llm_validation_types`` so they can be shared between the LLM
+dispatch layer, the schema layer and this orchestration layer.
 """
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 from waivern_core import Finding
 from waivern_llm import SkippedFinding, SkipReason
 
 __all__ = [
     "FALLBACK_ELIGIBLE_SKIP_REASONS",
     "LLMValidationOutcome",
-    "LLMValidationResponseModel",
-    "LLMValidationResultModel",
-    "RecommendedActionType",
     "RemovedGroup",
     "SkippedFinding",
     "SkipReason",
     "ValidationResult",
-    "ValidationResultType",
 ]
-
-
-# =============================================================================
-# Type Aliases and Constants
-# =============================================================================
-
-ValidationResultType = Literal["TRUE_POSITIVE", "FALSE_POSITIVE"]
-RecommendedActionType = Literal["keep", "discard", "flag_for_review"]
-
-
-# =============================================================================
-# LLM Response Models (Pydantic for structured output parsing)
-# =============================================================================
-
-
-class LLMValidationResultModel(BaseModel):
-    """Strongly typed model for LLM validation results.
-
-    This model represents a single validation result from the LLM, including
-    the finding ID for explicit matching back to the original finding.
-    Using UUIDs instead of indices makes matching robust against LLM reordering.
-    """
-
-    finding_id: str = Field(
-        min_length=1,
-        description="UUID of the finding this result corresponds to (echo back exactly)",
-    )
-    validation_result: ValidationResultType = Field(
-        default="TRUE_POSITIVE", description="The validation result"
-    )
-    confidence: float = Field(
-        default=0.0,
-        description="Confidence score from LLM (0.0-1.0)",
-    )
-    reasoning: str = Field(
-        default="No reasoning provided", description="Reasoning provided by LLM"
-    )
-    recommended_action: RecommendedActionType = Field(
-        default="keep", description="Recommended action from LLM"
-    )
-
-
-class LLMValidationResponseModel(BaseModel):
-    """Wrapper model for structured output from LLM validation.
-
-    This model wraps the list of validation results in a single field,
-    which is required for LangChain's with_structured_output() method.
-    """
-
-    results: list[LLMValidationResultModel] = Field(
-        description="List of validation results for each finding"
-    )
 
 
 # Skip reasons eligible for fallback validation

--- a/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/models.py
+++ b/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/models.py
@@ -22,6 +22,7 @@ __all__ = [
     "FALLBACK_ELIGIBLE_SKIP_REASONS",
     "LLMValidationOutcome",
     "RemovedGroup",
+    "RemovedItem",
     "SkippedFinding",
     "SkipReason",
     "ValidationResult",
@@ -37,6 +38,35 @@ FALLBACK_ELIGIBLE_SKIP_REASONS: frozenset[SkipReason] = frozenset(
         SkipReason.MISSING_SOURCE,
     }
 )
+
+
+# =============================================================================
+# Shared Result Types (used by both strategy and orchestration layers)
+# =============================================================================
+
+
+class RemovedItem[T: Finding](BaseModel):
+    """A finding removed during LLM validation, paired with its removal reason.
+
+    The strategy layer attaches an LLM verdict's ``reasoning`` verbatim when
+    a finding is directly flagged FALSE_POSITIVE. The orchestrator
+    synthesises an ``"Inferred — …"`` reason when a finding is cascade-removed
+    as part of a whole-group removal (Case A in ``_apply_group_decisions``).
+    Pairing the reason with each finding at the point of removal means no
+    parallel-list invariants for downstream consumers to maintain.
+
+    Implemented as a Pydantic BaseModel so instances can live inside
+    ``LLMValidationOutcome.llm_validated_removed`` and round-trip through
+    ``model_dump(mode="json")`` on the distributed-processor resume path.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    finding: T
+    """The original finding that was removed."""
+
+    reason: str
+    """Human-readable removal reason — LLM verdict reasoning verbatim, or a synthesised cascade reason."""
 
 
 # =============================================================================
@@ -95,8 +125,12 @@ class ValidationResult[T: Finding]:
     skipped members inherit the group-level judgement.
     """
 
-    removed_findings: list[T]
-    """Individual findings marked FALSE_POSITIVE by LLM."""
+    removed_findings: list[RemovedItem[T]]
+    """Individual findings removed during validation, each paired with its removal reason.
+
+    Includes both LLM-direct removals (reason = verdict reasoning) and
+    group-cascade removals (reason = synthesised ``"Inferred — …"`` string).
+    """
 
     removed_groups: list[RemovedGroup]
     """Groups removed entirely (only when grouping is enabled)."""
@@ -142,8 +176,8 @@ class LLMValidationOutcome[T: Finding](BaseModel):
     llm_validated_kept: list[T]
     """Findings LLM saw and marked as TRUE_POSITIVE."""
 
-    llm_validated_removed: list[T]
-    """Findings LLM saw and marked as FALSE_POSITIVE."""
+    llm_validated_removed: list[RemovedItem[T]]
+    """Findings LLM saw and marked as FALSE_POSITIVE, each paired with the LLM's verdict reasoning."""
 
     llm_not_flagged: list[T]
     """Findings LLM saw but didn't mention (kept via fail-safe)."""
@@ -177,7 +211,9 @@ class LLMValidationOutcome[T: Finding](BaseModel):
 
         Marks both llm_validated_kept and llm_not_flagged since both went
         through LLM validation without being flagged as FALSE_POSITIVE.
-        Skipped findings are NOT marked (never went through LLM).
+        Skipped findings are NOT marked (never went through LLM). Removed
+        items are NOT marker-touched either — marking is for findings that
+        survive into the primary output, and removed items are filtered out.
 
         Args:
             marker: Function that takes a finding and returns a marked copy.

--- a/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/strategy.py
+++ b/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/strategy.py
@@ -11,7 +11,10 @@ from waivern_llm import LLMDispatchResult, LLMRequest, SkippedFinding, SkipReaso
 from waivern_analysers_shared.llm_validation.decision_engine import (
     ValidationDecisionEngine,
 )
-from waivern_analysers_shared.llm_validation.models import LLMValidationOutcome
+from waivern_analysers_shared.llm_validation.models import (
+    LLMValidationOutcome,
+    RemovedItem,
+)
 from waivern_analysers_shared.types import LLMValidationConfig
 
 logger = logging.getLogger(__name__)
@@ -157,10 +160,15 @@ class FilteringValidationStrategy[TFinding: Finding](
         self,
         raw_responses: list[dict[str, JsonValue]],
         findings_by_id: dict[str, TFinding],
-    ) -> tuple[list[TFinding], list[TFinding], set[str]]:
-        """Deserialise raw responses and split findings into kept/removed."""
+    ) -> tuple[list[TFinding], list[RemovedItem[TFinding]], set[str]]:
+        """Deserialise raw responses and split findings into kept/removed.
+
+        Each removed finding is paired with the LLM verdict's ``reasoning``
+        field verbatim, surfacing the model's own justification at the point
+        of removal for downstream audit-trail consumers.
+        """
         kept: list[TFinding] = []
-        removed: list[TFinding] = []
+        removed: list[RemovedItem[TFinding]] = []
         processed_ids: set[str] = set()
 
         for raw_response in raw_responses:
@@ -177,7 +185,7 @@ class FilteringValidationStrategy[TFinding: Finding](
                 if ValidationDecisionEngine.should_keep_finding(item, finding):
                     kept.append(finding)
                 else:
-                    removed.append(finding)
+                    removed.append(RemovedItem(finding=finding, reason=item.reasoning))
 
         return kept, removed, processed_ids
 

--- a/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/strategy.py
+++ b/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/strategy.py
@@ -4,17 +4,14 @@ import logging
 from abc import ABC, abstractmethod
 from typing import override
 
-from waivern_core import Finding
+from waivern_core import Finding, LLMValidationResponseModel
 from waivern_core.types import JsonValue
 from waivern_llm import LLMDispatchResult, LLMRequest, SkippedFinding, SkipReason
 
 from waivern_analysers_shared.llm_validation.decision_engine import (
     ValidationDecisionEngine,
 )
-from waivern_analysers_shared.llm_validation.models import (
-    LLMValidationOutcome,
-    LLMValidationResponseModel,
-)
+from waivern_analysers_shared.llm_validation.models import LLMValidationOutcome
 from waivern_analysers_shared.types import LLMValidationConfig
 
 logger = logging.getLogger(__name__)

--- a/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/validation_orchestrator.py
+++ b/libs/waivern-analysers-shared/src/waivern_analysers_shared/llm_validation/validation_orchestrator.py
@@ -44,6 +44,7 @@ from waivern_analysers_shared.llm_validation.models import (
     FALLBACK_ELIGIBLE_SKIP_REASONS,
     LLMValidationOutcome,
     RemovedGroup,
+    RemovedItem,
     SkippedFinding,
     ValidationResult,
 )
@@ -429,7 +430,9 @@ class ValidationOrchestrator[T: Finding]:
         # Build lookup sets for quick membership testing
         kept_ids = {f.id for f in outcome.llm_validated_kept}
         kept_ids.update(f.id for f in outcome.llm_not_flagged)
-        removed_ids = {f.id for f in outcome.llm_validated_removed}
+        removed_items_by_id = {
+            item.finding.id: item for item in outcome.llm_validated_removed
+        }
         skipped_ids = {s.finding.id for s in outcome.skipped}
 
         # Build mapping from ID to actual findings from outcome
@@ -440,7 +443,7 @@ class ValidationOrchestrator[T: Finding]:
 
         # Accumulators
         all_kept: list[T] = []
-        all_removed: list[T] = []
+        all_removed: list[RemovedItem[T]] = []
         removed_groups: list[RemovedGroup] = []
 
         for group_key, group_findings in groups.items():
@@ -449,13 +452,17 @@ class ValidationOrchestrator[T: Finding]:
 
             # Identify validated samples by category (exclude skipped from decision)
             validated_kept_ids = [f.id for f in group_samples if f.id in kept_ids]
-            validated_removed = [f for f in group_samples if f.id in removed_ids]
+            validated_removed_items = [
+                removed_items_by_id[f.id]
+                for f in group_samples
+                if f.id in removed_items_by_id
+            ]
             group_skipped_ids = [f.id for f in group_samples if f.id in skipped_ids]
 
             # Classify group using decision engine
             decision = ValidationDecisionEngine.classify_group(
                 kept_count=len(validated_kept_ids),
-                removed_count=len(validated_removed),
+                removed_count=len(validated_removed_items),
             )
 
             match decision:
@@ -469,14 +476,32 @@ class ValidationOrchestrator[T: Finding]:
                     # a whole group is false-positive, the skipped members of that
                     # group inherit the group-level judgement. Conservative handling
                     # of skipped findings only applies when the group is NOT removed.
-                    all_removed.extend(group_findings)
+                    #
+                    # Sampled FALSE_POSITIVE members keep their LLM-direct reason;
+                    # all other members (non-sampled, skipped) inherit a synthesised
+                    # cascade reason explaining the inference.
+                    sampled_fp_ids = {
+                        item.finding.id for item in validated_removed_items
+                    }
+                    cascade_reason = (
+                        f"Inferred — all {len(validated_removed_items)} validated samples in "
+                        f"{grouping_strategy.concern_key}='{group_key}' "
+                        "were marked FALSE_POSITIVE by LLM"
+                    )
+                    for finding in group_findings:
+                        if finding.id in sampled_fp_ids:
+                            all_removed.append(removed_items_by_id[finding.id])
+                        else:
+                            all_removed.append(
+                                RemovedItem(finding=finding, reason=cascade_reason)
+                            )
                     removed_groups.append(
                         RemovedGroup(
                             concern_key=grouping_strategy.concern_key,
                             concern_value=group_key,
                             findings_count=len(group_findings),
                             samples_validated=len(validated_kept_ids)
-                            + len(validated_removed),
+                            + len(validated_removed_items),
                             reason="All validated samples were false positives",
                             require_review=True,
                         )
@@ -494,8 +519,8 @@ class ValidationOrchestrator[T: Finding]:
                     all_kept.extend(
                         skipped_findings_by_id[fid] for fid in group_skipped_ids
                     )
-                    # Remove: FALSE_POSITIVE samples
-                    all_removed.extend(validated_removed)
+                    # Remove: FALSE_POSITIVE samples (with their LLM-direct reasons)
+                    all_removed.extend(validated_removed_items)
 
         return ValidationResult(
             kept_findings=all_kept,

--- a/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_decision_engine.py
+++ b/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_decision_engine.py
@@ -1,5 +1,6 @@
 """Tests for shared validation decision engine."""
 
+from waivern_core import LLMValidationResultModel, RecommendedActionType
 from waivern_core.schemas import (
     BaseFindingEvidence,
     BaseFindingMetadata,
@@ -7,11 +8,7 @@ from waivern_core.schemas import (
     PatternMatchDetail,
 )
 
-from waivern_analysers_shared.llm_validation import (
-    LLMValidationResultModel,
-    RecommendedActionType,
-    ValidationDecisionEngine,
-)
+from waivern_analysers_shared.llm_validation import ValidationDecisionEngine
 
 
 def _create_test_finding(

--- a/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_models.py
+++ b/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_models.py
@@ -9,6 +9,11 @@ from waivern_core.schemas import (
     PatternMatchDetail,
 )
 
+from waivern_analysers_shared.llm_validation.models import (
+    LLMValidationOutcome,
+    RemovedItem,
+)
+
 
 def _create_test_finding() -> BaseFindingModel[BaseFindingMetadata]:
     """Create a test finding with auto-generated UUID."""
@@ -17,6 +22,52 @@ def _create_test_finding() -> BaseFindingModel[BaseFindingMetadata]:
         matched_patterns=[PatternMatchDetail(pattern="test_pattern", match_count=1)],
         metadata=BaseFindingMetadata(source="test_source"),
     )
+
+
+class TestLLMValidationOutcome:
+    """Tests for LLMValidationOutcome.with_marked_findings preserving removed items."""
+
+    def test_with_marked_findings_preserves_removed_unchanged(self) -> None:
+        """Marker is applied to kept findings only; removed items pass through untouched.
+
+        The marker callback exists to tag findings that survived LLM
+        validation (e.g., flagging them as 'llm-validated' in the output).
+        Applying it to removed findings would be incoherent — those items are
+        being filtered out, so 'marking' them has no consumer. This test
+        guards that invariant: ``with_marked_findings`` must return the exact
+        same ``RemovedItem`` instances in ``llm_validated_removed``, with
+        their reasons untouched.
+        """
+        kept_finding = _create_test_finding()
+        removed_finding = _create_test_finding()
+        removed_item = RemovedItem(finding=removed_finding, reason="LLM marked as FP")
+        outcome = LLMValidationOutcome[BaseFindingModel[BaseFindingMetadata]](
+            llm_validated_kept=[kept_finding],
+            llm_validated_removed=[removed_item],
+            llm_not_flagged=[],
+            skipped=[],
+        )
+
+        def _mark(
+            f: BaseFindingModel[BaseFindingMetadata],
+        ) -> BaseFindingModel[BaseFindingMetadata]:
+            return f.model_copy(
+                update={"metadata": BaseFindingMetadata(source="MARKED")}
+            )
+
+        marked_outcome = outcome.with_marked_findings(_mark)
+
+        # The marker IS applied to kept findings (sanity check).
+        assert marked_outcome.llm_validated_kept[0].metadata.source == "MARKED"
+
+        # The marker must not touch removed items: reasons stay intact and
+        # the finding's metadata is the original, not the MARKED version.
+        assert marked_outcome.llm_validated_removed == [removed_item]
+        assert marked_outcome.llm_validated_removed[0].reason == "LLM marked as FP"
+        assert (
+            marked_outcome.llm_validated_removed[0].finding.metadata.source
+            == "test_source"
+        )
 
 
 class TestLLMValidationResultModel:

--- a/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_models.py
+++ b/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_models.py
@@ -1,14 +1,13 @@
 """Tests for shared LLM validation models - focuses on business-critical constraints."""
 
 import pytest
+from waivern_core import LLMValidationResultModel
 from waivern_core.schemas import (
     BaseFindingEvidence,
     BaseFindingMetadata,
     BaseFindingModel,
     PatternMatchDetail,
 )
-
-from waivern_analysers_shared.llm_validation import LLMValidationResultModel
 
 
 def _create_test_finding() -> BaseFindingModel[BaseFindingMetadata]:

--- a/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_orchestrator_prepare_finalise.py
+++ b/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_orchestrator_prepare_finalise.py
@@ -20,6 +20,7 @@ from waivern_llm import LLMDispatchResult, LLMRequest, SkippedFinding, SkipReaso
 
 from waivern_analysers_shared.llm_validation.models import (
     LLMValidationOutcome,
+    RemovedItem,
     ValidationResult,
 )
 from waivern_analysers_shared.llm_validation.validation_orchestrator import (
@@ -257,13 +258,16 @@ class TestOrchestratorFinalise:
     """Tests for ValidationOrchestrator.finalise()."""
 
     def test_finalise_without_grouping_returns_validation_result(self) -> None:
-        """Ungrouped path -> ValidationResult with correct kept/removed."""
+        """Ungrouped path -> ValidationResult propagates RemovedItem reasons from the strategy outcome."""
         kept = _make_finding("k")
         removed = _make_finding("r")
+        removed_item = RemovedItem(
+            finding=removed, reason="LLM marked as false positive"
+        )
         strategy = _make_finalise_strategy(
             LLMValidationOutcome(
                 llm_validated_kept=[kept],
-                llm_validated_removed=[removed],
+                llm_validated_removed=[removed_item],
                 llm_not_flagged=[],
                 skipped=[],
             )
@@ -279,12 +283,18 @@ class TestOrchestratorFinalise:
 
         assert isinstance(result, ValidationResult)
         assert result.kept_findings == [kept]
-        assert result.removed_findings == [removed]
+        assert result.removed_findings == [removed_item]
+        assert result.removed_findings[0].finding == removed
+        assert result.removed_findings[0].reason == "LLM marked as false positive"
         assert result.removed_groups == []
         assert result.all_succeeded is True
 
     def test_finalise_with_grouping_applies_group_decisions(self) -> None:
-        """Grouped path -> group decisions (Case A/B/C) applied correctly."""
+        """Grouped Case A removes all members; sampled FPs keep LLM reasons, cascade members get 'Inferred —' reasons.
+
+        Case C is implicit: GroupB has no validated FPs, so it contributes
+        nothing to ``removed_findings`` and is fully kept.
+        """
         # GroupA: all samples FALSE_POSITIVE -> whole group removed
         # GroupB: all kept -> whole group kept
         a1 = _make_finding("a1", "GroupA")
@@ -292,10 +302,11 @@ class TestOrchestratorFinalise:
         b1 = _make_finding("b1", "GroupB")
         b2_unsampled = _make_finding("b2", "GroupB")
 
+        a1_removed = RemovedItem(finding=a1, reason="LLM said FP for a1")
         strategy = _make_finalise_strategy(
             LLMValidationOutcome(
                 llm_validated_kept=[b1],
-                llm_validated_removed=[a1],
+                llm_validated_removed=[a1_removed],
                 llm_not_flagged=[],
                 skipped=[],
             )
@@ -317,10 +328,94 @@ class TestOrchestratorFinalise:
 
         assert isinstance(result, ValidationResult)
         # GroupA fully removed; GroupB fully kept
-        assert {f.id for f in result.removed_findings} == {"a1", "a2"}
+        assert {item.finding.id for item in result.removed_findings} == {"a1", "a2"}
         assert {f.id for f in result.kept_findings} == {"b1", "b2"}
         assert len(result.removed_groups) == 1
         assert result.removed_groups[0].concern_value == "GroupA"
+
+        # Reason provenance: sampled FP keeps its LLM-direct reason; cascade
+        # member (a2_unsampled) gets a synthesised 'Inferred —' reason
+        # referencing the concern key and value.
+        by_id = {item.finding.id: item for item in result.removed_findings}
+        assert by_id["a1"].reason == "LLM said FP for a1"
+        assert by_id["a2"].reason.startswith("Inferred —")
+        assert "group='GroupA'" in by_id["a2"].reason
+
+    def test_finalise_case_b_partial_keep_in_same_group(self) -> None:
+        """Case B (mixed kept + FP samples in same group) -> keep group, remove only FP samples with verbatim LLM reasons.
+
+        Case A removes the whole group when all validated samples are
+        FALSE_POSITIVE; Case C keeps the whole group when none are. Case B is
+        the middle ground: some samples in the group are validated as
+        TRUE_POSITIVE and some as FALSE_POSITIVE, so the group survives but
+        the LLM-flagged false positives are filtered out. Non-sampled and
+        skipped members of the group remain kept (conservative semantics —
+        they weren't validated, so we don't infer anything about them).
+        """
+        # One group, two sampled findings (one kept, one removed) plus a
+        # non-sampled member.
+        a1_kept = _make_finding("a1", "GroupA")
+        a2_removed = _make_finding("a2", "GroupA")
+        a3_unsampled = _make_finding("a3", "GroupA")
+
+        a2_removed_item = RemovedItem(finding=a2_removed, reason="LLM said FP for a2")
+        strategy = _make_finalise_strategy(
+            LLMValidationOutcome(
+                llm_validated_kept=[a1_kept],
+                llm_validated_removed=[a2_removed_item],
+                llm_not_flagged=[],
+                skipped=[],
+            )
+        )
+        orchestrator = ValidationOrchestrator(
+            llm_strategy=strategy,
+            grouping_strategy=_GroupingByAttr(),
+        )
+        state = OrchestratorPrepareState(
+            strategy_findings=[a1_kept, a2_removed],
+            config=_make_config(),
+            run_id=_TEST_RUN_ID,
+            groups={"GroupA": [a1_kept, a2_removed, a3_unsampled]},
+            sampled={"GroupA": [a1_kept, a2_removed]},
+            non_sampled={"GroupA": [a3_unsampled]},
+        )
+
+        result = orchestrator.finalise(state, _dispatch_result())
+
+        assert isinstance(result, ValidationResult)
+        # Only the FP sample is removed, with its LLM-direct reason.
+        assert result.removed_findings == [a2_removed_item]
+        # The kept-validated and non-sampled members survive in the group.
+        assert {f.id for f in result.kept_findings} == {"a1", "a3"}
+        # Group was NOT wholesale-removed, so removed_groups stays empty.
+        assert result.removed_groups == []
+
+    def test_finalise_empty_findings_short_circuits_with_no_removed(self) -> None:
+        """Empty state.strategy_findings -> ValidationResult with no removed findings.
+
+        Guards the explicit short-circuit at the top of finalise(); without
+        this guard a downstream change could accidentally invoke the strategy
+        on an empty input and produce a non-empty removed list.
+        """
+        # Strategy is configured but should NEVER be invoked — the empty
+        # short-circuit must fire before any strategy call.
+        strategy = Mock()
+        orchestrator = ValidationOrchestrator(llm_strategy=strategy)
+        state = OrchestratorPrepareState[_Finding](
+            strategy_findings=[],
+            config=_make_config(),
+            run_id=_TEST_RUN_ID,
+        )
+
+        result = orchestrator.finalise(state, _dispatch_result())
+
+        assert isinstance(result, ValidationResult)
+        assert result.removed_findings == []
+        assert result.kept_findings == []
+        assert result.removed_groups == []
+        assert result.samples_validated == 0
+        assert result.all_succeeded is True
+        strategy.finalise_validation.assert_not_called()
 
     def test_finalise_applies_marker(self) -> None:
         """Marker callback applied to validated findings, not skipped."""
@@ -402,19 +497,29 @@ class TestOrchestratorFinaliseFallback:
         assert [f.id for f in returned.state.strategy_findings] == ["o"]
 
     def test_finalise_completes_fallback_round(self) -> None:
-        """Round 2 (is_fallback_round=True) -> merged ValidationResult."""
+        """Round 2 (is_fallback_round=True) -> merged ValidationResult; removed findings from primary and fallback are concatenated with reasons preserved."""
         validated = _make_finding("v")
         oversized = _make_finding("o")
+        primary_removed = _make_finding("pr")
+        fallback_removed = _make_finding("fr")
+
+        primary_removed_item = RemovedItem(
+            finding=primary_removed, reason="primary LLM said FP"
+        )
+        fallback_removed_item = RemovedItem(
+            finding=fallback_removed, reason="fallback LLM said FP"
+        )
         primary_outcome = LLMValidationOutcome(
             llm_validated_kept=[validated],
-            llm_validated_removed=[],
+            llm_validated_removed=[primary_removed_item],
             llm_not_flagged=[],
             skipped=[SkippedFinding(finding=oversized, reason=SkipReason.OVERSIZED)],
         )
-        # Fallback succeeds: oversized now validated as kept
+        # Fallback succeeds: oversized now validated as kept; fallback also
+        # flags its own FP.
         fallback_outcome = LLMValidationOutcome(
             llm_validated_kept=[oversized],
-            llm_validated_removed=[],
+            llm_validated_removed=[fallback_removed_item],
             llm_not_flagged=[],
             skipped=[],
         )
@@ -441,6 +546,13 @@ class TestOrchestratorFinaliseFallback:
         assert result.all_succeeded is True
         fallback_strategy.finalise_validation.assert_called_once()
         primary_strategy.finalise_validation.assert_not_called()
+
+        # Merged outcome concatenates primary + fallback removed items, each
+        # with its origin reason intact.
+        assert result.removed_findings == [
+            primary_removed_item,
+            fallback_removed_item,
+        ]
 
     def test_finalise_no_fallback_when_no_eligible_skipped(self) -> None:
         """Fallback configured but no eligible skipped -> ValidationResult directly."""

--- a/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_strategy_finalise_validation.py
+++ b/libs/waivern-analysers-shared/tests/waivern_analysers_shared/llm_validation/test_strategy_finalise_validation.py
@@ -21,6 +21,7 @@ from waivern_llm import (
     SkipReason,
 )
 
+from waivern_analysers_shared.llm_validation.models import RemovedItem
 from waivern_analysers_shared.llm_validation.strategy import (
     FilteringValidationStrategy,
 )
@@ -84,7 +85,7 @@ class TestDefaultFinaliseValidation:
     """Tests for the default finalise_validation() on FilteringValidationStrategy."""
 
     def test_deserialises_responses_and_categorises_findings(self) -> None:
-        """Raw dict responses -> TRUE_POSITIVE in kept, FALSE_POSITIVE in removed."""
+        """Raw dict responses -> TRUE_POSITIVE in kept, FALSE_POSITIVE in removed paired with LLM reasoning verbatim."""
         strategy = _FilteringStrategyForTests()
         kept_finding = _make_finding("kept")
         removed_finding = _make_finding("removed")
@@ -104,7 +105,9 @@ class TestDefaultFinaliseValidation:
         )
 
         assert outcome.llm_validated_kept == [kept_finding]
-        assert outcome.llm_validated_removed == [removed_finding]
+        assert outcome.llm_validated_removed == [
+            RemovedItem(finding=removed_finding, reason="test reasoning")
+        ]
         assert outcome.llm_not_flagged == []
         assert outcome.skipped == []
 

--- a/libs/waivern-core/docs/processor-input-requirements.md
+++ b/libs/waivern-core/docs/processor-input-requirements.md
@@ -221,7 +221,9 @@ artifacts:
 The processor receives both messages and should merge them:
 
 ```python
-def process(self, inputs: list[Message], output_schema: Schema) -> Message:
+def process(
+    self, inputs: list[Message], output_schema: Schema
+) -> tuple[Message, list[Message]]:
     # Merge all items from all inputs
     all_items = []
     for message in inputs:
@@ -231,7 +233,8 @@ def process(self, inputs: list[Message], output_schema: Schema) -> Message:
 
     # Process the combined dataset
     findings = self._analyse(all_items)
-    return self._create_output(findings, output_schema)
+    primary = self._create_output(findings, output_schema)
+    return primary, []
 ```
 
 ### Multi-Schema Routing
@@ -239,7 +242,9 @@ def process(self, inputs: list[Message], output_schema: Schema) -> Message:
 When inputs have different schemas, route to appropriate handlers:
 
 ```python
-def process(self, inputs: list[Message], output_schema: Schema) -> Message:
+def process(
+    self, inputs: list[Message], output_schema: Schema
+) -> tuple[Message, list[Message]]:
     # Determine which schema combination we received
     schemas = frozenset((msg.schema.name, msg.schema.version) for msg in inputs)
 
@@ -248,13 +253,13 @@ def process(self, inputs: list[Message], output_schema: Schema) -> Message:
         ("processing_purpose_finding", "1.0.0"),
         ("gdpr_data_subject", "1.0.0"),
     }:
-        return self._process_full(inputs, output_schema)
+        return self._process_full(inputs, output_schema), []
 
     elif schemas == {
         ("gdpr_personal_data", "1.0.0"),
         ("processing_purpose_finding", "1.0.0"),
     }:
-        return self._process_without_subjects(inputs, output_schema)
+        return self._process_without_subjects(inputs, output_schema), []
 
     else:
         # Should never happen if Planner validated correctly
@@ -302,7 +307,9 @@ def _load_reader(self, schema: Schema) -> ModuleType:
 ### Usage in process()
 
 ```python
-def process(self, inputs: list[Message], output_schema: Schema) -> Message:
+def process(
+    self, inputs: list[Message], output_schema: Schema
+) -> tuple[Message, list[Message]]:
     all_items = []
     for message in inputs:
         reader = self._load_reader(message.schema)
@@ -316,7 +323,8 @@ def process(self, inputs: list[Message], output_schema: Schema) -> Message:
         result = self._analyse_item(item)
         findings.append(result)
 
-    return self._create_output(findings, output_schema)
+    primary = self._create_output(findings, output_schema)
+    return primary, []
 ```
 
 ---
@@ -434,7 +442,9 @@ class PersonalDataAnalyser(Analyser):
         return [Schema("personal_data_indicator", "1.0.0")]
 
     @override
-    def process(self, inputs: list[Message], output_schema: Schema) -> Message:
+    def process(
+        self, inputs: list[Message], output_schema: Schema
+    ) -> tuple[Message, list[Message]]:
         # Merge all inputs (same-schema fan-in)
         all_items = []
         for message in inputs:
@@ -446,7 +456,8 @@ class PersonalDataAnalyser(Analyser):
         for item in all_items:
             findings.extend(self._find_personal_data(item))
 
-        return self._create_output(findings, output_schema)
+        primary = self._create_output(findings, output_schema)
+        return primary, []
 ```
 
 ### Example 2: Multi-Schema Synthesiser
@@ -481,13 +492,15 @@ class GdprArticle30Analyser(Analyser):
         return [Schema("gdpr_article_30_finding", "1.0.0")]
 
     @override
-    def process(self, inputs: list[Message], output_schema: Schema) -> Message:
+    def process(
+        self, inputs: list[Message], output_schema: Schema
+    ) -> tuple[Message, list[Message]]:
         schemas = frozenset((m.schema.name, m.schema.version) for m in inputs)
 
         if len(schemas) == 3:
-            return self._process_full(inputs, output_schema)
+            return self._process_full(inputs, output_schema), []
         else:
-            return self._process_partial(inputs, output_schema)
+            return self._process_partial(inputs, output_schema), []
 
     def _process_full(self, inputs: list[Message], output_schema: Schema) -> Message:
         personal_data = self._extract_by_schema(inputs, "gdpr_personal_data")

--- a/libs/waivern-core/src/waivern_core/__init__.py
+++ b/libs/waivern-core/src/waivern_core/__init__.py
@@ -38,6 +38,12 @@ from waivern_core.errors import (
     ProcessorProcessingError,
     WaivernError,
 )
+from waivern_core.llm_validation_types import (
+    LLMValidationResponseModel,
+    LLMValidationResultModel,
+    RecommendedActionType,
+    ValidationResultType,
+)
 from waivern_core.message import ExecutionContext, Message, MessageExtensions
 from waivern_core.protocols import Finding, FindingMetadata
 from waivern_core.ruleset_types import (
@@ -109,6 +115,11 @@ __all__ = [
     # Types
     "InputRequirement",
     "JsonValue",
+    # LLM validation types
+    "LLMValidationResponseModel",
+    "LLMValidationResultModel",
+    "RecommendedActionType",
+    "ValidationResultType",
     # Protocols
     "DistributedProcessor",
     "Finding",

--- a/libs/waivern-core/src/waivern_core/base_analyser.py
+++ b/libs/waivern-core/src/waivern_core/base_analyser.py
@@ -28,8 +28,11 @@ class Analyser(Processor):
             def get_input_requirements(cls) -> list[list[InputRequirement]]:
                 return [[InputRequirement("standard_input", "1.0.0")]]
 
-            def process(self, inputs: list[Message], output_schema: Schema) -> Message:
+            def process(
+                self, inputs: list[Message], output_schema: Schema
+            ) -> tuple[Message, list[Message]]:
                 # Analysis logic here
-                ...
+                primary = Message(...)
+                return primary, []
 
     """

--- a/libs/waivern-core/src/waivern_core/base_processor.py
+++ b/libs/waivern-core/src/waivern_core/base_processor.py
@@ -115,8 +115,8 @@ class Processor(abc.ABC):
         self,
         inputs: list[Message],
         output_schema: Schema,
-    ) -> Message:
-        """Process input data and produce output.
+    ) -> tuple[Message, list[Message]]:
+        """Process input data and produce a primary output plus optional sidecars.
 
         This is the synchronous path. Subclasses override it for in-process
         transformation. Subclasses implementing the ``DistributedProcessor``
@@ -132,16 +132,22 @@ class Processor(abc.ABC):
             inputs: List of input messages to process. For single-input
                 processors, this will contain one message. For fan-in
                 processors, this contains multiple messages.
-            output_schema: Output schema for result validation
+            output_schema: Output schema for result validation.
 
         Returns:
-            Processed results that conform to the processor's output schema
+            A two-element tuple ``(primary, sidecars)``:
+
+            - ``primary``: the artifact's main output. Flowed downstream
+              in the DAG and validated against ``output_schema``.
+            - ``sidecars``: zero or more typed ``Message`` objects persisted
+              alongside the primary but NOT flowed downstream. Each sidecar
+              carries its own schema. Use ``[]`` when no sidecars are emitted.
 
         Raises:
             NotImplementedError: If the subclass does not override this method
                 and is not routed through the ``DistributedProcessor`` path.
-            ProcessorError: If processing fails
-            SchemaLoadError: If schema validation fails
+            ProcessorError: If processing fails.
+            SchemaLoadError: If schema validation fails.
 
         """
         raise NotImplementedError(

--- a/libs/waivern-core/src/waivern_core/dispatch.py
+++ b/libs/waivern-core/src/waivern_core/dispatch.py
@@ -278,7 +278,7 @@ class DistributedProcessor[S: BaseModel](Protocol):
         state: S,
         results: Sequence[DispatchResult],
         output_schema: Schema,
-    ) -> Message | PrepareResult[S]:
+    ) -> tuple[Message, list[Message]] | PrepareResult[S]:
         """Produce output from intermediate state and dispatch results.
 
         This method must be synchronous with no internal I/O. It receives
@@ -293,8 +293,14 @@ class DistributedProcessor[S: BaseModel](Protocol):
             output_schema: The schema for the output message.
 
         Returns:
-            A ``Message`` if processing is complete, or a new
+            ``(primary, sidecars)`` if processing is complete, or a new
             ``PrepareResult`` if another dispatch round is needed.
+
+            - ``primary``: the artifact's main output, flowed downstream
+              in the DAG and validated against ``output_schema``.
+            - ``sidecars``: zero or more typed ``Message`` objects persisted
+              alongside the primary but NOT flowed downstream. Each sidecar
+              carries its own schema. Use ``[]`` when no sidecars are emitted.
 
         """
         ...

--- a/libs/waivern-core/src/waivern_core/llm_validation_types.py
+++ b/libs/waivern-core/src/waivern_core/llm_validation_types.py
@@ -1,0 +1,66 @@
+"""Foundational data shapes for LLM validation verdicts.
+
+Defines the structured contract for a single LLM judgement on a finding and
+the list-wrapper used to parse batched structured output from the LLM. These
+are pure Pydantic data carriers with no behaviour beyond field declarations
+and validation.
+
+Lives in waivern-core so that the LLM dispatch layer (``waivern-llm``), the
+schema layer (``waivern-schemas``) and the validation orchestration layer
+(``waivern-analysers-shared``) can all reference the same verdict shape
+without inverting the dependency graph.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "LLMValidationResponseModel",
+    "LLMValidationResultModel",
+    "RecommendedActionType",
+    "ValidationResultType",
+]
+
+
+ValidationResultType = Literal["TRUE_POSITIVE", "FALSE_POSITIVE"]
+RecommendedActionType = Literal["keep", "discard", "flag_for_review"]
+
+
+class LLMValidationResultModel(BaseModel):
+    """Strongly typed model for LLM validation results.
+
+    This model represents a single validation result from the LLM, including
+    the finding ID for explicit matching back to the original finding.
+    Using UUIDs instead of indices makes matching robust against LLM reordering.
+    """
+
+    finding_id: str = Field(
+        min_length=1,
+        description="UUID of the finding this result corresponds to (echo back exactly)",
+    )
+    validation_result: ValidationResultType = Field(
+        default="TRUE_POSITIVE", description="The validation result"
+    )
+    confidence: float = Field(
+        default=0.0,
+        description="Confidence score from LLM (0.0-1.0)",
+    )
+    reasoning: str = Field(
+        default="No reasoning provided", description="Reasoning provided by LLM"
+    )
+    recommended_action: RecommendedActionType = Field(
+        default="keep", description="Recommended action from LLM"
+    )
+
+
+class LLMValidationResponseModel(BaseModel):
+    """Wrapper model for structured output from LLM validation.
+
+    This model wraps the list of validation results in a single field,
+    which is required for LangChain's with_structured_output() method.
+    """
+
+    results: list[LLMValidationResultModel] = Field(
+        description="List of validation results for each finding"
+    )

--- a/libs/waivern-core/tests/waivern_core/test_base_classifier.py
+++ b/libs/waivern-core/tests/waivern_core/test_base_classifier.py
@@ -30,11 +30,16 @@ class GDPRClassifier(Classifier):
         return [Schema("gdpr_classified_finding", "1.0.0")]
 
     @override
-    def process(self, inputs: list[Message], output_schema: Schema) -> Message:
-        return Message(
-            id="test",
-            content={"classified": True},
-            schema=output_schema,
+    def process(
+        self, inputs: list[Message], output_schema: Schema
+    ) -> tuple[Message, list[Message]]:
+        return (
+            Message(
+                id="test",
+                content={"classified": True},
+                schema=output_schema,
+            ),
+            [],
         )
 
 

--- a/libs/waivern-crypto-quality-analyser/src/waivern_crypto_quality_analyser/analyser.py
+++ b/libs/waivern-crypto-quality-analyser/src/waivern_crypto_quality_analyser/analyser.py
@@ -144,7 +144,7 @@ class CryptoQualityAnalyser(Analyser):
         self,
         inputs: list[Message],
         output_schema: Schema,
-    ) -> Message:
+    ) -> tuple[Message, list[Message]]:
         """Process data to find cryptographic algorithm patterns.
 
         Supports same-schema fan-in: multiple standard_input messages are merged
@@ -155,9 +155,11 @@ class CryptoQualityAnalyser(Analyser):
             output_schema: Expected output schema.
 
         Returns:
-            Output message with crypto quality findings from all inputs combined.
+            ``(primary, [])`` where ``primary`` is the crypto quality findings
+            message from all inputs combined. No sidecars are emitted.
 
         """
         data_items = self._merge_input_data_items(inputs)
         findings = self._find_patterns_in_data_items(data_items)
-        return self._result_builder.build_output_message(findings, output_schema)
+        primary = self._result_builder.build_output_message(findings, output_schema)
+        return primary, []

--- a/libs/waivern-crypto-quality-analyser/tests/waivern_crypto_quality_analyser/test_analyser.py
+++ b/libs/waivern-crypto-quality-analyser/tests/waivern_crypto_quality_analyser/test_analyser.py
@@ -125,7 +125,7 @@ class TestCryptoQualityPolarity:
         analyser = CryptoQualityAnalyser(config=_make_config())
         message = _make_message("Using test_deprecated_pattern for hashing")
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -138,7 +138,7 @@ class TestCryptoQualityPolarity:
         analyser = CryptoQualityAnalyser(config=_make_config())
         message = _make_message("Using test_strong_pattern for hashing")
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -151,7 +151,7 @@ class TestCryptoQualityPolarity:
         analyser = CryptoQualityAnalyser(config=_make_config())
         message = _make_message("Using test_weak_pattern for encryption")
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -164,7 +164,7 @@ class TestCryptoQualityPolarity:
         analyser = CryptoQualityAnalyser(config=_make_config())
         message = _make_message("x = a + b")
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         assert result.content["findings"] == []
         assert result.content["summary"]["total_findings"] == 0
@@ -188,7 +188,7 @@ class TestCryptoQualityOutputStructure:
         analyser = CryptoQualityAnalyser(config=_make_config())
         message = _make_message("Using test_strong_pattern for hashing")
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         assert isinstance(result, Message)
         assert result.schema == OUTPUT_SCHEMA
@@ -202,7 +202,7 @@ class TestCryptoQualityOutputStructure:
         analyser = CryptoQualityAnalyser(config=_make_config())
         message = _make_message("Using test_strong_pattern for hashing")
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
         summary = result.content["summary"]
@@ -228,7 +228,7 @@ class TestCryptoQualityFanIn:
         msg_deprecated = _make_message("Using test_deprecated_pattern for hashing")
         msg_strong = _make_message("Using test_strong_pattern for encryption")
 
-        result = analyser.process([msg_deprecated, msg_strong], OUTPUT_SCHEMA)
+        result, _ = analyser.process([msg_deprecated, msg_strong], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
         algorithms = {f["algorithm"] for f in findings}

--- a/libs/waivern-data-collection-analyser/src/waivern_data_collection_analyser/analyser.py
+++ b/libs/waivern-data-collection-analyser/src/waivern_data_collection_analyser/analyser.py
@@ -68,7 +68,7 @@ class DataCollectionAnalyser(Analyser):
         self,
         inputs: list[Message],
         output_schema: Schema,
-    ) -> Message:
+    ) -> tuple[Message, list[Message]]:
         """Process source code to find data collection patterns.
 
         Orchestrates the analysis flow:
@@ -81,7 +81,8 @@ class DataCollectionAnalyser(Analyser):
             output_schema: Expected output schema.
 
         Returns:
-            Output message with data collection findings.
+            ``(primary, [])`` where ``primary`` is the data-collection
+            findings message. No sidecars are emitted.
 
         """
         findings: list[DataCollectionIndicatorModel] = []
@@ -90,7 +91,8 @@ class DataCollectionAnalyser(Analyser):
             source_data = reader.read(message.content)
             findings.extend(self._handler.analyse(source_data))
 
-        return self._result_builder.build_output_message(findings, output_schema)
+        primary = self._result_builder.build_output_message(findings, output_schema)
+        return primary, []
 
     def _load_reader(self, schema: Schema) -> SchemaReader[SourceCodeDataModel]:
         """Dynamically import reader module for the given input schema.

--- a/libs/waivern-data-collection-analyser/tests/waivern_data_collection_analyser/test_analyser.py
+++ b/libs/waivern-data-collection-analyser/tests/waivern_data_collection_analyser/test_analyser.py
@@ -256,7 +256,7 @@ class TestDataCollectionOutputStructure:
             schema=Schema("source_code", "1.0.0"),
         )
 
-        result = analyser.process([message], output_schema)
+        result, _ = analyser.process([message], output_schema)
 
         assert isinstance(result, Message)
         assert result.schema == output_schema
@@ -297,7 +297,7 @@ class TestDataCollectionOutputStructure:
             schema=Schema("source_code", "1.0.0"),
         )
 
-        result = analyser.process([message], output_schema)
+        result, _ = analyser.process([message], output_schema)
 
         summary = result.content["summary"]
         category_names = {c["collection_type"] for c in summary["categories"]}
@@ -353,7 +353,7 @@ class TestDataCollectionSourceCodeInput:
             schema=Schema("source_code", "1.0.0"),
         )
 
-        result = analyser.process([message], output_schema)
+        result, _ = analyser.process([message], output_schema)
 
         assert isinstance(result, Message)
         assert result.schema == output_schema
@@ -421,7 +421,7 @@ class TestDataCollectionSourceCodeInput:
             schema=Schema("source_code", "1.0.0"),
         )
 
-        result = analyser.process([message_a, message_b], output_schema)
+        result, _ = analyser.process([message_a, message_b], output_schema)
 
         sources = {f["metadata"]["source"] for f in result.content["findings"]}
         assert "a/form.php" in sources

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/analyser.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/analyser.py
@@ -136,7 +136,7 @@ class DataSubjectAnalyser(Analyser):
         state: DataSubjectPrepareState,
         results: Sequence[DispatchResult],
         output_schema: Schema,
-    ) -> Message | PrepareResult[DataSubjectPrepareState]:
+    ) -> tuple[Message, list[Message]] | PrepareResult[DataSubjectPrepareState]:
         """Produce output message from state and dispatch results.
 
         Paths:
@@ -151,11 +151,12 @@ class DataSubjectAnalyser(Analyser):
         retained defensively to satisfy the typed return union.
         """
         if not state.llm_enabled or state.orchestrator_state is None:
-            return self._result_builder.build_output_message(
+            primary = self._result_builder.build_output_message(
                 state.all_findings,
                 output_schema,
                 validation_result=None,
             )
+            return primary, []
 
         llm_result = self._extract_llm_result(results)
         outcome = self._orchestrator.finalise(
@@ -177,11 +178,12 @@ class DataSubjectAnalyser(Analyser):
             f"({len(outcome.removed_groups)} groups removed)"
         )
 
-        return self._result_builder.build_output_message(
+        primary = self._result_builder.build_output_message(
             outcome.kept_findings,
             output_schema,
             validation_result=outcome,
         )
+        return primary, []
 
     def deserialise_prepare_result(
         self, raw: dict[str, Any]

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/analyser.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/analyser.py
@@ -156,7 +156,7 @@ class DataSubjectAnalyser(Analyser):
                 output_schema,
                 validation_result=None,
             )
-            return primary, []
+            return primary, self._result_builder.build_sidecars(None, state.run_id)
 
         llm_result = self._extract_llm_result(results)
         outcome = self._orchestrator.finalise(
@@ -183,7 +183,7 @@ class DataSubjectAnalyser(Analyser):
             output_schema,
             validation_result=outcome,
         )
-        return primary, []
+        return primary, self._result_builder.build_sidecars(outcome, state.run_id)
 
     def deserialise_prepare_result(
         self, raw: dict[str, Any]

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/llm_validation_strategy.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/llm_validation_strategy.py
@@ -2,9 +2,9 @@
 
 from typing import override
 
-from waivern_analysers_shared.llm_validation.models import LLMValidationResponseModel
 from waivern_analysers_shared.llm_validation.strategy import FilteringValidationStrategy
 from waivern_analysers_shared.types import LLMValidationConfig
+from waivern_core import LLMValidationResponseModel
 from waivern_llm import BatchingMode, ItemGroup, LLMRequest
 from waivern_schemas.data_subject_indicator import DataSubjectIndicatorModel
 

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/result_builder.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/result_builder.py
@@ -15,8 +15,11 @@ from waivern_schemas.data_subject_indicator import (
     DataSubjectIndicatorOutput,
     DataSubjectIndicatorSummary,
 )
+from waivern_schemas.removed_findings import RemovedFinding, RemovedFindingsOutput
 
 from .types import DataSubjectAnalyserConfig
+
+_REMOVED_FINDINGS_SCHEMA = Schema("removed_findings", "1.0.0")
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +81,58 @@ class DataSubjectResultBuilder:
         )
 
         return output_message
+
+    def build_sidecars(
+        self,
+        validation_result: ValidationResult[DataSubjectIndicatorModel] | None,
+        run_id: str,
+    ) -> list[Message]:
+        """Build the analyser's sidecar Messages.
+
+        Dispatches to one private builder per sidecar type. Each builder
+        returns ``Message | None`` so this method can filter the absent ones
+        out — a sidecar is "absent" when there is no content to record.
+        Adding a new sidecar type is a new ``_build_X_sidecar`` method plus
+        one line here; the analyser call site does not change.
+        """
+        candidates = [
+            self._build_removed_findings_sidecar(validation_result, run_id),
+        ]
+        return [s for s in candidates if s is not None]
+
+    def _build_removed_findings_sidecar(
+        self,
+        validation_result: ValidationResult[DataSubjectIndicatorModel] | None,
+        run_id: str,
+    ) -> Message | None:
+        """Build the audit-trail sidecar listing LLM-removed findings.
+
+        Returns None when validation was disabled or produced no removals —
+        there is no audit content to record.
+        """
+        if validation_result is None or not validation_result.removed_findings:
+            return None
+
+        payload = RemovedFindingsOutput(
+            analyser_name="data_subject_analyser",
+            run_id=run_id,
+            ruleset=self._config.pattern_matching.ruleset,
+            removed_findings=[
+                RemovedFinding(
+                    original_finding=item.finding.model_dump(mode="json"),
+                    reason=item.reason,
+                )
+                for item in validation_result.removed_findings
+            ],
+        )
+
+        sidecar = Message(
+            id=f"data_subject_removed_findings_{datetime.now(UTC).isoformat()}",
+            content=payload.model_dump(mode="json"),
+            schema=_REMOVED_FINDINGS_SCHEMA,
+        )
+        sidecar.validate()
+        return sidecar
 
     def _build_summary(
         self, indicators: list[DataSubjectIndicatorModel]

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/result_builder.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/result_builder.py
@@ -176,6 +176,10 @@ class DataSubjectResultBuilder:
                 "samples_validated": validation_result.samples_validated,
                 "all_succeeded": validation_result.all_succeeded,
                 "skipped_count": len(validation_result.skipped_samples),
+                # Pre-emitted so the key is always present once validation ran;
+                # DAGExecutor stamps the sidecar's artifact_id when removals
+                # produced an audit-trail sidecar.
+                "removed_findings_artifact_id": None,
             }
 
             # Map RemovedGroup to subject_categories_removed for output

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_distributed.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_distributed.py
@@ -249,10 +249,12 @@ class TestFinalise:
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
         assert len(result.content["findings"]) == len(prepare_result.state.all_findings)
+        # LLM never ran → no audit content
+        assert sidecars == []
 
     def test_no_findings_produces_empty_output(self) -> None:
         """Empty findings state → empty output, no validation_summary."""
@@ -262,10 +264,12 @@ class TestFinalise:
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert result.content["findings"] == []
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
+        # No findings → no removals → no audit content
+        assert sidecars == []
 
     def test_llm_result_filters_false_positives_and_marks_kept(self) -> None:
         """LLM TRUE_POSITIVE/FALSE_POSITIVE verdicts → filtering + marking."""
@@ -288,7 +292,7 @@ class TestFinalise:
             prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
         )
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert "validation_summary" in metadata
@@ -302,6 +306,8 @@ class TestFinalise:
                     finding["metadata"]["context"].get("data_subject_llm_validated")
                     is True
                 )
+        # All-TRUE_POSITIVE verdicts → no removals → no audit content
+        assert sidecars == []
 
     def test_missing_llm_result_treats_all_as_skipped_with_failure(self) -> None:
         """No LLM result (e.g. dispatcher error) → findings kept, all_succeeded=False.
@@ -318,12 +324,58 @@ class TestFinalise:
 
         finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert metadata["validation_summary"]["all_succeeded"] is False
         assert metadata["validation_summary"]["skipped_count"] > 0
         assert len(result.content["findings"]) == original_count
+        # BATCH_ERROR never reached the LLM → no removals → no audit content
+        assert sidecars == []
+
+    def test_sidecar_carries_serialised_finding_and_reason(self) -> None:
+        """FALSE_POSITIVE removals → one sidecar with identity fields and serialised entries.
+
+        Cascade-reason synthesis (``"Inferred — …"`` prefix) is exercised at
+        the orchestrator layer (Step 3); here we only need to confirm that
+        whatever ``reason`` the orchestrator attaches to a ``RemovedItem``
+        reaches the sidecar entry verbatim, and that the wrapper carries the
+        analyser identity for cross-artifact correlation.
+        """
+        analyser = _make_analyser()
+        message = _make_employee_customer_message()
+
+        prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
+        assert prepare_result.state.orchestrator_state is not None
+        sampled = prepare_result.state.orchestrator_state.strategy_findings
+
+        assert isinstance(prepare_result.requests[0], LLMRequest)
+        llm_request = cast(
+            LLMRequest[DataSubjectIndicatorModel], prepare_result.requests[0]
+        )
+        verdicts = {f.id: "FALSE_POSITIVE" for f in sampled}
+        dispatch_result = _build_llm_dispatch_result(llm_request, verdicts)
+
+        finalise_outcome = analyser.finalise(
+            prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        _result, sidecars = finalise_outcome
+        assert len(sidecars) == 1
+        sidecar = sidecars[0]
+        assert sidecar.schema == Schema("removed_findings", "1.0.0")
+        assert sidecar.content["analyser_name"] == "data_subject_analyser"
+        assert sidecar.content["run_id"] == RUN_ID
+        assert sidecar.content["ruleset"] == _UNUSED_RULESET_URI
+
+        removed = sidecar.content["removed_findings"]
+        assert len(removed) >= 1
+        sampled_ids = {f.id for f in sampled}
+        for entry in removed:
+            assert entry["original_finding"]["id"] in sampled_ids
+            # LLM-direct reasons preserve the verdict's reasoning verbatim.
+            # _build_llm_dispatch_result attaches "test reasoning" to every result.
+            assert entry["reason"] == "test reasoning"
 
 
 # =============================================================================

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_distributed.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_distributed.py
@@ -250,8 +250,9 @@ class TestFinalise:
         message = _make_employee_customer_message()
 
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
-        result = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
-
+        finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
         assert len(result.content["findings"]) == len(prepare_result.state.all_findings)
@@ -262,8 +263,9 @@ class TestFinalise:
         message = _make_no_pattern_message()
 
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
-        result = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
-
+        finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert result.content["findings"] == []
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
@@ -285,10 +287,11 @@ class TestFinalise:
         verdicts = {f.id: "TRUE_POSITIVE" for f in sampled}
         dispatch_result = _build_llm_dispatch_result(llm_request, verdicts)
 
-        result = analyser.finalise(
+        finalise_outcome = analyser.finalise(
             prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
         )
-
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert "validation_summary" in metadata
@@ -316,8 +319,9 @@ class TestFinalise:
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         original_count = len(prepare_result.state.all_findings)
 
-        result = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
-
+        finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert metadata["validation_summary"]["all_succeeded"] is False

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_distributed.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_distributed.py
@@ -11,15 +11,12 @@ Uses monkeypatched RulesetManager to decouple from production ruleset data.
 from typing import Any, cast
 
 import pytest
-from waivern_analysers_shared.llm_validation.models import (
-    LLMValidationResponseModel,
-    LLMValidationResultModel,
-)
 from waivern_analysers_shared.llm_validation.validation_orchestrator import (
     OrchestratorPrepareState,
 )
 from waivern_analysers_shared.types import LLMValidationConfig, PatternMatchingConfig
 from waivern_analysers_shared.utilities import RulesetManager
+from waivern_core import LLMValidationResponseModel, LLMValidationResultModel
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
 from waivern_llm.types import BatchingMode, LLMDispatchResult, LLMRequest

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_distributed.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_distributed.py
@@ -271,6 +271,35 @@ class TestFinalise:
         # No findings → no removals → no audit content
         assert sidecars == []
 
+    def test_validation_summary_pre_emits_removed_findings_artifact_id_as_none(
+        self,
+    ) -> None:
+        """When validation ran, ``validation_summary.removed_findings_artifact_id`` is None.
+
+        The analyser pre-emits ``None`` so the key is always present once
+        validation ran; the executor overwrites it with the sidecar's
+        artifact_id when removals produced an audit-trail sidecar.
+        """
+        analyser = _make_analyser()
+        message = _make_employee_customer_message()
+
+        prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
+        assert isinstance(prepare_result.requests[0], LLMRequest)
+        llm_request = cast(
+            LLMRequest[DataSubjectIndicatorModel], prepare_result.requests[0]
+        )
+        sampled = prepare_result.state.orchestrator_state.strategy_findings  # pyright: ignore[reportOptionalMemberAccess]
+        verdicts = {f.id: "TRUE_POSITIVE" for f in sampled}
+        dispatch_result = _build_llm_dispatch_result(llm_request, verdicts)
+
+        finalise_outcome = analyser.finalise(
+            prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
+        validation_summary = result.content["analysis_metadata"]["validation_summary"]
+        assert validation_summary["removed_findings_artifact_id"] is None
+
     def test_llm_result_filters_false_positives_and_marks_kept(self) -> None:
         """LLM TRUE_POSITIVE/FALSE_POSITIVE verdicts → filtering + marking."""
         analyser = _make_analyser()

--- a/libs/waivern-gdpr-data-collection-classifier/src/waivern_gdpr_data_collection_classifier/classifier.py
+++ b/libs/waivern-gdpr-data-collection-classifier/src/waivern_gdpr_data_collection_classifier/classifier.py
@@ -94,7 +94,9 @@ class GDPRDataCollectionClassifier(Classifier):
         return [Schema("gdpr_data_collection", "1.0.0")]
 
     @override
-    def process(self, inputs: list[Message], output_schema: Schema) -> Message:
+    def process(
+        self, inputs: list[Message], output_schema: Schema
+    ) -> tuple[Message, list[Message]]:
         """Process input findings and classify according to GDPR.
 
         Args:
@@ -102,7 +104,8 @@ class GDPRDataCollectionClassifier(Classifier):
             output_schema: The schema to use for the output message.
 
         Returns:
-            Message containing GDPR-classified data collection findings.
+            ``(primary, [])`` where ``primary`` is the GDPR-classified
+            data-collection findings message. No sidecars are emitted.
 
         Raises:
             ValueError: If inputs list is empty.
@@ -125,13 +128,13 @@ class GDPRDataCollectionClassifier(Classifier):
             classified = self._classify_finding(finding)
             classified_findings.append(classified)
 
-        # Build and return output message
-        return self._result_builder.build_output_message(
+        primary = self._result_builder.build_output_message(
             classified_findings,
             output_schema,
             self._ruleset.name,
             self._ruleset.version,
         )
+        return primary, []
 
     def _classify_finding(
         self, finding: dict[str, Any]

--- a/libs/waivern-gdpr-data-collection-classifier/tests/waivern_gdpr_data_collection_classifier/test_classifier.py
+++ b/libs/waivern-gdpr-data-collection-classifier/tests/waivern_gdpr_data_collection_classifier/test_classifier.py
@@ -136,7 +136,7 @@ class TestGDPRDataCollectionClassification:
         finding = make_indicator_finding("form_data", "http_post")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["gdpr_purpose_category"] == "context_dependent"
@@ -154,7 +154,7 @@ class TestGDPRDataCollectionClassification:
         finding = make_indicator_finding("cookies", "http_cookie")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["gdpr_purpose_category"] == "context_dependent"
@@ -169,7 +169,7 @@ class TestGDPRDataCollectionClassification:
         finding = make_indicator_finding("database_query", "mysql")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["gdpr_purpose_category"] == "context_dependent"
@@ -185,7 +185,7 @@ class TestGDPRDataCollectionClassification:
         finding = make_indicator_finding("unknown_type_xyz", "unknown_source")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["gdpr_purpose_category"] == "unclassified"
@@ -200,7 +200,7 @@ class TestGDPRDataCollectionClassification:
         finding = make_indicator_finding("form_data", "http_post")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["collection_type"] == "form_data"
@@ -229,7 +229,7 @@ class TestSummaryGeneration:
         ]
         input_msg = make_input_message(findings)
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         summary = result.content["summary"]
 
         assert summary["total_findings"] == 3
@@ -247,7 +247,7 @@ class TestSummaryGeneration:
         ]
         input_msg = make_input_message(findings)
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         summary = result.content["summary"]
 
         assert summary["sensitive_purposes_count"] == 0
@@ -264,7 +264,7 @@ class TestSummaryGeneration:
         ]
         input_msg = make_input_message(findings)
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         summary = result.content["summary"]
 
         assert summary["dpia_required_count"] == 0
@@ -281,7 +281,7 @@ class TestSummaryGeneration:
         ]
         input_msg = make_input_message(findings)
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         summary = result.content["summary"]
 
         assert summary["requires_review_count"] == 2
@@ -313,7 +313,7 @@ class TestEdgeCases:
         msg1 = make_input_message([make_indicator_finding("form_data", "http_post")])
         msg2 = make_input_message([make_indicator_finding("cookies", "http_cookie")])
 
-        result = classifier.process([msg1, msg2], output_schema)
+        result, _ = classifier.process([msg1, msg2], output_schema)
 
         assert result.content["summary"]["total_findings"] == 2
 
@@ -332,7 +332,7 @@ class TestEdgeCases:
         }
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         # Should default to "unknown" source when metadata is missing

--- a/libs/waivern-gdpr-data-collection-classifier/tests/waivern_gdpr_data_collection_classifier/test_pipeline_integration.py
+++ b/libs/waivern-gdpr-data-collection-classifier/tests/waivern_gdpr_data_collection_classifier/test_pipeline_integration.py
@@ -97,7 +97,7 @@ class TestAnalyserToClassifierPipeline:
         with mocked data wouldn't reveal.
         """
         # Run real analyser
-        indicator_output = analyser.process(
+        indicator_output, _ = analyser.process(
             [source_code_with_data_collection],
             Schema("data_collection_indicator", "1.0.0"),
         )
@@ -107,7 +107,7 @@ class TestAnalyserToClassifierPipeline:
         assert len(indicator_output.content.get("findings", [])) > 0
 
         # Run real classifier on analyser output
-        gdpr_output = classifier.process(
+        gdpr_output, _ = classifier.process(
             [indicator_output],
             Schema("gdpr_data_collection", "1.0.0"),
         )

--- a/libs/waivern-gdpr-data-subject-classifier/src/waivern_gdpr_data_subject_classifier/classifier.py
+++ b/libs/waivern-gdpr-data-subject-classifier/src/waivern_gdpr_data_subject_classifier/classifier.py
@@ -212,7 +212,7 @@ class GDPRDataSubjectClassifier(Classifier):
         state: GDPRDataSubjectPrepareState,
         results: Sequence[DispatchResult],
         output_schema: Schema,
-    ) -> Message:
+    ) -> tuple[Message, list[Message]]:
         """Produce output from classified findings and dispatch results.
 
         Paths:
@@ -225,13 +225,14 @@ class GDPRDataSubjectClassifier(Classifier):
         llm_result = self._extract_llm_result(results)
         if not state.llm_enabled or llm_result is None or not llm_result.responses:
             enriched = self._apply_risk_modifiers_via_regex(state.classified_findings)
-            return self._result_builder.build_output_message(
+            primary = self._result_builder.build_output_message(
                 enriched,
                 output_schema,
                 self._ruleset.name,
                 self._ruleset.version,
                 validation_result=None,
             )
+            return primary, []
 
         validation_result = self._aggregate_llm_responses(
             state.classified_findings, llm_result
@@ -239,13 +240,14 @@ class GDPRDataSubjectClassifier(Classifier):
         enriched = self._apply_category_modifiers(
             state.classified_findings, validation_result
         )
-        return self._result_builder.build_output_message(
+        primary = self._result_builder.build_output_message(
             enriched,
             output_schema,
             self._ruleset.name,
             self._ruleset.version,
             validation_result=validation_result,
         )
+        return primary, []
 
     def deserialise_prepare_result(
         self, raw: dict[str, Any]

--- a/libs/waivern-gdpr-data-subject-classifier/tests/waivern_gdpr_data_subject_classifier/test_distributed.py
+++ b/libs/waivern-gdpr-data-subject-classifier/tests/waivern_gdpr_data_subject_classifier/test_distributed.py
@@ -183,7 +183,9 @@ class TestFinalise:
         prepare_result = classifier.prepare(
             inputs=[message], output_schema=OUTPUT_SCHEMA
         )
-        result = classifier.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        finalise_outcome = classifier.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         metadata = result.content["analysis_metadata"]
         assert metadata["validation_summary"]["method_used"] == "regex"
@@ -208,7 +210,9 @@ class TestFinalise:
             inputs=[message], output_schema=OUTPUT_SCHEMA
         )
         assert prepare_result.state.llm_enabled is True
-        result = classifier.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        finalise_outcome = classifier.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         metadata = result.content["analysis_metadata"]
         assert metadata["validation_summary"]["method_used"] == "regex"
@@ -251,9 +255,11 @@ class TestFinalise:
             finding_modifiers={classified[0].id: ["minor"]},
         )
 
-        result = classifier.finalise(
+        finalise_outcome = classifier.finalise(
             prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
         )
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         metadata = result.content["analysis_metadata"]
         assert metadata["validation_summary"]["method_used"] == "llm"
@@ -286,9 +292,11 @@ class TestFinalise:
             skipped=[],
         )
 
-        result = classifier.finalise(
+        finalise_outcome = classifier.finalise(
             prepare_result.state, [empty_dispatch_result], OUTPUT_SCHEMA
         )
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         metadata = result.content["analysis_metadata"]
         assert metadata["validation_summary"]["method_used"] == "regex"
@@ -307,7 +315,9 @@ class TestFinalise:
         prepare_result = classifier.prepare(
             inputs=[message], output_schema=OUTPUT_SCHEMA
         )
-        result = classifier.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        finalise_outcome = classifier.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         assert result.content["findings"] == []
         assert result.content["summary"]["total_findings"] == 0

--- a/libs/waivern-gdpr-personal-data-classifier/src/waivern_gdpr_personal_data_classifier/classifier.py
+++ b/libs/waivern-gdpr-personal-data-classifier/src/waivern_gdpr_personal_data_classifier/classifier.py
@@ -89,7 +89,9 @@ class GDPRPersonalDataClassifier(Classifier):
         return [Schema("gdpr_personal_data", "1.0.0")]
 
     @override
-    def process(self, inputs: list[Message], output_schema: Schema) -> Message:
+    def process(
+        self, inputs: list[Message], output_schema: Schema
+    ) -> tuple[Message, list[Message]]:
         """Process input findings and classify according to GDPR."""
         if not inputs:
             raise ValueError(
@@ -108,13 +110,13 @@ class GDPRPersonalDataClassifier(Classifier):
             classified = self._classify_finding(finding)
             classified_findings.append(classified)
 
-        # Build and return output message
-        return self._result_builder.build_output_message(
+        primary = self._result_builder.build_output_message(
             classified_findings,
             output_schema,
             self._ruleset.name,
             self._ruleset.version,
         )
+        return primary, []
 
     def _classify_finding(
         self, finding: dict[str, Any]

--- a/libs/waivern-gdpr-personal-data-classifier/tests/waivern_gdpr_personal_data_classifier/test_classifier.py
+++ b/libs/waivern-gdpr-personal-data-classifier/tests/waivern_gdpr_personal_data_classifier/test_classifier.py
@@ -74,7 +74,7 @@ class TestGDPRPersonalDataClassifier:
         classifier = GDPRPersonalDataClassifier()
 
         # Act
-        result = classifier.process([input_message], output_schema)
+        result, _ = classifier.process([input_message], output_schema)
 
         assert (
             result.content["findings"][0]["privacy_category"] == "identification_data"
@@ -106,7 +106,7 @@ class TestGDPRPersonalDataClassifier:
         )
         classifier = GDPRPersonalDataClassifier()
 
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_message], Schema("gdpr_personal_data", "1.0.0")
         )
 
@@ -138,7 +138,7 @@ class TestGDPRPersonalDataClassifier:
         )
         classifier = GDPRPersonalDataClassifier()
 
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_message], Schema("gdpr_personal_data", "1.0.0")
         )
 
@@ -177,7 +177,7 @@ class TestGDPRPersonalDataClassifier:
         )
         classifier = GDPRPersonalDataClassifier()
 
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_message], Schema("gdpr_personal_data", "1.0.0")
         )
 
@@ -210,7 +210,7 @@ class TestGDPRPersonalDataClassifier:
         )
         classifier = GDPRPersonalDataClassifier()
 
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_message], Schema("gdpr_personal_data", "1.0.0")
         )
 
@@ -250,7 +250,7 @@ class TestGDPRPersonalDataClassifier:
         )
         classifier = GDPRPersonalDataClassifier()
 
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_message], Schema("gdpr_personal_data", "1.0.0")
         )
 
@@ -289,7 +289,7 @@ class TestGDPRPersonalDataClassifier:
         )
         classifier = GDPRPersonalDataClassifier()
 
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_message], Schema("gdpr_personal_data", "1.0.0")
         )
 
@@ -344,7 +344,7 @@ class TestGDPRPersonalDataClassifierErrorHandling:
         classifier = GDPRPersonalDataClassifier()
 
         # Should not crash, provides fallback metadata
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_message], Schema("gdpr_personal_data", "1.0.0")
         )
 
@@ -371,7 +371,7 @@ class TestGDPRPersonalDataClassifierErrorHandling:
         )
         classifier = GDPRPersonalDataClassifier()
 
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_message], Schema("gdpr_personal_data", "1.0.0")
         )
 
@@ -434,7 +434,7 @@ class TestFanInSupport:
 
         classifier = GDPRPersonalDataClassifier()
 
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_1, input_2], Schema("gdpr_personal_data", "1.0.0")
         )
 
@@ -491,7 +491,7 @@ class TestFanInSupport:
 
         classifier = GDPRPersonalDataClassifier()
 
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_1, input_2], Schema("gdpr_personal_data", "1.0.0")
         )
 
@@ -554,7 +554,7 @@ class TestFanInSupport:
 
         classifier = GDPRPersonalDataClassifier()
 
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_1, input_2], Schema("gdpr_personal_data", "1.0.0")
         )
 

--- a/libs/waivern-gdpr-personal-data-classifier/tests/waivern_gdpr_personal_data_classifier/test_factory.py
+++ b/libs/waivern-gdpr-personal-data-classifier/tests/waivern_gdpr_personal_data_classifier/test_factory.py
@@ -55,7 +55,7 @@ class TestGDPRPersonalDataClassifierFactory:
             schema=Schema("personal_data_indicator", "1.0.0"),
         )
 
-        result = classifier.process(
+        result, _ = classifier.process(
             [input_message], Schema("gdpr_personal_data", "1.0.0")
         )
 

--- a/libs/waivern-gdpr-processing-purpose-classifier/src/waivern_gdpr_processing_purpose_classifier/classifier.py
+++ b/libs/waivern-gdpr-processing-purpose-classifier/src/waivern_gdpr_processing_purpose_classifier/classifier.py
@@ -94,7 +94,9 @@ class GDPRProcessingPurposeClassifier(Classifier):
         return [Schema("gdpr_processing_purpose", "1.0.0")]
 
     @override
-    def process(self, inputs: list[Message], output_schema: Schema) -> Message:
+    def process(
+        self, inputs: list[Message], output_schema: Schema
+    ) -> tuple[Message, list[Message]]:
         """Process input findings and classify according to GDPR.
 
         Args:
@@ -102,7 +104,8 @@ class GDPRProcessingPurposeClassifier(Classifier):
             output_schema: The schema to use for the output message.
 
         Returns:
-            Message containing GDPR-classified processing purpose findings.
+            ``(primary, [])`` where ``primary`` is the GDPR-classified
+            processing-purpose findings message. No sidecars are emitted.
 
         Raises:
             ValueError: If inputs list is empty.
@@ -125,13 +128,13 @@ class GDPRProcessingPurposeClassifier(Classifier):
             classified = self._classify_finding(finding)
             classified_findings.append(classified)
 
-        # Build and return output message
-        return self._result_builder.build_output_message(
+        primary = self._result_builder.build_output_message(
             classified_findings,
             output_schema,
             self._ruleset.name,
             self._ruleset.version,
         )
+        return primary, []
 
     def _classify_finding(
         self, finding: dict[str, Any]

--- a/libs/waivern-gdpr-processing-purpose-classifier/tests/waivern_gdpr_processing_purpose_classifier/test_classifier.py
+++ b/libs/waivern-gdpr-processing-purpose-classifier/tests/waivern_gdpr_processing_purpose_classifier/test_classifier.py
@@ -137,7 +137,7 @@ class TestGDPRProcessingPurposeClassification:
         finding = make_indicator_finding("payment_processing")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["purpose_category"] == "operational"
@@ -156,7 +156,7 @@ class TestGDPRProcessingPurposeClassification:
         finding = make_indicator_finding("behavioural_analytics")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["purpose_category"] == "analytics"
@@ -173,7 +173,7 @@ class TestGDPRProcessingPurposeClassification:
         finding = make_indicator_finding("ai_model_training")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["purpose_category"] == "ai_and_ml"
@@ -189,7 +189,7 @@ class TestGDPRProcessingPurposeClassification:
         finding = make_indicator_finding("fraud_detection")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["purpose_category"] == "security"
@@ -205,7 +205,7 @@ class TestGDPRProcessingPurposeClassification:
         finding = make_indicator_finding("targeted_advertising")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["purpose_category"] == "marketing_and_advertising"
@@ -220,7 +220,7 @@ class TestGDPRProcessingPurposeClassification:
         finding = make_indicator_finding("unknown_purpose_xyz")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["purpose_category"] == "unclassified"
@@ -235,7 +235,7 @@ class TestGDPRProcessingPurposeClassification:
         finding = make_indicator_finding("behavioural_analytics")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["processing_purpose"] == "behavioural_analytics"
@@ -262,7 +262,7 @@ class TestSummaryGeneration:
         ]
         input_msg = make_input_message(findings)
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         summary = result.content["summary"]
 
         assert summary["total_findings"] == 3
@@ -283,7 +283,7 @@ class TestSummaryGeneration:
         ]
         input_msg = make_input_message(findings)
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         summary = result.content["summary"]
 
         assert summary["sensitive_purposes_count"] == 2
@@ -301,7 +301,7 @@ class TestSummaryGeneration:
         ]
         input_msg = make_input_message(findings)
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         summary = result.content["summary"]
 
         assert summary["dpia_required_count"] == 1
@@ -333,7 +333,7 @@ class TestEdgeCases:
         msg1 = make_input_message([make_indicator_finding("behavioural_analytics")])
         msg2 = make_input_message([make_indicator_finding("fraud_detection")])
 
-        result = classifier.process([msg1, msg2], output_schema)
+        result, _ = classifier.process([msg1, msg2], output_schema)
 
         assert result.content["summary"]["total_findings"] == 2
 
@@ -351,7 +351,7 @@ class TestEdgeCases:
         }
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         # Should default to "unknown" source when metadata is missing

--- a/libs/waivern-gdpr-service-integration-classifier/src/waivern_gdpr_service_integration_classifier/classifier.py
+++ b/libs/waivern-gdpr-service-integration-classifier/src/waivern_gdpr_service_integration_classifier/classifier.py
@@ -94,7 +94,9 @@ class GDPRServiceIntegrationClassifier(Classifier):
         return [Schema("gdpr_service_integration", "1.0.0")]
 
     @override
-    def process(self, inputs: list[Message], output_schema: Schema) -> Message:
+    def process(
+        self, inputs: list[Message], output_schema: Schema
+    ) -> tuple[Message, list[Message]]:
         """Process input findings and classify according to GDPR.
 
         Args:
@@ -102,7 +104,8 @@ class GDPRServiceIntegrationClassifier(Classifier):
             output_schema: The schema to use for the output message.
 
         Returns:
-            Message containing GDPR-classified service integration findings.
+            ``(primary, [])`` where ``primary`` is the GDPR-classified
+            service-integration findings message. No sidecars are emitted.
 
         Raises:
             ValueError: If inputs list is empty.
@@ -125,13 +128,13 @@ class GDPRServiceIntegrationClassifier(Classifier):
             classified = self._classify_finding(finding)
             classified_findings.append(classified)
 
-        # Build and return output message
-        return self._result_builder.build_output_message(
+        primary = self._result_builder.build_output_message(
             classified_findings,
             output_schema,
             self._ruleset.name,
             self._ruleset.version,
         )
+        return primary, []
 
     def _classify_finding(
         self, finding: dict[str, Any]

--- a/libs/waivern-gdpr-service-integration-classifier/tests/waivern_gdpr_service_integration_classifier/test_classifier.py
+++ b/libs/waivern-gdpr-service-integration-classifier/tests/waivern_gdpr_service_integration_classifier/test_classifier.py
@@ -141,7 +141,7 @@ class TestGDPRServiceIntegrationClassification:
         finding = make_indicator_finding("cloud_infrastructure", "operational")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["gdpr_purpose_category"] == "operational"
@@ -160,7 +160,7 @@ class TestGDPRServiceIntegrationClassification:
         finding = make_indicator_finding("user_analytics", "analytics")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["gdpr_purpose_category"] == "analytics"
@@ -177,7 +177,7 @@ class TestGDPRServiceIntegrationClassification:
         finding = make_indicator_finding("ai_ml_services", "data_processing")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["gdpr_purpose_category"] == "ai_and_ml"
@@ -193,7 +193,7 @@ class TestGDPRServiceIntegrationClassification:
         finding = make_indicator_finding("healthcare_integrations", "operational")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["gdpr_purpose_category"] == "healthcare"
@@ -210,7 +210,7 @@ class TestGDPRServiceIntegrationClassification:
         finding = make_indicator_finding("communication", "operational")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["gdpr_purpose_category"] == "context_dependent"
@@ -225,7 +225,7 @@ class TestGDPRServiceIntegrationClassification:
         finding = make_indicator_finding("unknown_service_xyz", "operational")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["gdpr_purpose_category"] == "unclassified"
@@ -244,7 +244,7 @@ class TestGDPRServiceIntegrationClassification:
         finding = make_indicator_finding("communication", "operational")
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         assert classified["service_category"] == "communication"
@@ -275,7 +275,7 @@ class TestSummaryGeneration:
         ]
         input_msg = make_input_message(findings)
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         summary = result.content["summary"]
 
         assert summary["total_findings"] == 3
@@ -298,7 +298,7 @@ class TestSummaryGeneration:
         ]
         input_msg = make_input_message(findings)
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         summary = result.content["summary"]
 
         assert summary["sensitive_purposes_count"] == 2
@@ -318,7 +318,7 @@ class TestSummaryGeneration:
         ]
         input_msg = make_input_message(findings)
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         summary = result.content["summary"]
 
         assert summary["dpia_required_count"] == 1
@@ -337,7 +337,7 @@ class TestSummaryGeneration:
         ]
         input_msg = make_input_message(findings)
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         summary = result.content["summary"]
 
         assert summary["requires_review_count"] == 1
@@ -373,7 +373,7 @@ class TestEdgeCases:
             [make_indicator_finding("cloud_infrastructure", "operational")]
         )
 
-        result = classifier.process([msg1, msg2], output_schema)
+        result, _ = classifier.process([msg1, msg2], output_schema)
 
         assert result.content["summary"]["total_findings"] == 2
 
@@ -392,7 +392,7 @@ class TestEdgeCases:
         }
         input_msg = make_input_message([finding])
 
-        result = classifier.process([input_msg], output_schema)
+        result, _ = classifier.process([input_msg], output_schema)
         classified = result.content["findings"][0]
 
         # Should default to "unknown" source when metadata is missing

--- a/libs/waivern-gdpr-service-integration-classifier/tests/waivern_gdpr_service_integration_classifier/test_pipeline_integration.py
+++ b/libs/waivern-gdpr-service-integration-classifier/tests/waivern_gdpr_service_integration_classifier/test_pipeline_integration.py
@@ -97,7 +97,7 @@ class TestAnalyserToClassifierPipeline:
         with mocked data wouldn't reveal.
         """
         # Run real analyser
-        indicator_output = analyser.process(
+        indicator_output, _ = analyser.process(
             [source_code_with_service_integrations],
             Schema("service_integration_indicator", "1.0.0"),
         )
@@ -107,7 +107,7 @@ class TestAnalyserToClassifierPipeline:
         assert len(indicator_output.content.get("findings", [])) > 0
 
         # Run real classifier on analyser output
-        gdpr_output = classifier.process(
+        gdpr_output, _ = classifier.process(
             [indicator_output],
             Schema("gdpr_service_integration", "1.0.0"),
         )

--- a/libs/waivern-iso27001-control-assessor/src/waivern_iso27001_control_assessor/analyser.py
+++ b/libs/waivern-iso27001-control-assessor/src/waivern_iso27001_control_assessor/analyser.py
@@ -191,7 +191,7 @@ class ISO27001Assessor(Analyser):
         state: ISO27001PrepareState,
         results: Sequence[DispatchResult],
         output_schema: Schema,
-    ) -> Message:
+    ) -> tuple[Message, list[Message]]:
         """Produce assessment verdict from state and dispatch results.
 
         1. Short-circuit paths (insufficient/requires-attestation): emit NOT_ASSESSED.
@@ -202,7 +202,7 @@ class ISO27001Assessor(Analyser):
 
         match state.evidence_status:
             case EvidenceStatus.INSUFFICIENT_EVIDENCE:
-                return self._result_builder.build_output_message(
+                primary = self._result_builder.build_output_message(
                     rule,
                     verdict=AssessmentVerdict(
                         status=ControlStatus.NOT_ASSESSED,
@@ -218,7 +218,7 @@ class ISO27001Assessor(Analyser):
                     output_schema=output_schema,
                 )
             case EvidenceStatus.REQUIRES_ATTESTATION:
-                return self._result_builder.build_output_message(
+                primary = self._result_builder.build_output_message(
                     rule,
                     verdict=AssessmentVerdict(
                         status=ControlStatus.NOT_ASSESSED,
@@ -234,7 +234,9 @@ class ISO27001Assessor(Analyser):
                     output_schema=output_schema,
                 )
             case EvidenceStatus.AUTOMATED:
-                return self._finalise_llm_result(rule, results, output_schema)
+                primary = self._finalise_llm_result(rule, results, output_schema)
+
+        return primary, []
 
     def _finalise_llm_result(
         self,

--- a/libs/waivern-iso27001-control-assessor/tests/waivern_iso27001_control_assessor/test_distributed.py
+++ b/libs/waivern-iso27001-control-assessor/tests/waivern_iso27001_control_assessor/test_distributed.py
@@ -111,7 +111,9 @@ class TestFinalise:
         prepare_result = assessor.prepare(
             inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA
         )
-        result = assessor.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        finalise_outcome = assessor.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         output = parse_output(result)
         finding = output.findings[0]
@@ -133,7 +135,9 @@ class TestFinalise:
         prepare_result = assessor.prepare(
             inputs=[evidence_msg], output_schema=OUTPUT_SCHEMA
         )
-        result = assessor.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        finalise_outcome = assessor.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         output = parse_output(result)
         finding = output.findings[0]
@@ -165,7 +169,11 @@ class TestFinalise:
             skipped=[],
         )
 
-        result = assessor.finalise(prepare_result.state, [llm_result], OUTPUT_SCHEMA)
+        finalise_outcome = assessor.finalise(
+            prepare_result.state, [llm_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         output = parse_output(result)
         finding = output.findings[0]
@@ -202,7 +210,11 @@ class TestFinalise:
             skipped=[],
         )
 
-        result = assessor.finalise(prepare_result.state, [llm_result], OUTPUT_SCHEMA)
+        finalise_outcome = assessor.finalise(
+            prepare_result.state, [llm_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         output = parse_output(result)
         finding = output.findings[0]
@@ -229,7 +241,11 @@ class TestFinalise:
             skipped=[],
         )
 
-        result = assessor.finalise(prepare_result.state, [llm_result], OUTPUT_SCHEMA)
+        finalise_outcome = assessor.finalise(
+            prepare_result.state, [llm_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         output = parse_output(result)
         finding = output.findings[0]

--- a/libs/waivern-orchestration/src/waivern_orchestration/executor.py
+++ b/libs/waivern-orchestration/src/waivern_orchestration/executor.py
@@ -98,6 +98,8 @@ from waivern_orchestration.utils import get_origin_from_artifact_id
 
 logger = logging.getLogger(__name__)
 
+_REMOVED_FINDINGS_SCHEMA_NAME = "removed_findings"
+
 
 @dataclass
 class _ExecutionContext:
@@ -117,7 +119,8 @@ class _DistributedEntry:
 
     Bundles the processor instance, inputs, and schema so they survive
     across phases. ``prepare_result`` is populated after Phase 1 (or
-    loaded from store on resume).
+    loaded from store on resume); ``finalise_output`` is populated after
+    Phase 3 with the ``(primary, sidecars)`` tuple ready to persist.
 
     """
 
@@ -126,7 +129,25 @@ class _DistributedEntry:
     inputs: list[Message]
     output_schema: Schema
     prepare_result: PrepareResult[Any] | None = None
+    finalise_output: tuple[Message, list[Message]] | None = None
     start_time: float = 0.0
+
+
+@dataclass
+class _ArtifactSaveContext:
+    """Identity bundle applied to a primary and its sidecars during persistence.
+
+    Every Message produced by a single artifact execution (primary + zero
+    or more sidecars) is enriched with the same ``run_id``, ``source``, and
+    ``execution_context`` before saving. This bundle holds that shared
+    identity so it can be passed as a single argument instead of five.
+    """
+
+    artifact_id: str
+    run_id: str
+    source: str
+    execution_context: ExecutionContext
+    store: ArtifactStore
 
 
 class DAGExecutor:
@@ -681,10 +702,9 @@ class DAGExecutor:
                     continue
 
                 if isinstance(result, tuple):
-                    primary, _sidecars = result
+                    entry.finalise_output = result
                     await self._save_distributed_artifact(
                         entry,
-                        primary,
                         results_by_artifact[entry.artifact_id],
                         plan,
                         ctx,
@@ -716,22 +736,47 @@ class DAGExecutor:
     async def _save_distributed_artifact(
         self,
         entry: _DistributedEntry,
-        message: Message,
         results: Sequence[DispatchResult],
         plan: ExecutionPlan,
         ctx: _ExecutionContext,
     ) -> None:
-        """Save a completed distributed artifact with metadata.
+        """Persist a completed distributed artifact and its sidecars.
 
-        Follows the same metadata pattern as ``_produce``: populates
-        ``run_id``, ``source``, and ``extensions`` with ``ExecutionContext``.
-        Calls ``enrich_execution_context`` on each dispatch result to
-        propagate dispatch-specific metadata (e.g., ``model_name``).
+        Reads the ``(primary, sidecars)`` tuple from ``entry.finalise_output``
+        (populated by the caller after Phase 3), builds the persistence
+        identity, persists everything via ``_persist_with_sidecars``, then
+        cleans up: deletes the persisted PrepareResult, marks the artifact
+        completed, and saves state.
+        """
+        if entry.finalise_output is None:
+            msg = f"Cannot save '{entry.artifact_id}': no finalise_output"
+            raise RuntimeError(msg)
+        primary, sidecars = entry.finalise_output
 
+        save_ctx = self._build_save_ctx_for_distributed(entry, results, plan, ctx)
+        await self._persist_with_sidecars(primary, sidecars, save_ctx)
+
+        await ctx.store.delete_prepared(ctx.run_id, entry.artifact_id)
+        ctx.state.mark_completed(entry.artifact_id)
+        await ctx.state.save(ctx.store)
+
+    def _build_save_ctx_for_distributed(
+        self,
+        entry: _DistributedEntry,
+        results: Sequence[DispatchResult],
+        plan: ExecutionPlan,
+        ctx: _ExecutionContext,
+    ) -> _ArtifactSaveContext:
+        """Build the persistence identity for a completed distributed artifact.
+
+        Computes ``source`` from the artifact definition, builds an
+        ``ExecutionContext`` reflecting duration/origin/alias, then lets
+        each dispatch result enrich it (e.g., to propagate ``model_name``).
         """
         definition = plan.runbook.artifacts[entry.artifact_id]
         origin = get_origin_from_artifact_id(entry.artifact_id)
         alias = plan.reversed_aliases.get(entry.artifact_id)
+        source = self._determine_source(definition)
 
         duration = time.monotonic() - entry.start_time
         execution_context = ExecutionContext(
@@ -743,16 +788,84 @@ class DAGExecutor:
         for result in results:
             execution_context = result.enrich_execution_context(execution_context)
 
-        message = replace(
-            message,
+        return _ArtifactSaveContext(
+            artifact_id=entry.artifact_id,
             run_id=ctx.run_id,
-            source=self._determine_source(definition),
-            extensions=MessageExtensions(execution=execution_context),
+            source=source,
+            execution_context=execution_context,
+            store=ctx.store,
         )
-        await ctx.store.save_artifact(ctx.run_id, entry.artifact_id, message)
-        await ctx.store.delete_prepared(ctx.run_id, entry.artifact_id)
-        ctx.state.mark_completed(entry.artifact_id)
-        await ctx.state.save(ctx.store)
+
+    async def _persist_with_sidecars(
+        self,
+        primary: Message,
+        sidecars: list[Message],
+        save_ctx: _ArtifactSaveContext,
+    ) -> Message:
+        """Persist sidecars, stamp the back-reference, then persist the primary.
+
+        Sidecars are persisted **before** the primary so a crash mid-write
+        leaves the artifact in a re-runnable state — on resume the artifact
+        re-runs in full, idempotently overwriting any partial sidecar.
+        Every Message is enriched with the same ``run_id``, ``source``, and
+        ``ExecutionContext`` from ``save_ctx``. Returns the enriched primary
+        so callers needing the persisted form (e.g., ``_produce`` for its
+        ``is_success`` return) don't re-enrich.
+        """
+        for sidecar in sidecars:
+            sidecar_artifact_id = f"{save_ctx.artifact_id}.{sidecar.schema.name}"
+            enriched_sidecar = self._enrich_for_persistence(sidecar, save_ctx)
+            await save_ctx.store.save_artifact(
+                save_ctx.run_id, sidecar_artifact_id, enriched_sidecar
+            )
+
+        self._stamp_back_reference(primary, sidecars, save_ctx.artifact_id)
+
+        enriched_primary = self._enrich_for_persistence(primary, save_ctx)
+        await save_ctx.store.save_artifact(
+            save_ctx.run_id, save_ctx.artifact_id, enriched_primary
+        )
+        return enriched_primary
+
+    @staticmethod
+    def _enrich_for_persistence(
+        message: Message, save_ctx: _ArtifactSaveContext
+    ) -> Message:
+        """Stamp identity (run_id, source, ExecutionContext) onto a Message."""
+        return replace(
+            message,
+            run_id=save_ctx.run_id,
+            source=save_ctx.source,
+            extensions=MessageExtensions(execution=save_ctx.execution_context),
+        )
+
+    def _stamp_back_reference(
+        self,
+        primary: Message,
+        sidecars: list[Message],
+        primary_artifact_id: str,
+    ) -> None:
+        """Stamp the audit-trail sidecar's artifact_id into the primary.
+
+        Mutates ``primary.content["analysis_metadata"]["validation_summary"]``
+        in place when a ``removed_findings`` sidecar is present. No-op when
+        no such sidecar exists, or when the primary lacks the expected
+        nested structure (e.g., a raw passthrough primary). At most one
+        ``removed_findings`` sidecar per primary is expected.
+        """
+        for sidecar in sidecars:
+            if sidecar.schema.name != _REMOVED_FINDINGS_SCHEMA_NAME:
+                continue
+            metadata: object = primary.content.get("analysis_metadata")
+            if not isinstance(metadata, dict):
+                return
+            summary: object = cast("dict[str, Any]", metadata).get("validation_summary")
+            if not isinstance(summary, dict):
+                return
+            cast("dict[str, Any]", summary)["removed_findings_artifact_id"] = (
+                f"{primary_artifact_id}.{sidecar.schema.name}"
+            )
+            return
 
     async def _dispatch_all(
         self,
@@ -974,6 +1087,7 @@ class DAGExecutor:
 
         async with ctx.semaphore:
             try:
+                sidecars: list[Message] = []
                 match definition:
                     case ArtifactDefinition(reuse=ReuseConfig() as reuse):
                         message = await self._reuse_from_previous_run(
@@ -984,29 +1098,27 @@ class DAGExecutor:
                             source, output_schema, ctx.thread_pool
                         )
                     case _:
-                        message = await self._process_from_inputs(
+                        message, sidecars = await self._process_from_inputs(
                             definition, output_schema, ctx
                         )
 
                 # Determine source component type
                 source = self._determine_source(definition)
                 duration = time.monotonic() - start_time
-
-                # Add all metadata to the message before saving
-                message = replace(
-                    message,
+                save_ctx = _ArtifactSaveContext(
+                    artifact_id=artifact_id,
                     run_id=ctx.run_id,
                     source=source,
-                    extensions=MessageExtensions(
-                        execution=ExecutionContext(
-                            status="success",
-                            duration_seconds=duration,
-                            origin=origin,
-                            alias=alias,
-                        )
+                    execution_context=ExecutionContext(
+                        status="success",
+                        duration_seconds=duration,
+                        origin=origin,
+                        alias=alias,
                     ),
+                    store=ctx.store,
                 )
-                await ctx.store.save_artifact(ctx.run_id, artifact_id, message)
+
+                message = await self._persist_with_sidecars(message, sidecars, save_ctx)
 
                 logger.debug(
                     "Artifact %s completed successfully (%.2fs)", artifact_id, duration
@@ -1091,7 +1203,7 @@ class DAGExecutor:
         inputs: list[Message],
         output_schema: Schema,
         thread_pool: ThreadPoolExecutor,
-    ) -> Message:
+    ) -> tuple[Message, list[Message]]:
         """Run a processor in the thread pool.
 
         Args:
@@ -1101,7 +1213,7 @@ class DAGExecutor:
             thread_pool: ThreadPoolExecutor for sync->async bridging.
 
         Returns:
-            Processed message from the processor.
+            ``(primary, sidecars)`` tuple from the processor.
 
         Raises:
             KeyError: If processor type not found in registry.
@@ -1109,10 +1221,9 @@ class DAGExecutor:
         """
         factory = self._registry.processor_factories[process_config.type]
 
-        def sync_process() -> Message:
+        def sync_process() -> tuple[Message, list[Message]]:
             processor = factory.create(process_config.properties)
-            primary, _sidecars = processor.process(inputs, output_schema)
-            return primary
+            return processor.process(inputs, output_schema)
 
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(thread_pool, sync_process)
@@ -1122,7 +1233,7 @@ class DAGExecutor:
         definition: ArtifactDefinition,
         output_schema: Schema,
         ctx: _ExecutionContext,
-    ) -> Message:
+    ) -> tuple[Message, list[Message]]:
         """Produce a derived artifact from its inputs.
 
         Args:
@@ -1131,7 +1242,7 @@ class DAGExecutor:
             ctx: The execution context containing store, run_id, and thread pool.
 
         Returns:
-            The produced message.
+            ``(primary, sidecars)`` — passthrough produces an empty sidecars list.
 
         """
         input_messages = await self._load_inputs(definition, ctx)
@@ -1146,7 +1257,7 @@ class DAGExecutor:
 
         # Passthrough: use first input (or merge for fan-in)
         if len(input_messages) == 1:
-            return input_messages[0]
+            return input_messages[0], []
 
         # Fan-in: merge messages - deferred to Phase 2
         raise NotImplementedError("Fan-in message merge not yet implemented")

--- a/libs/waivern-orchestration/src/waivern_orchestration/executor.py
+++ b/libs/waivern-orchestration/src/waivern_orchestration/executor.py
@@ -591,7 +591,7 @@ class DAGExecutor:
         entry: _DistributedEntry,
         results: Sequence[DispatchResult],
         ctx: _ExecutionContext,
-    ) -> Message | PrepareResult[Any]:
+    ) -> tuple[Message, list[Message]] | PrepareResult[Any]:
         """Run finalise() in the thread pool, governed by the semaphore.
 
         Follows the same bridge pattern as ``_run_prepare``.
@@ -628,11 +628,12 @@ class DAGExecutor:
         """Orchestrate Phase 2–3 with multi-round loop for distributed entries.
 
         Drives the dispatch → finalise cycle until all entries produce a
-        ``Message`` or max rounds is exceeded:
+        ``(primary, sidecars)`` tuple or max rounds is exceeded:
         1. Filter out entries already marked pending by dispatch
         2. Dispatch all entries with requests (Phase 2)
         3. Finalise each entry (Phase 3)
-        4. Message → save artifact, mark completed, clean up, notify sorter
+        4. ``(primary, sidecars)`` tuple → save artifact, mark completed,
+           clean up, notify sorter
         5. PrepareResult → queue for another round
         6. Repeat until no entries remain or max rounds exceeded
 
@@ -679,9 +680,14 @@ class DAGExecutor:
                     )
                     continue
 
-                if isinstance(result, Message):
+                if isinstance(result, tuple):
+                    primary, _sidecars = result
                     await self._save_distributed_artifact(
-                        entry, result, results_by_artifact[entry.artifact_id], plan, ctx
+                        entry,
+                        primary,
+                        results_by_artifact[entry.artifact_id],
+                        plan,
+                        ctx,
                     )
                     sorter.done(entry.artifact_id)
                 else:
@@ -1105,7 +1111,8 @@ class DAGExecutor:
 
         def sync_process() -> Message:
             processor = factory.create(process_config.properties)
-            return processor.process(inputs, output_schema)
+            primary, _sidecars = processor.process(inputs, output_schema)
+            return primary
 
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(thread_pool, sync_process)

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor.py
@@ -390,7 +390,7 @@ class TestDAGExecutorProcess:
         mock_processor_class.get_supported_output_schemas.return_value = [output_schema]
         processor_factory.component_class = mock_processor_class
         mock_processor = MagicMock(spec=["process"])
-        mock_processor.process.return_value = processed_message
+        mock_processor.process.return_value = (processed_message, [])
         processor_factory.create.return_value = mock_processor
 
         artifacts = {
@@ -564,7 +564,7 @@ class TestDAGExecutorArtifactMetadata:
         mock_processor_class.get_supported_output_schemas.return_value = [output_schema]
         processor_factory.component_class = mock_processor_class
         mock_processor = MagicMock(spec=["process"])
-        mock_processor.process.return_value = processed_message
+        mock_processor.process.return_value = (processed_message, [])
         processor_factory.create.return_value = mock_processor
 
         artifacts = {

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_child_runbooks.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_child_runbooks.py
@@ -103,7 +103,7 @@ class TestExecutorChildRunbookAliases:
         mock_processor_class.get_supported_output_schemas.return_value = [output_schema]
         processor_factory.component_class = mock_processor_class
         mock_processor = MagicMock(spec=["process"])
-        mock_processor.process.return_value = processed_message
+        mock_processor.process.return_value = (processed_message, [])
         processor_factory.create.return_value = mock_processor
 
         # Namespaced child artifact

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_classification.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_classification.py
@@ -73,7 +73,7 @@ class TestDistributedProcessorHappyPath:
                 state=StubState(value="my_state"),
                 requests=[request],
             ),
-            finalise_results=[final_message],
+            finalise_results=[(final_message, [])],
         )
 
         connector_factory = create_mock_connector_factory(
@@ -149,7 +149,7 @@ class TestDistributedProcessorHappyPath:
         dispatch_result = DispatchResult(request_id=request.request_id, name="test_res")
         dist_processor = StubDistributedProcessor(
             prepare_result=PrepareResult(state=StubState(), requests=[request]),
-            finalise_results=[distributed_result_msg],
+            finalise_results=[(distributed_result_msg, [])],
         )
 
         connector_factory = create_mock_connector_factory(
@@ -159,7 +159,7 @@ class TestDistributedProcessorHappyPath:
             "regular_analyser",
             [source_schema],
             [output_schema],
-            process_result=regular_result_msg,
+            process_result=(regular_result_msg, []),
         )
         distributed_factory = create_distributed_processor_factory(
             "distributed_analyser", dist_processor
@@ -245,11 +245,11 @@ class TestDistributedDispatch:
 
         proc_a = StubDistributedProcessor(
             prepare_result=PrepareResult(state=StubState(), requests=[req_a]),
-            finalise_results=[final_message],
+            finalise_results=[(final_message, [])],
         )
         proc_b = StubDistributedProcessor(
             prepare_result=PrepareResult(state=StubState(), requests=[req_b]),
-            finalise_results=[final_message],
+            finalise_results=[(final_message, [])],
         )
 
         connector_factory = create_mock_connector_factory(
@@ -324,7 +324,7 @@ class TestDistributedDispatch:
                 prepare_result: PrepareResult[StubState],
                 final_msg: Message,
             ) -> None:
-                super().__init__(prepare_result, [final_msg])
+                super().__init__(prepare_result, [(final_msg, [])])
                 self.tag = tag
 
             def finalise(self, state, results, output_schema):  # type: ignore[override]
@@ -406,7 +406,7 @@ class TestDistributedDispatch:
                 state=StubState(value="pending_state"),
                 requests=[request],
             ),
-            finalise_results=[create_test_message({}, schema=output_schema)],
+            finalise_results=[(create_test_message({}, schema=output_schema), [])],
         )
 
         connector_factory = create_mock_connector_factory(
@@ -479,14 +479,17 @@ class TestDistributedDispatch:
         request = DispatchRequest(name="failing_req")
         dist_processor = StubDistributedProcessor(
             prepare_result=PrepareResult(state=StubState(), requests=[request]),
-            finalise_results=[create_test_message({}, schema=output_schema)],
+            finalise_results=[(create_test_message({}, schema=output_schema), [])],
         )
 
         connector_factory = create_mock_connector_factory(
             "src", [source_schema], source_message
         )
         regular_factory = create_mock_processor_factory(
-            "regular", [source_schema], [output_schema], process_result=regular_result
+            "regular",
+            [source_schema],
+            [output_schema],
+            process_result=(regular_result, []),
         )
         dispatcher = create_mock_dispatcher(
             [], side_effect=RuntimeError("Dispatch failed")
@@ -549,7 +552,7 @@ class TestDistributedDispatch:
 
         processor = StubDistributedProcessor(
             prepare_result=PrepareResult(state=StubState(), requests=[]),
-            finalise_results=[final_message],
+            finalise_results=[(final_message, [])],
         )
 
         connector_factory = create_mock_connector_factory(
@@ -625,14 +628,17 @@ class TestDistributedErrorIsolation:
 
         failing_processor = FailingPrepareProcessor(
             prepare_result=PrepareResult(state=StubState(), requests=[]),
-            finalise_results=[create_test_message({}, schema=output_schema)],
+            finalise_results=[(create_test_message({}, schema=output_schema), [])],
         )
 
         connector_factory = create_mock_connector_factory(
             "src", [source_schema], source_message
         )
         regular_factory = create_mock_processor_factory(
-            "regular", [source_schema], [output_schema], process_result=regular_result
+            "regular",
+            [source_schema],
+            [output_schema],
+            process_result=(regular_result, []),
         )
 
         artifacts = {
@@ -710,7 +716,7 @@ class TestDistributedResume:
                 state=StubState(value="resume_state"),
                 requests=[request],
             ),
-            finalise_results=[final_message],
+            finalise_results=[(final_message, [])],
         )
 
         connector_factory = create_mock_connector_factory(
@@ -764,7 +770,7 @@ class TestDistributedResume:
                 state=StubState(value="resume_state"),
                 requests=[request],
             ),
-            finalise_results=[final_message],
+            finalise_results=[(final_message, [])],
         )
         processor_factory2 = create_distributed_processor_factory(
             "dist_proc", processor2

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_finalise.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_finalise.py
@@ -66,7 +66,7 @@ class TestDistributedArtifactMetadata:
 
         processor = StubDistributedProcessor(
             prepare_result=PrepareResult(state=StubState(), requests=[request]),
-            finalise_results=[final_message],
+            finalise_results=[(final_message, [])],
         )
 
         connector_factory = create_mock_connector_factory(
@@ -151,7 +151,7 @@ class TestDistributedArtifactMetadata:
 
         processor = StubDistributedProcessor(
             prepare_result=PrepareResult(state=StubState(), requests=[request]),
-            finalise_results=[final_message],
+            finalise_results=[(final_message, [])],
         )
 
         connector_factory = create_mock_connector_factory(
@@ -214,7 +214,7 @@ class TestDistributedArtifactMetadata:
 
         processor = StubDistributedProcessor(
             prepare_result=PrepareResult(state=StubState(), requests=[request]),
-            finalise_results=[final_message],
+            finalise_results=[(final_message, [])],
         )
 
         connector_factory = create_mock_connector_factory(
@@ -260,6 +260,83 @@ class TestDistributedArtifactMetadata:
 
 
 # =============================================================================
+# Tuple Return Contract
+# =============================================================================
+
+
+class TestTupleFinaliseResult:
+    """Tests for finalise() returning ``(primary, sidecars)`` tuples."""
+
+    async def test_tuple_result_completes_artifact_without_extra_rounds(
+        self,
+    ) -> None:
+        """finalise() returning ``(primary, sidecars)`` completes the artifact.
+
+        Pins the executor branch that treats a tuple finalise result as
+        completion (save artifact, sorter.done) rather than as a
+        ``PrepareResult`` requiring another dispatch-finalise round.
+        """
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("findings", "1.0.0")
+        source_message = create_test_message({"files": []})
+        primary_message = create_test_message(
+            {"findings": ["tuple_complete"]}, schema=output_schema
+        )
+
+        request = DispatchRequest(name="tuple_req")
+        dispatch_result = DispatchResult(request_id=request.request_id)
+
+        processor = StubDistributedProcessor(
+            prepare_result=PrepareResult(state=StubState(), requests=[request]),
+            finalise_results=[(primary_message, [])],
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        dispatcher = create_mock_dispatcher([dispatch_result])
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="dist_proc", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "findings": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={
+                "dist_proc": create_distributed_processor_factory(
+                    "dist_proc", processor
+                ),
+            },
+        )
+        registry.get_dispatcher_for.return_value = dispatcher
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        assert "findings" in exec_result.completed
+        assert dispatcher.dispatch.call_count == 1
+        assert processor.call_log == ["prepare", "finalise"]
+
+        store = registry.container.get_service(ArtifactStore)
+        stored = await store.get_artifact(exec_result.run_id, "findings")
+        assert stored.content == primary_message.content
+
+
+# =============================================================================
 # Multi-Round
 # =============================================================================
 
@@ -298,7 +375,7 @@ class TestMultiRoundDispatch:
             prepare_result=PrepareResult(
                 state=StubState(value="round_1"), requests=[req1]
             ),
-            finalise_results=[round2_prepare, final_message],
+            finalise_results=[round2_prepare, (final_message, [])],
         )
 
         connector_factory = create_mock_connector_factory(

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_resume.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_resume.py
@@ -669,7 +669,7 @@ class TestInterruptResumeLifecycle:
                 state=StubState(value="batch_state"),
                 requests=[request],
             ),
-            finalise_results=[final_message],
+            finalise_results=[(final_message, [])],
         )
 
         connector_factory = create_mock_connector_factory(
@@ -730,7 +730,7 @@ class TestInterruptResumeLifecycle:
                 state=StubState(value="batch_state"),
                 requests=[request],
             ),
-            finalise_results=[final_message],
+            finalise_results=[(final_message, [])],
         )
         registry.processor_factories["dist_proc"] = (
             create_distributed_processor_factory("dist_proc", processor2)
@@ -782,7 +782,7 @@ class TestInterruptResumeLifecycle:
                 state=StubState(value="batch_state"),
                 requests=[request],
             ),
-            finalise_results=[findings_message],
+            finalise_results=[(findings_message, [])],
         )
 
         connector_factory = create_mock_connector_factory(
@@ -792,7 +792,7 @@ class TestInterruptResumeLifecycle:
             "validator",
             [findings_schema],
             [validated_schema],
-            process_result=validated_message,
+            process_result=(validated_message, []),
         )
 
         artifacts = {
@@ -857,7 +857,7 @@ class TestInterruptResumeLifecycle:
                 state=StubState(value="batch_state"),
                 requests=[request],
             ),
-            finalise_results=[findings_message],
+            finalise_results=[(findings_message, [])],
         )
         registry.processor_factories["dist_proc"] = (
             create_distributed_processor_factory("dist_proc", processor2)

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_sidecars.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_executor_sidecars.py
@@ -1,0 +1,672 @@
+"""Tests for sidecar persistence and back-reference stamping in DAGExecutor.
+
+Covers both code paths (sync ``_run_processor`` and distributed
+``_finalise_distributed_artifacts``) and the audit-trail back-reference
+stamping into the primary's ``analysis_metadata.validation_summary``.
+"""
+
+from collections.abc import Sequence
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+from waivern_artifact_store import ArtifactStore
+from waivern_core import (
+    LLMValidationResponseModel,
+    LLMValidationResultModel,
+    Message,
+)
+from waivern_core.dispatch import DispatchRequest, DispatchResult, PrepareResult
+from waivern_core.schemas import Schema
+from waivern_llm.types import LLMDispatchResult, LLMRequest
+
+from waivern_orchestration.executor import DAGExecutor
+from waivern_orchestration.models import (
+    ArtifactDefinition,
+    ProcessConfig,
+    SourceConfig,
+)
+from waivern_orchestration.planner import ExecutionPlan
+
+from .test_helpers import (
+    StubDistributedProcessor,
+    StubState,
+    create_distributed_processor_factory,
+    create_mock_connector_factory,
+    create_mock_dispatcher,
+    create_mock_processor_factory,
+    create_mock_registry,
+    create_simple_plan,
+    create_test_message,
+)
+
+
+def _build_sync_plan_and_registry(
+    primary: Message,
+    sidecars: list[Message],
+    output_schema: Schema,
+) -> tuple[ExecutionPlan, MagicMock]:
+    """Build a minimal plan + registry for a single synchronous-processor artifact.
+
+    Source connector → regular ``Processor.process()`` returning
+    ``(primary, sidecars)``.
+    """
+    source_schema = Schema("standard_input", "1.0.0")
+    source_message = create_test_message({"files": []})
+
+    connector_factory = create_mock_connector_factory(
+        "src", [source_schema], source_message
+    )
+    processor_factory = create_mock_processor_factory(
+        "sync_proc",
+        input_schemas=[source_schema],
+        output_schemas=[output_schema],
+        process_result=(primary, sidecars),
+    )
+
+    artifacts = {
+        "source": ArtifactDefinition(source=SourceConfig(type="src", properties={})),
+        "findings": ArtifactDefinition(
+            inputs="source",
+            process=ProcessConfig(type="sync_proc", properties={}),
+        ),
+    }
+    plan = create_simple_plan(
+        artifacts,
+        {
+            "source": (None, source_schema),
+            "findings": ([source_schema], output_schema),
+        },
+    )
+
+    registry = create_mock_registry(
+        with_container=True,
+        connector_factories={"src": connector_factory},
+        processor_factories={"sync_proc": processor_factory},
+    )
+    return plan, registry
+
+
+def _build_distributed_plan_and_registry(
+    primary: Message,
+    sidecars: list[Message],
+    output_schema: Schema,
+) -> tuple[ExecutionPlan, MagicMock]:
+    """Build a minimal plan + registry for a single distributed-processor artifact.
+
+    Single source connector feeding a single distributed processor that
+    returns ``(primary, sidecars)`` in one round.
+    """
+    source_schema = Schema("standard_input", "1.0.0")
+    source_message = create_test_message({"files": []})
+
+    request = DispatchRequest(name="req")
+    dispatch_result = DispatchResult(request_id=request.request_id)
+
+    processor = StubDistributedProcessor(
+        prepare_result=PrepareResult(state=StubState(), requests=[request]),
+        finalise_results=[(primary, sidecars)],
+    )
+
+    connector_factory = create_mock_connector_factory(
+        "src", [source_schema], source_message
+    )
+    dispatcher = create_mock_dispatcher([dispatch_result])
+
+    artifacts = {
+        "source": ArtifactDefinition(source=SourceConfig(type="src", properties={})),
+        "findings": ArtifactDefinition(
+            inputs="source",
+            process=ProcessConfig(type="dist_proc", properties={}),
+        ),
+    }
+    plan = create_simple_plan(
+        artifacts,
+        {
+            "source": (None, source_schema),
+            "findings": ([source_schema], output_schema),
+        },
+    )
+
+    registry = create_mock_registry(
+        with_container=True,
+        connector_factories={"src": connector_factory},
+        processor_factories={
+            "dist_proc": create_distributed_processor_factory("dist_proc", processor),
+        },
+    )
+    registry.get_dispatcher_for.return_value = dispatcher
+    return plan, registry
+
+
+class TestDistributedSidecarPersistence:
+    """Group A — sidecar persistence on the distributed (DistributedProcessor) path."""
+
+    async def test_distributed_sidecar_persisted_at_dotted_artifact_id(self) -> None:
+        """Distributed (primary, [sidecar]) → sidecar in store at ``{primary}.{schema.name}``.
+
+        Arrange: distributed processor finalises with one ``removed_findings``
+        sidecar alongside the primary.
+        Assert: ``store.get_artifact(run_id, "findings.removed_findings")``
+        returns a Message whose schema matches the sidecar's schema.
+        """
+        output_schema = Schema("findings", "1.0.0")
+        sidecar_schema = Schema("removed_findings", "1.0.0")
+
+        primary = create_test_message({"findings": []}, schema=output_schema)
+        sidecar = create_test_message(
+            {"analyser_name": "x", "run_id": "x", "removed_findings": []},
+            schema=sidecar_schema,
+        )
+
+        plan, registry = _build_distributed_plan_and_registry(
+            primary, [sidecar], output_schema
+        )
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+        assert "findings" in exec_result.completed
+
+        store = registry.container.get_service(ArtifactStore)
+        stored = await store.get_artifact(
+            exec_result.run_id, "findings.removed_findings"
+        )
+        assert stored.schema == sidecar_schema
+
+    async def test_distributed_sidecar_carries_run_id(self) -> None:
+        """Persisted sidecar carries the executor's run_id, not whatever the analyser set.
+
+        The store is queried by (run_id, artifact_id); a sidecar with the
+        wrong (or missing) run_id is unreachable.
+        """
+        output_schema = Schema("findings", "1.0.0")
+        sidecar_schema = Schema("removed_findings", "1.0.0")
+
+        primary = create_test_message({"findings": []}, schema=output_schema)
+        sidecar = create_test_message(
+            {"analyser_name": "x", "run_id": "stale-id", "removed_findings": []},
+            schema=sidecar_schema,
+        )
+
+        plan, registry = _build_distributed_plan_and_registry(
+            primary, [sidecar], output_schema
+        )
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        store = registry.container.get_service(ArtifactStore)
+        stored = await store.get_artifact(
+            exec_result.run_id, "findings.removed_findings"
+        )
+        assert stored.run_id == exec_result.run_id
+
+    async def test_distributed_multiple_sidecars_all_persisted(self) -> None:
+        """Two sidecars with different schema.name → both land at their dotted IDs.
+
+        Forward-compat: defends the iteration loop against off-by-one or
+        "save only first" regressions as future sidecar types arrive.
+        """
+        output_schema = Schema("findings", "1.0.0")
+        sidecar_a_schema = Schema("removed_findings", "1.0.0")
+        sidecar_b_schema = Schema("standard_input", "1.0.0")
+
+        primary = create_test_message({"findings": []}, schema=output_schema)
+        sidecar_a = create_test_message({"a": 1}, schema=sidecar_a_schema)
+        sidecar_b = create_test_message({"b": 2}, schema=sidecar_b_schema)
+
+        plan, registry = _build_distributed_plan_and_registry(
+            primary, [sidecar_a, sidecar_b], output_schema
+        )
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        store = registry.container.get_service(ArtifactStore)
+        stored_a = await store.get_artifact(
+            exec_result.run_id, "findings.removed_findings"
+        )
+        stored_b = await store.get_artifact(
+            exec_result.run_id, "findings.standard_input"
+        )
+        assert stored_a.schema == sidecar_a_schema
+        assert stored_b.schema == sidecar_b_schema
+
+    async def test_distributed_no_sidecars_stores_only_primary(self) -> None:
+        """Empty sidecar list → only the primary is in the store (no spurious files).
+
+        Negative case for the persistence loop.
+        """
+        output_schema = Schema("findings", "1.0.0")
+        primary = create_test_message({"findings": []}, schema=output_schema)
+
+        plan, registry = _build_distributed_plan_and_registry(
+            primary, [], output_schema
+        )
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        store = registry.container.get_service(ArtifactStore)
+        artifact_ids = await store.list_artifacts(exec_result.run_id)
+        # Only the source and the primary "findings" — no sidecars.
+        assert sorted(artifact_ids) == ["findings", "source"]
+
+
+class TestSyncSidecarPersistence:
+    """Group B — sidecar persistence on the synchronous (Processor.process) path."""
+
+    async def test_sync_sidecar_persisted_at_dotted_artifact_id(self) -> None:
+        """Sync ``Processor.process()`` returning ``(primary, [sidecar])`` persists both.
+
+        Arrange: a regular (non-DistributedProcessor) processor that returns
+        a primary plus one sidecar.
+        Assert: store has the sidecar at ``{primary}.{schema.name}``.
+        """
+        output_schema = Schema("findings", "1.0.0")
+        sidecar_schema = Schema("removed_findings", "1.0.0")
+
+        primary = create_test_message({"findings": []}, schema=output_schema)
+        sidecar = create_test_message(
+            {"analyser_name": "x", "run_id": "x", "removed_findings": []},
+            schema=sidecar_schema,
+        )
+
+        plan, registry = _build_sync_plan_and_registry(
+            primary, [sidecar], output_schema
+        )
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+        assert "findings" in exec_result.completed
+
+        store = registry.container.get_service(ArtifactStore)
+        stored = await store.get_artifact(
+            exec_result.run_id, "findings.removed_findings"
+        )
+        assert stored.schema == sidecar_schema
+        assert stored.run_id == exec_result.run_id
+
+    async def test_sync_no_sidecars_stores_only_primary(self) -> None:
+        """Sync processor returning ``(primary, [])`` → only primary in store.
+
+        Negative case mirroring A4 on the synchronous path.
+        """
+        output_schema = Schema("findings", "1.0.0")
+        primary = create_test_message({"findings": []}, schema=output_schema)
+
+        plan, registry = _build_sync_plan_and_registry(primary, [], output_schema)
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        store = registry.container.get_service(ArtifactStore)
+        artifact_ids = await store.list_artifacts(exec_result.run_id)
+        assert sorted(artifact_ids) == ["findings", "source"]
+
+
+class TestBackReferenceStamping:
+    """Group C — stamping ``removed_findings_artifact_id`` into the primary."""
+
+    async def test_removed_findings_sidecar_stamps_artifact_id_into_validation_summary(
+        self,
+    ) -> None:
+        """``removed_findings`` sidecar → primary's ``validation_summary`` carries back-ref.
+
+        The bridge between the primary output and the audit-trail sidecar:
+        downstream consumers reading the primary find the sidecar's
+        artifact_id under
+        ``analysis_metadata.validation_summary.removed_findings_artifact_id``.
+        """
+        output_schema = Schema("findings", "1.0.0")
+        sidecar_schema = Schema("removed_findings", "1.0.0")
+
+        primary = create_test_message(
+            {
+                "findings": [],
+                "analysis_metadata": {
+                    "validation_summary": {
+                        "removed_findings_artifact_id": None,
+                    },
+                },
+            },
+            schema=output_schema,
+        )
+        sidecar = create_test_message(
+            {"analyser_name": "x", "run_id": "x", "removed_findings": []},
+            schema=sidecar_schema,
+        )
+
+        plan, registry = _build_distributed_plan_and_registry(
+            primary, [sidecar], output_schema
+        )
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        store = registry.container.get_service(ArtifactStore)
+        stored_primary = await store.get_artifact(exec_result.run_id, "findings")
+        validation_summary = stored_primary.content["analysis_metadata"][
+            "validation_summary"
+        ]
+        assert (
+            validation_summary["removed_findings_artifact_id"]
+            == "findings.removed_findings"
+        )
+
+    async def test_non_removed_findings_sidecar_does_not_stamp(self) -> None:
+        """A sidecar with a different schema.name does not trigger stamping.
+
+        Locks in the matching rule: only ``removed_findings`` sidecars
+        cause back-reference stamping. Future sidecar types (e.g. SOC 2
+        evidence trail) are persisted but do not back-stamp.
+        """
+        output_schema = Schema("findings", "1.0.0")
+        sidecar_schema = Schema("some_other_sidecar", "1.0.0")
+
+        primary = create_test_message(
+            {
+                "findings": [],
+                "analysis_metadata": {
+                    "validation_summary": {
+                        "removed_findings_artifact_id": None,
+                    },
+                },
+            },
+            schema=output_schema,
+        )
+        sidecar = create_test_message({"x": 1}, schema=sidecar_schema)
+
+        plan, registry = _build_distributed_plan_and_registry(
+            primary, [sidecar], output_schema
+        )
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        store = registry.container.get_service(ArtifactStore)
+        stored_primary = await store.get_artifact(exec_result.run_id, "findings")
+        validation_summary = stored_primary.content["analysis_metadata"][
+            "validation_summary"
+        ]
+        # Untouched — still the pre-emitted None.
+        assert validation_summary["removed_findings_artifact_id"] is None
+
+    async def test_primary_without_validation_summary_skips_stamp_gracefully(
+        self,
+    ) -> None:
+        """Primary lacking ``analysis_metadata.validation_summary`` is untouched.
+
+        Defensive: a non-analyser processor (e.g. raw passthrough) that
+        somehow emits a ``removed_findings`` sidecar must not cause the
+        executor to crash. The sidecar persists; the primary stays as-is.
+        """
+        output_schema = Schema("findings", "1.0.0")
+        sidecar_schema = Schema("removed_findings", "1.0.0")
+
+        primary = create_test_message({"findings": []}, schema=output_schema)
+        sidecar = create_test_message(
+            {"analyser_name": "x", "run_id": "x", "removed_findings": []},
+            schema=sidecar_schema,
+        )
+
+        plan, registry = _build_distributed_plan_and_registry(
+            primary, [sidecar], output_schema
+        )
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        store = registry.container.get_service(ArtifactStore)
+        stored_primary = await store.get_artifact(exec_result.run_id, "findings")
+        # Primary content unchanged (no analysis_metadata fabricated by executor).
+        assert "analysis_metadata" not in stored_primary.content
+        # Sidecar still persisted.
+        assert await store.artifact_exists(
+            exec_result.run_id, "findings.removed_findings"
+        )
+
+    async def test_validation_with_no_removals_no_sidecar_no_stamp(self) -> None:
+        """Validation produced no removals → no sidecar → primary unchanged.
+
+        Common case: LLM validation enabled, but no false positives found.
+        The analyser pre-emits ``removed_findings_artifact_id: None`` in
+        ``validation_summary``; the executor sees no sidecar and leaves
+        that ``None`` in place.
+        """
+        output_schema = Schema("findings", "1.0.0")
+        primary = create_test_message(
+            {
+                "findings": [],
+                "analysis_metadata": {
+                    "validation_summary": {
+                        "removed_findings_artifact_id": None,
+                    },
+                },
+            },
+            schema=output_schema,
+        )
+
+        plan, registry = _build_distributed_plan_and_registry(
+            primary, [], output_schema
+        )
+        executor = DAGExecutor(registry)
+
+        exec_result = await executor.execute(plan)
+
+        store = registry.container.get_service(ArtifactStore)
+        stored_primary = await store.get_artifact(exec_result.run_id, "findings")
+        validation_summary = stored_primary.content["analysis_metadata"][
+            "validation_summary"
+        ]
+        assert validation_summary["removed_findings_artifact_id"] is None
+
+
+class TestSidecarSaveOrder:
+    """Group D — sidecars must be persisted before the primary (crash safety)."""
+
+    async def test_sidecars_saved_before_primary(self, mocker: MockerFixture) -> None:
+        """Sidecars are saved before the primary.
+
+        Crash safety invariant: if execution crashes after a sidecar write
+        but before the primary write, the artifact is not marked completed,
+        so resume re-runs it idempotently. Reversing the order would risk
+        the primary's stamped ``removed_findings_artifact_id`` pointing at
+        a sidecar that was never persisted.
+        """
+        output_schema = Schema("findings", "1.0.0")
+        sidecar_schema = Schema("removed_findings", "1.0.0")
+
+        primary = create_test_message({"findings": []}, schema=output_schema)
+        sidecar = create_test_message(
+            {"analyser_name": "x", "run_id": "x", "removed_findings": []},
+            schema=sidecar_schema,
+        )
+
+        plan, registry = _build_distributed_plan_and_registry(
+            primary, [sidecar], output_schema
+        )
+        store = registry.container.get_service(ArtifactStore)
+        spy = mocker.spy(store, "save_artifact")
+
+        executor = DAGExecutor(registry)
+        await executor.execute(plan)
+
+        # save_artifact is called for: source (connector output), then
+        # findings.removed_findings (sidecar), then findings (primary).
+        # We assert the sidecar precedes the primary for the same artifact.
+        saved_ids = [call.args[1] for call in spy.call_args_list]
+        sidecar_idx = saved_ids.index("findings.removed_findings")
+        primary_idx = saved_ids.index("findings")
+        assert sidecar_idx < primary_idx
+
+
+class _AllFalsePositiveDispatcher:
+    """Test dispatcher that marks every finding in every request FALSE_POSITIVE."""
+
+    async def dispatch(
+        self, requests: Sequence[DispatchRequest]
+    ) -> Sequence[DispatchResult]:
+        results: list[DispatchResult] = []
+        for request in requests:
+            assert isinstance(request, LLMRequest)
+            verdict_results = [
+                LLMValidationResultModel(
+                    finding_id=item.id,
+                    validation_result="FALSE_POSITIVE",
+                    confidence=0.9,
+                    reasoning="LLM rejected: not actually personal data",
+                    recommended_action="discard",
+                )
+                for group in request.groups
+                for item in group.items
+            ]
+            response = LLMValidationResponseModel(results=verdict_results)
+            results.append(
+                LLMDispatchResult(
+                    request_id=request.request_id,
+                    model_name="test-model",
+                    responses=[response.model_dump(mode="json")],
+                    skipped=[],
+                )
+            )
+        return results
+
+
+class TestAnalyserSidecarE2E:
+    """Group E — end-to-end through a real LLM-validating analyser."""
+
+    async def test_personal_data_analyser_audit_trail_e2e(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """personal_data_analyser through executor → sidecar persisted + back-ref stamped.
+
+        Integration smoke validating that the real analyser's primary
+        content shape matches the executor's stamping path. Uses synthetic
+        ruleset rules to avoid coupling to production ruleset data.
+        """
+        from waivern_analysers_shared.types import (
+            LLMValidationConfig,
+            PatternMatchingConfig,
+        )
+        from waivern_analysers_shared.utilities import RulesetManager
+        from waivern_personal_data_analyser.analyser import PersonalDataAnalyser
+        from waivern_personal_data_analyser.types import PersonalDataAnalyserConfig
+        from waivern_rulesets.personal_data_indicator import (
+            PersonalDataIndicatorRule,
+        )
+        from waivern_schemas import register_schemas
+        from waivern_schemas.connector_types import BaseMetadata
+        from waivern_schemas.standard_input import (
+            StandardInputDataItemModel,
+            StandardInputDataModel,
+        )
+
+        # Make personal_data_indicator JSON schema discoverable; the
+        # workspace conftest snapshots/restores SchemaRegistry per test.
+        register_schemas()
+
+        synthetic_rules = (
+            PersonalDataIndicatorRule(
+                name="Email Address",
+                description="Email detection",
+                category="email",
+                patterns=("email",),
+            ),
+        )
+
+        def _mock_get_rules(
+            uri: str, rule_type: type[PersonalDataIndicatorRule]
+        ) -> tuple[PersonalDataIndicatorRule, ...]:
+            return synthetic_rules
+
+        monkeypatch.setattr(RulesetManager, "get_rules", _mock_get_rules)
+
+        config = PersonalDataAnalyserConfig(
+            pattern_matching=PatternMatchingConfig(ruleset="test/personal_data/1.0.0"),
+            llm_validation=LLMValidationConfig(
+                enable_llm_validation=True,
+                llm_validation_mode="standard",
+            ),
+        )
+        analyser = PersonalDataAnalyser(config=config)
+
+        source_schema = Schema("standard_input", "1.0.0")
+        output_schema = Schema("personal_data_indicator", "1.0.0")
+        input_data = StandardInputDataModel(
+            schemaVersion="1.0.0",
+            name="test_data",
+            data=[
+                StandardInputDataItemModel(
+                    content="Contact email: john.doe@company.com",
+                    metadata=BaseMetadata(source="email_source", connector_type="test"),
+                ),
+            ],
+        )
+        source_message = Message(
+            id="src-msg",
+            content=input_data.model_dump(exclude_none=True),
+            schema=source_schema,
+        )
+
+        connector_factory = create_mock_connector_factory(
+            "src", [source_schema], source_message
+        )
+        # Inline a factory matching ``create_distributed_processor_factory`` but
+        # accepting any DistributedProcessor, since the shared helper is typed
+        # to a stub class.
+        analyser_factory = MagicMock()
+        analyser_factory.component_class = MagicMock()
+        analyser_factory.component_class.get_name.return_value = "pda"
+        analyser_factory.create.return_value = analyser
+
+        artifacts = {
+            "source": ArtifactDefinition(
+                source=SourceConfig(type="src", properties={})
+            ),
+            "findings": ArtifactDefinition(
+                inputs="source",
+                process=ProcessConfig(type="pda", properties={}),
+            ),
+        }
+        plan = create_simple_plan(
+            artifacts,
+            {
+                "source": (None, source_schema),
+                "findings": ([source_schema], output_schema),
+            },
+        )
+
+        registry = create_mock_registry(
+            with_container=True,
+            connector_factories={"src": connector_factory},
+            processor_factories={"pda": analyser_factory},
+        )
+        registry.get_dispatcher_for.return_value = _AllFalsePositiveDispatcher()
+
+        executor = DAGExecutor(registry)
+        exec_result = await executor.execute(plan)
+        assert "findings" in exec_result.completed, exec_result.failed
+
+        store = registry.container.get_service(ArtifactStore)
+        stored_primary = await store.get_artifact(exec_result.run_id, "findings")
+        stored_sidecar = await store.get_artifact(
+            exec_result.run_id, "findings.removed_findings"
+        )
+
+        # Sidecar carries the analyser's audit trail with the LLM's reasoning verbatim.
+        assert stored_sidecar.schema == Schema("removed_findings", "1.0.0")
+        removed = stored_sidecar.content["removed_findings"]
+        assert len(removed) >= 1
+        assert all(
+            r["reason"] == "LLM rejected: not actually personal data" for r in removed
+        )
+
+        # Primary's validation_summary back-references the sidecar by artifact_id.
+        validation_summary = stored_primary.content["analysis_metadata"][
+            "validation_summary"
+        ]
+        assert (
+            validation_summary["removed_findings_artifact_id"]
+            == "findings.removed_findings"
+        )

--- a/libs/waivern-orchestration/tests/waivern_orchestration/test_helpers.py
+++ b/libs/waivern-orchestration/tests/waivern_orchestration/test_helpers.py
@@ -57,7 +57,7 @@ def create_mock_processor_factory(
     name: str,
     input_schemas: list[Schema],
     output_schemas: list[Schema],
-    process_result: Message | None = None,
+    process_result: tuple[Message, list[Message]] | None = None,
     input_requirements: list[list[Schema]] | None = None,
 ) -> MagicMock:
     """Create a mock processor factory.
@@ -67,8 +67,8 @@ def create_mock_processor_factory(
         input_schemas: List of input schemas the processor accepts.
             Each schema becomes a separate single-item alternative.
         output_schemas: List of output schemas the processor produces.
-        process_result: Optional message to return from process().
-            If provided, creates a mock processor that returns this message.
+        process_result: Optional ``(primary, sidecars)`` tuple to return from
+            process(). If provided, creates a mock processor that returns it.
         input_requirements: Optional explicit input requirement combinations.
             Each inner list is one valid combination of schema types.
             If provided, overrides the default conversion from input_schemas.
@@ -311,7 +311,9 @@ class StubDistributedProcessor:
     def __init__(
         self,
         prepare_result: PrepareResult[StubState],
-        finalise_results: Sequence[Message | PrepareResult[StubState]],
+        finalise_results: Sequence[
+            tuple[Message, list[Message]] | PrepareResult[StubState]
+        ],
     ) -> None:
         self.prepare_result = prepare_result
         self.finalise_results = list(finalise_results)
@@ -335,7 +337,7 @@ class StubDistributedProcessor:
         state: StubState,
         results: Sequence[DispatchResult],
         output_schema: Schema,
-    ) -> Message | PrepareResult[StubState]:
+    ) -> tuple[Message, list[Message]] | PrepareResult[StubState]:
         self.call_log.append("finalise")
         idx = min(self._finalise_call_count, len(self.finalise_results) - 1)
         self._finalise_call_count += 1

--- a/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/analyser.py
+++ b/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/analyser.py
@@ -163,7 +163,7 @@ class PersonalDataAnalyser(Analyser):
                 output_schema,
                 validation_result=None,
             )
-            return primary, []
+            return primary, self._result_builder.build_sidecars(None, state.run_id)
 
         llm_result = self._extract_llm_result(results)
         outcome = self._orchestrator.finalise(
@@ -190,7 +190,7 @@ class PersonalDataAnalyser(Analyser):
             output_schema,
             validation_result=outcome,
         )
-        return primary, []
+        return primary, self._result_builder.build_sidecars(outcome, state.run_id)
 
     def deserialise_prepare_result(
         self, raw: dict[str, Any]

--- a/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/analyser.py
+++ b/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/analyser.py
@@ -143,7 +143,7 @@ class PersonalDataAnalyser(Analyser):
         state: PersonalDataPrepareState,
         results: Sequence[DispatchResult],
         output_schema: Schema,
-    ) -> Message | PrepareResult[PersonalDataPrepareState]:
+    ) -> tuple[Message, list[Message]] | PrepareResult[PersonalDataPrepareState]:
         """Produce output message from state and dispatch results.
 
         Paths:
@@ -158,11 +158,12 @@ class PersonalDataAnalyser(Analyser):
         retained defensively to satisfy the typed return union.
         """
         if not state.llm_enabled or state.orchestrator_state is None:
-            return self._result_builder.build_output_message(
+            primary = self._result_builder.build_output_message(
                 state.all_findings,
                 output_schema,
                 validation_result=None,
             )
+            return primary, []
 
         llm_result = self._extract_llm_result(results)
         outcome = self._orchestrator.finalise(
@@ -184,11 +185,12 @@ class PersonalDataAnalyser(Analyser):
             f"({len(outcome.removed_groups)} groups removed)"
         )
 
-        return self._result_builder.build_output_message(
+        primary = self._result_builder.build_output_message(
             outcome.kept_findings,
             output_schema,
             validation_result=outcome,
         )
+        return primary, []
 
     def deserialise_prepare_result(
         self, raw: dict[str, Any]

--- a/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/llm_validation_strategy.py
+++ b/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/llm_validation_strategy.py
@@ -2,9 +2,9 @@
 
 from typing import override
 
-from waivern_analysers_shared.llm_validation.models import LLMValidationResponseModel
 from waivern_analysers_shared.llm_validation.strategy import FilteringValidationStrategy
 from waivern_analysers_shared.types import LLMValidationConfig
+from waivern_core import LLMValidationResponseModel
 from waivern_llm import BatchingMode, ItemGroup, LLMRequest
 from waivern_schemas.personal_data_indicator import PersonalDataIndicatorModel
 

--- a/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/result_builder.py
+++ b/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/result_builder.py
@@ -180,6 +180,10 @@ class PersonalDataResultBuilder:
                 "samples_validated": validation_result.samples_validated,
                 "all_succeeded": validation_result.all_succeeded,
                 "skipped_count": len(validation_result.skipped_samples),
+                # Pre-emitted so the key is always present once validation ran;
+                # DAGExecutor stamps the sidecar's artifact_id when removals
+                # produced an audit-trail sidecar.
+                "removed_findings_artifact_id": None,
             }
 
             # Map RemovedGroup to categories_removed for output

--- a/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/result_builder.py
+++ b/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/result_builder.py
@@ -16,8 +16,11 @@ from waivern_schemas.personal_data_indicator import (
     PersonalDataIndicatorOutput,
     PersonalDataIndicatorSummary,
 )
+from waivern_schemas.removed_findings import RemovedFinding, RemovedFindingsOutput
 
 from .types import PersonalDataAnalyserConfig
+
+_REMOVED_FINDINGS_SCHEMA = Schema("removed_findings", "1.0.0")
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +86,58 @@ class PersonalDataResultBuilder:
         )
 
         return output_message
+
+    def build_sidecars(
+        self,
+        validation_result: ValidationResult[PersonalDataIndicatorModel] | None,
+        run_id: str,
+    ) -> list[Message]:
+        """Build the analyser's sidecar Messages.
+
+        Dispatches to one private builder per sidecar type. Each builder
+        returns ``Message | None`` so this method can filter the absent ones
+        out — a sidecar is "absent" when there is no content to record.
+        Adding a new sidecar type is a new ``_build_X_sidecar`` method plus
+        one line here; the analyser call site does not change.
+        """
+        candidates = [
+            self._build_removed_findings_sidecar(validation_result, run_id),
+        ]
+        return [s for s in candidates if s is not None]
+
+    def _build_removed_findings_sidecar(
+        self,
+        validation_result: ValidationResult[PersonalDataIndicatorModel] | None,
+        run_id: str,
+    ) -> Message | None:
+        """Build the audit-trail sidecar listing LLM-removed findings.
+
+        Returns None when validation was disabled or produced no removals —
+        there is no audit content to record.
+        """
+        if validation_result is None or not validation_result.removed_findings:
+            return None
+
+        payload = RemovedFindingsOutput(
+            analyser_name="personal_data_analyser",
+            run_id=run_id,
+            ruleset=self._config.pattern_matching.ruleset,
+            removed_findings=[
+                RemovedFinding(
+                    original_finding=item.finding.model_dump(mode="json"),
+                    reason=item.reason,
+                )
+                for item in validation_result.removed_findings
+            ],
+        )
+
+        sidecar = Message(
+            id=f"personal_data_removed_findings_{datetime.now(UTC).isoformat()}",
+            content=payload.model_dump(mode="json"),
+            schema=_REMOVED_FINDINGS_SCHEMA,
+        )
+        sidecar.validate()
+        return sidecar
 
     def _build_findings_summary(
         self, findings: list[PersonalDataIndicatorModel]

--- a/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_distributed.py
+++ b/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_distributed.py
@@ -251,11 +251,13 @@ class TestFinalise:
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
         # Findings preserved without filtering
         assert len(result.content["findings"]) == len(prepare_result.state.all_findings)
+        # LLM never ran → no audit content
+        assert sidecars == []
 
     def test_no_findings_produces_empty_output(self) -> None:
         """Empty findings state → empty output, no validation_summary."""
@@ -265,10 +267,12 @@ class TestFinalise:
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert result.content["findings"] == []
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
+        # No findings → no removals → no audit content
+        assert sidecars == []
 
     def test_llm_result_filters_false_positives_and_marks_kept(self) -> None:
         """LLM TRUE_POSITIVE/FALSE_POSITIVE verdicts → filtering + marking."""
@@ -295,7 +299,7 @@ class TestFinalise:
             prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
         )
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert "validation_summary" in metadata
@@ -312,6 +316,55 @@ class TestFinalise:
             is True
         )
 
+        # FALSE_POSITIVE removal produced an audit-trail sidecar
+        assert len(sidecars) == 1
+        sidecar = sidecars[0]
+        assert sidecar.schema == Schema("removed_findings", "1.0.0")
+        assert sidecar.content["analyser_name"] == "personal_data_analyser"
+        assert sidecar.content["run_id"] == RUN_ID
+        assert sidecar.content["ruleset"] == _UNUSED_RULESET_URI
+        assert len(sidecar.content["removed_findings"]) >= 1
+
+    def test_sidecar_carries_serialised_finding_and_reason(self) -> None:
+        """Each RemovedFinding has matching id and reason verbatim from the LLM verdict.
+
+        Cascade-reason synthesis (``"Inferred — …"`` prefix) is exercised at
+        the orchestrator layer (Step 3); here we only need to confirm that
+        whatever ``reason`` the orchestrator attaches to a ``RemovedItem``
+        reaches the sidecar entry verbatim.
+        """
+        analyser = _make_analyser()
+        message = _make_email_phone_message()
+
+        prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
+        assert prepare_result.state.orchestrator_state is not None
+        sampled = prepare_result.state.orchestrator_state.strategy_findings
+
+        # Mark all sampled findings FALSE_POSITIVE → every sample ends up in
+        # removed_findings with the LLM verdict's reasoning attached.
+        assert isinstance(prepare_result.requests[0], LLMRequest)
+        llm_request = cast(
+            LLMRequest[PersonalDataIndicatorModel], prepare_result.requests[0]
+        )
+        verdicts = {f.id: "FALSE_POSITIVE" for f in sampled}
+        dispatch_result = _build_llm_dispatch_result(llm_request, verdicts)
+
+        finalise_outcome = analyser.finalise(
+            prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        _result, sidecars = finalise_outcome
+        assert len(sidecars) == 1
+        removed = sidecars[0].content["removed_findings"]
+        assert len(removed) >= 1
+
+        sampled_ids = {f.id for f in sampled}
+        for entry in removed:
+            assert entry["original_finding"]["id"] in sampled_ids
+            # LLM-direct reasons preserve the verdict's reasoning verbatim.
+            # _build_llm_dispatch_result attaches "test reasoning" to every result.
+            assert entry["reason"] == "test reasoning"
+
     def test_missing_llm_result_treats_all_as_skipped_with_failure(self) -> None:
         """No LLM result (e.g. dispatcher error) → findings kept, all_succeeded=False."""
         analyser = _make_analyser()
@@ -323,13 +376,15 @@ class TestFinalise:
         # and all strategy findings are categorised as skipped (BATCH_ERROR).
         finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert metadata["validation_summary"]["all_succeeded"] is False
         assert metadata["validation_summary"]["skipped_count"] > 0
         # Conservative keep: findings preserved
         assert len(result.content["findings"]) >= 1
+        # BATCH_ERROR never reached the LLM → no removals → no audit content
+        assert sidecars == []
 
 
 # =============================================================================

--- a/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_distributed.py
+++ b/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_distributed.py
@@ -252,8 +252,9 @@ class TestFinalise:
         message = _make_email_phone_message()
 
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
-        result = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
-
+        finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
         # Findings preserved without filtering
@@ -265,8 +266,9 @@ class TestFinalise:
         message = _make_no_pattern_message()
 
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
-        result = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
-
+        finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert result.content["findings"] == []
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
@@ -292,10 +294,11 @@ class TestFinalise:
         }
         dispatch_result = _build_llm_dispatch_result(llm_request, verdicts)
 
-        result = analyser.finalise(
+        finalise_outcome = analyser.finalise(
             prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
         )
-
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert "validation_summary" in metadata
@@ -321,8 +324,9 @@ class TestFinalise:
 
         # Empty results list: the orchestrator treats this as a failed dispatch
         # and all strategy findings are categorised as skipped (BATCH_ERROR).
-        result = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
-
+        finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert metadata["validation_summary"]["all_succeeded"] is False

--- a/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_distributed.py
+++ b/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_distributed.py
@@ -12,15 +12,12 @@ production ruleset data.
 from typing import Any, cast
 
 import pytest
-from waivern_analysers_shared.llm_validation.models import (
-    LLMValidationResponseModel,
-    LLMValidationResultModel,
-)
 from waivern_analysers_shared.llm_validation.validation_orchestrator import (
     OrchestratorPrepareState,
 )
 from waivern_analysers_shared.types import LLMValidationConfig, PatternMatchingConfig
 from waivern_analysers_shared.utilities import RulesetManager
+from waivern_core import LLMValidationResponseModel, LLMValidationResultModel
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
 from waivern_llm.types import BatchingMode, LLMDispatchResult, LLMRequest

--- a/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_distributed.py
+++ b/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_distributed.py
@@ -274,6 +274,37 @@ class TestFinalise:
         # No findings → no removals → no audit content
         assert sidecars == []
 
+    def test_validation_summary_pre_emits_removed_findings_artifact_id_as_none(
+        self,
+    ) -> None:
+        """When validation ran, ``validation_summary.removed_findings_artifact_id`` is None.
+
+        The analyser pre-emits ``None`` so the key is always present once
+        validation ran; the executor overwrites it with the sidecar's
+        artifact_id when removals occurred. Tests the analyser-side half of
+        the audit-trail back-reference contract.
+        """
+        analyser = _make_analyser()
+        message = _make_email_phone_message()
+
+        prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
+        assert isinstance(prepare_result.requests[0], LLMRequest)
+        llm_request = cast(
+            LLMRequest[PersonalDataIndicatorModel], prepare_result.requests[0]
+        )
+        # No removals: every sampled finding TRUE_POSITIVE.
+        sampled = prepare_result.state.orchestrator_state.strategy_findings  # pyright: ignore[reportOptionalMemberAccess]
+        verdicts = {f.id: "TRUE_POSITIVE" for f in sampled}
+        dispatch_result = _build_llm_dispatch_result(llm_request, verdicts)
+
+        finalise_outcome = analyser.finalise(
+            prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
+        validation_summary = result.content["analysis_metadata"]["validation_summary"]
+        assert validation_summary["removed_findings_artifact_id"] is None
+
     def test_llm_result_filters_false_positives_and_marks_kept(self) -> None:
         """LLM TRUE_POSITIVE/FALSE_POSITIVE verdicts → filtering + marking."""
         analyser = _make_analyser()

--- a/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/analyser.py
+++ b/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/analyser.py
@@ -162,7 +162,7 @@ class ProcessingPurposeAnalyser(Analyser):
                 output_schema,
                 validation_result=None,
             )
-            return primary, []
+            return primary, self._result_builder.build_sidecars(None, state.run_id)
 
         orchestrator = self._rebuild_orchestrator(state)
         llm_result = self._extract_llm_result(results)
@@ -189,7 +189,7 @@ class ProcessingPurposeAnalyser(Analyser):
             output_schema,
             validation_result=outcome,
         )
-        return primary, []
+        return primary, self._result_builder.build_sidecars(outcome, state.run_id)
 
     def deserialise_prepare_result(
         self, raw: dict[str, Any]

--- a/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/analyser.py
+++ b/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/analyser.py
@@ -144,7 +144,7 @@ class ProcessingPurposeAnalyser(Analyser):
         state: ProcessingPurposePrepareState,
         results: Sequence[DispatchResult],
         output_schema: Schema,
-    ) -> Message | PrepareResult[ProcessingPurposePrepareState]:
+    ) -> tuple[Message, list[Message]] | PrepareResult[ProcessingPurposePrepareState]:
         """Produce output from state and dispatch results.
 
         Paths:
@@ -157,11 +157,12 @@ class ProcessingPurposeAnalyser(Analyser):
           ``finalise()`` merges primary + fallback outcomes into a Message.
         """
         if not state.llm_enabled or state.orchestrator_state is None:
-            return self._result_builder.build_output_message(
+            primary = self._result_builder.build_output_message(
                 state.all_findings,
                 output_schema,
                 validation_result=None,
             )
+            return primary, []
 
         orchestrator = self._rebuild_orchestrator(state)
         llm_result = self._extract_llm_result(results)
@@ -183,11 +184,12 @@ class ProcessingPurposeAnalyser(Analyser):
             f"({len(outcome.removed_groups)} groups removed)"
         )
 
-        return self._result_builder.build_output_message(
+        primary = self._result_builder.build_output_message(
             outcome.kept_findings,
             output_schema,
             validation_result=outcome,
         )
+        return primary, []
 
     def deserialise_prepare_result(
         self, raw: dict[str, Any]

--- a/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/llm_validation_strategy.py
+++ b/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/llm_validation_strategy.py
@@ -2,9 +2,9 @@
 
 from typing import override
 
-from waivern_analysers_shared.llm_validation.models import LLMValidationResponseModel
 from waivern_analysers_shared.llm_validation.strategy import FilteringValidationStrategy
 from waivern_analysers_shared.types import LLMValidationConfig
+from waivern_core import LLMValidationResponseModel
 from waivern_llm import BatchingMode, ItemGroup, LLMRequest
 from waivern_schemas.processing_purpose_indicator import ProcessingPurposeIndicatorModel
 

--- a/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/result_builder.py
+++ b/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/result_builder.py
@@ -16,8 +16,11 @@ from waivern_schemas.processing_purpose_indicator import (
     ProcessingPurposeIndicatorSummary,
     PurposeBreakdown,
 )
+from waivern_schemas.removed_findings import RemovedFinding, RemovedFindingsOutput
 
 from .types import ProcessingPurposeAnalyserConfig
+
+_REMOVED_FINDINGS_SCHEMA = Schema("removed_findings", "1.0.0")
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +81,58 @@ class ProcessingPurposeResultBuilder:
         )
 
         return output_message
+
+    def build_sidecars(
+        self,
+        validation_result: ValidationResult[ProcessingPurposeIndicatorModel] | None,
+        run_id: str,
+    ) -> list[Message]:
+        """Build the analyser's sidecar Messages.
+
+        Dispatches to one private builder per sidecar type. Each builder
+        returns ``Message | None`` so this method can filter the absent ones
+        out — a sidecar is "absent" when there is no content to record.
+        Adding a new sidecar type is a new ``_build_X_sidecar`` method plus
+        one line here; the analyser call site does not change.
+        """
+        candidates = [
+            self._build_removed_findings_sidecar(validation_result, run_id),
+        ]
+        return [s for s in candidates if s is not None]
+
+    def _build_removed_findings_sidecar(
+        self,
+        validation_result: ValidationResult[ProcessingPurposeIndicatorModel] | None,
+        run_id: str,
+    ) -> Message | None:
+        """Build the audit-trail sidecar listing LLM-removed findings.
+
+        Returns None when validation was disabled or produced no removals —
+        there is no audit content to record.
+        """
+        if validation_result is None or not validation_result.removed_findings:
+            return None
+
+        payload = RemovedFindingsOutput(
+            analyser_name="processing_purpose_analyser",
+            run_id=run_id,
+            ruleset=self._config.pattern_matching.ruleset,
+            removed_findings=[
+                RemovedFinding(
+                    original_finding=item.finding.model_dump(mode="json"),
+                    reason=item.reason,
+                )
+                for item in validation_result.removed_findings
+            ],
+        )
+
+        sidecar = Message(
+            id=f"processing_purpose_removed_findings_{datetime.now(UTC).isoformat()}",
+            content=payload.model_dump(mode="json"),
+            schema=_REMOVED_FINDINGS_SCHEMA,
+        )
+        sidecar.validate()
+        return sidecar
 
     def _build_findings_summary(
         self, findings: list[ProcessingPurposeIndicatorModel]

--- a/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/result_builder.py
+++ b/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/result_builder.py
@@ -189,6 +189,10 @@ class ProcessingPurposeResultBuilder:
                 "samples_validated": validation_result.samples_validated,
                 "all_succeeded": validation_result.all_succeeded,
                 "skipped_count": len(validation_result.skipped_samples),
+                # Pre-emitted so the key is always present once validation ran;
+                # DAGExecutor stamps the sidecar's artifact_id when removals
+                # produced an audit-trail sidecar.
+                "removed_findings_artifact_id": None,
             }
 
             # Map RemovedGroup to purposes_removed for backwards compatibility

--- a/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/validation/extended_context_strategy.py
+++ b/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/validation/extended_context_strategy.py
@@ -8,11 +8,11 @@ categorisation is inherited from ``FilteringValidationStrategy``.
 from typing import override
 
 from pydantic import BaseModel
-from waivern_analysers_shared.llm_validation.models import LLMValidationResponseModel
 from waivern_analysers_shared.llm_validation.strategy import (
     FilteringValidationStrategy,
 )
 from waivern_analysers_shared.types import LLMValidationConfig
+from waivern_core import LLMValidationResponseModel
 from waivern_core.types import JsonValue
 from waivern_llm import BatchingMode, ItemGroup, LLMRequest
 from waivern_schemas.processing_purpose_indicator import (

--- a/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_distributed.py
+++ b/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_distributed.py
@@ -305,11 +305,13 @@ class TestFinalise:
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
         # Findings preserved without filtering
         assert len(result.content["findings"]) == len(prepare_result.state.all_findings)
+        # LLM never ran → no audit content
+        assert sidecars == []
 
     def test_no_findings_produces_empty_output(self) -> None:
         """Empty findings state → empty output, no validation_summary."""
@@ -319,10 +321,12 @@ class TestFinalise:
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
         finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert result.content["findings"] == []
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
+        # No findings → no removals → no audit content
+        assert sidecars == []
 
     def test_llm_result_filters_false_positives_and_marks_kept(self) -> None:
         """LLM TRUE_POSITIVE/FALSE_POSITIVE verdicts → filtering + marker."""
@@ -346,7 +350,7 @@ class TestFinalise:
             prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
         )
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert "validation_summary" in metadata
@@ -362,6 +366,8 @@ class TestFinalise:
                     )
                     is True
                 )
+        # All-TRUE_POSITIVE verdicts → no removals → no audit content
+        assert sidecars == []
 
     def test_missing_llm_result_treats_all_as_skipped_with_failure(self) -> None:
         """No LLM result (e.g. dispatcher error) → findings kept, all_succeeded=False.
@@ -380,13 +386,59 @@ class TestFinalise:
         # and every strategy finding is categorised as skipped (BATCH_ERROR).
         finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
         assert isinstance(finalise_outcome, tuple)
-        result, _sidecars = finalise_outcome
+        result, sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert metadata["validation_summary"]["all_succeeded"] is False
         assert metadata["validation_summary"]["skipped_count"] > 0
         # Conservative keep: every original finding preserved
         assert len(result.content["findings"]) == original_count
+        # BATCH_ERROR never reached the LLM → no removals → no audit content
+        assert sidecars == []
+
+    def test_sidecar_carries_serialised_finding_and_reason(self) -> None:
+        """FALSE_POSITIVE removals → one sidecar with identity fields and serialised entries.
+
+        Cascade-reason synthesis (``"Inferred — …"`` prefix) is exercised at
+        the orchestrator layer (Step 3); here we only need to confirm that
+        whatever ``reason`` the orchestrator attaches to a ``RemovedItem``
+        reaches the sidecar entry verbatim, and that the wrapper carries the
+        analyser identity for cross-artifact correlation.
+        """
+        analyser = _make_analyser()
+        message = _make_standard_input_purpose_message()
+
+        prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
+        assert prepare_result.state.orchestrator_state is not None
+        sampled = prepare_result.state.orchestrator_state.strategy_findings
+
+        assert isinstance(prepare_result.requests[0], LLMRequest)
+        llm_request = cast(
+            LLMRequest[ProcessingPurposeIndicatorModel], prepare_result.requests[0]
+        )
+        verdicts = {f.id: "FALSE_POSITIVE" for f in sampled}
+        dispatch_result = _build_llm_dispatch_result(llm_request, verdicts)
+
+        finalise_outcome = analyser.finalise(
+            prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        _result, sidecars = finalise_outcome
+        assert len(sidecars) == 1
+        sidecar = sidecars[0]
+        assert sidecar.schema == Schema("removed_findings", "1.0.0")
+        assert sidecar.content["analyser_name"] == "processing_purpose_analyser"
+        assert sidecar.content["run_id"] == RUN_ID
+        assert sidecar.content["ruleset"] == "local/processing_purposes/1.0.0"
+
+        removed = sidecar.content["removed_findings"]
+        assert len(removed) >= 1
+        sampled_ids = {f.id for f in sampled}
+        for entry in removed:
+            assert entry["original_finding"]["id"] in sampled_ids
+            # LLM-direct reasons preserve the verdict's reasoning verbatim.
+            # _build_llm_dispatch_result attaches "test reasoning" to every result.
+            assert entry["reason"] == "test reasoning"
 
 
 # =============================================================================
@@ -477,10 +529,12 @@ class TestFinaliseMultiRound:
             round_two_prep.state, [fallback_result], OUTPUT_SCHEMA
         )
         assert isinstance(finalise_outcome, tuple)
-        final, _sidecars = finalise_outcome
+        final, sidecars = finalise_outcome
         assert isinstance(final, Message)
         metadata = final.content["analysis_metadata"]
         assert "validation_summary" in metadata
+        # Both rounds verdicted TRUE_POSITIVE → no removals → no audit content
+        assert sidecars == []
 
     def test_source_code_without_eligible_skipped_completes_in_single_round(
         self,
@@ -506,8 +560,10 @@ class TestFinaliseMultiRound:
             prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
         )
         assert isinstance(finalise_outcome, tuple)
-        outcome, _sidecars = finalise_outcome
+        outcome, sidecars = finalise_outcome
         assert isinstance(outcome, Message)
+        # All TRUE_POSITIVE → no removals → no audit content
+        assert sidecars == []
 
     def test_fallback_round_marker_applied_to_both_primary_and_fallback_kept(
         self,
@@ -554,8 +610,10 @@ class TestFinaliseMultiRound:
             round_two_prep.state, [fallback_result], OUTPUT_SCHEMA
         )
         assert isinstance(finalise_outcome, tuple)
-        final, _sidecars = finalise_outcome
+        final, sidecars = finalise_outcome
         assert isinstance(final, Message)
+        # Both rounds verdicted TRUE_POSITIVE → no removals → no audit content
+        assert sidecars == []
         findings_by_id = {f["id"]: f for f in final.content["findings"]}
         # Primary-validated finding carries marker
         assert (

--- a/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_distributed.py
+++ b/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_distributed.py
@@ -328,6 +328,35 @@ class TestFinalise:
         # No findings → no removals → no audit content
         assert sidecars == []
 
+    def test_validation_summary_pre_emits_removed_findings_artifact_id_as_none(
+        self,
+    ) -> None:
+        """When validation ran, ``validation_summary.removed_findings_artifact_id`` is None.
+
+        The analyser pre-emits ``None`` so the key is always present once
+        validation ran; the executor overwrites it with the sidecar's
+        artifact_id when removals produced an audit-trail sidecar.
+        """
+        analyser = _make_analyser()
+        message = _make_standard_input_purpose_message()
+
+        prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
+        assert isinstance(prepare_result.requests[0], LLMRequest)
+        llm_request = cast(
+            LLMRequest[ProcessingPurposeIndicatorModel], prepare_result.requests[0]
+        )
+        sampled = prepare_result.state.orchestrator_state.strategy_findings  # pyright: ignore[reportOptionalMemberAccess]
+        verdicts = {f.id: "TRUE_POSITIVE" for f in sampled}
+        dispatch_result = _build_llm_dispatch_result(llm_request, verdicts)
+
+        finalise_outcome = analyser.finalise(
+            prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
+        validation_summary = result.content["analysis_metadata"]["validation_summary"]
+        assert validation_summary["removed_findings_artifact_id"] is None
+
     def test_llm_result_filters_false_positives_and_marks_kept(self) -> None:
         """LLM TRUE_POSITIVE/FALSE_POSITIVE verdicts → filtering + marker."""
         analyser = _make_analyser()

--- a/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_distributed.py
+++ b/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_distributed.py
@@ -306,8 +306,9 @@ class TestFinalise:
         message = _make_standard_input_purpose_message()
 
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
-        result = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
-
+        finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
         # Findings preserved without filtering
@@ -319,8 +320,9 @@ class TestFinalise:
         message = _make_no_pattern_message()
 
         prepare_result = analyser.prepare(inputs=[message], output_schema=OUTPUT_SCHEMA)
-        result = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
-
+        finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         assert result.content["findings"] == []
         assert "validation_summary" not in result.content.get("analysis_metadata", {})
@@ -343,10 +345,11 @@ class TestFinalise:
         verdicts = {f.id: "TRUE_POSITIVE" for f in sampled}
         dispatch_result = _build_llm_dispatch_result(llm_request, verdicts)
 
-        result = analyser.finalise(
+        finalise_outcome = analyser.finalise(
             prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
         )
-
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert "validation_summary" in metadata
@@ -378,8 +381,9 @@ class TestFinalise:
 
         # Empty results list: orchestrator treats this as a failed dispatch
         # and every strategy finding is categorised as skipped (BATCH_ERROR).
-        result = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
-
+        finalise_outcome = analyser.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
         assert isinstance(result, Message)
         metadata = result.content["analysis_metadata"]
         assert metadata["validation_summary"]["all_succeeded"] is False
@@ -472,10 +476,11 @@ class TestFinaliseMultiRound:
             verdicts={sampled[0].id: "TRUE_POSITIVE"},
         )
 
-        final = analyser.finalise(
+        finalise_outcome = analyser.finalise(
             round_two_prep.state, [fallback_result], OUTPUT_SCHEMA
         )
-
+        assert isinstance(finalise_outcome, tuple)
+        final, _sidecars = finalise_outcome
         assert isinstance(final, Message)
         metadata = final.content["analysis_metadata"]
         assert "validation_summary" in metadata
@@ -500,10 +505,11 @@ class TestFinaliseMultiRound:
             llm_request, verdicts={f.id: "TRUE_POSITIVE" for f in sampled}
         )
 
-        outcome = analyser.finalise(
+        finalise_outcome = analyser.finalise(
             prepare_result.state, [dispatch_result], OUTPUT_SCHEMA
         )
-
+        assert isinstance(finalise_outcome, tuple)
+        outcome, _sidecars = finalise_outcome
         assert isinstance(outcome, Message)
 
     def test_fallback_round_marker_applied_to_both_primary_and_fallback_kept(
@@ -547,10 +553,11 @@ class TestFinaliseMultiRound:
             fallback_request,
             verdicts={fallback_kept.id: "TRUE_POSITIVE"},
         )
-        final = analyser.finalise(
+        finalise_outcome = analyser.finalise(
             round_two_prep.state, [fallback_result], OUTPUT_SCHEMA
         )
-
+        assert isinstance(finalise_outcome, tuple)
+        final, _sidecars = finalise_outcome
         assert isinstance(final, Message)
         findings_by_id = {f["id"]: f for f in final.content["findings"]}
         # Primary-validated finding carries marker

--- a/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_distributed.py
+++ b/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_distributed.py
@@ -7,14 +7,11 @@ skipped findings.
 
 from typing import Any, cast
 
-from waivern_analysers_shared.llm_validation.models import (
-    LLMValidationResponseModel,
-    LLMValidationResultModel,
-)
 from waivern_analysers_shared.llm_validation.validation_orchestrator import (
     OrchestratorPrepareState,
 )
 from waivern_analysers_shared.types import LLMValidationConfig, PatternMatchingConfig
+from waivern_core import LLMValidationResponseModel, LLMValidationResultModel
 from waivern_core.dispatch import PrepareResult
 from waivern_core.message import Message
 from waivern_core.schemas import Schema

--- a/libs/waivern-schemas/scripts/generate-schemas.sh
+++ b/libs/waivern-schemas/scripts/generate-schemas.sh
@@ -37,6 +37,7 @@ schemas = [
     ('waivern_schemas.security_evidence.v1', 'SecurityEvidenceOutput', 'security_evidence'),
     ('waivern_schemas.security_document_context.v1', 'SecurityDocumentContextOutput', 'security_document_context'),
     ('waivern_schemas.iso27001_assessment.v1', 'ISO27001AssessmentOutput', 'iso27001_assessment'),
+    ('waivern_schemas.removed_findings.v1', 'RemovedFindingsOutput', 'removed_findings'),
 ]
 
 import importlib

--- a/libs/waivern-schemas/src/waivern_schemas/json_schemas/removed_findings/1.0.0/removed_findings.json
+++ b/libs/waivern-schemas/src/waivern_schemas/json_schemas/removed_findings/1.0.0/removed_findings.json
@@ -31,57 +31,8 @@
         }
       ]
     },
-    "LLMValidationResultModel": {
-      "description": "Strongly typed model for LLM validation results.\n\nThis model represents a single validation result from the LLM, including\nthe finding ID for explicit matching back to the original finding.\nUsing UUIDs instead of indices makes matching robust against LLM reordering.",
-      "properties": {
-        "finding_id": {
-          "description": "UUID of the finding this result corresponds to (echo back exactly)",
-          "minLength": 1,
-          "title": "Finding Id",
-          "type": "string"
-        },
-        "validation_result": {
-          "default": "TRUE_POSITIVE",
-          "description": "The validation result",
-          "enum": [
-            "TRUE_POSITIVE",
-            "FALSE_POSITIVE"
-          ],
-          "title": "Validation Result",
-          "type": "string"
-        },
-        "confidence": {
-          "default": 0.0,
-          "description": "Confidence score from LLM (0.0-1.0)",
-          "title": "Confidence",
-          "type": "number"
-        },
-        "reasoning": {
-          "default": "No reasoning provided",
-          "description": "Reasoning provided by LLM",
-          "title": "Reasoning",
-          "type": "string"
-        },
-        "recommended_action": {
-          "default": "keep",
-          "description": "Recommended action from LLM",
-          "enum": [
-            "keep",
-            "discard",
-            "flag_for_review"
-          ],
-          "title": "Recommended Action",
-          "type": "string"
-        }
-      },
-      "required": [
-        "finding_id"
-      ],
-      "title": "LLMValidationResultModel",
-      "type": "object"
-    },
     "RemovedFinding": {
-      "description": "Single finding removed by LLM validation, paired with its verdict.\n\n``original_finding`` is stored as a JSON-serialised dict so that the\naudit-trail schema is decoupled from the producer analyser's specific\nfinding type. Migration across analyser-side schema versions is handled\nby pure forward-migration functions at read time.",
+      "description": "Single finding removed by LLM validation, paired with its removal reason.\n\n``original_finding`` is stored as a JSON-serialised dict so that the\naudit-trail schema is decoupled from the producer analyser's specific\nfinding type. Migration across analyser-side schema versions is handled\nby pure forward-migration functions at read time.",
       "properties": {
         "original_finding": {
           "additionalProperties": {
@@ -91,9 +42,10 @@
           "title": "Original Finding",
           "type": "object"
         },
-        "llm_verdict": {
-          "$ref": "#/$defs/LLMValidationResultModel",
-          "description": "The LLM verdict that caused the finding to be removed"
+        "reason": {
+          "description": "Human-readable removal reason. For LLM-direct removals this is the LLM's verdict reasoning verbatim; for group cascade removals it is a synthesised 'Inferred \u2014 \u2026' string explaining the cascade.",
+          "title": "Reason",
+          "type": "string"
         },
         "removal_timestamp": {
           "description": "When this finding was removed",
@@ -103,7 +55,7 @@
       },
       "required": [
         "original_finding",
-        "llm_verdict"
+        "reason"
       ],
       "title": "RemovedFinding",
       "type": "object"
@@ -148,7 +100,7 @@
       "title": "Ruleset Version"
     },
     "removed_findings": {
-      "description": "Findings removed during LLM validation, each paired with its verdict",
+      "description": "Findings removed during LLM validation, each paired with its removal reason",
       "items": {
         "$ref": "#/$defs/RemovedFinding"
       },

--- a/libs/waivern-schemas/src/waivern_schemas/json_schemas/removed_findings/1.0.0/removed_findings.json
+++ b/libs/waivern-schemas/src/waivern_schemas/json_schemas/removed_findings/1.0.0/removed_findings.json
@@ -73,7 +73,7 @@
       "title": "Run Id",
       "type": "string"
     },
-    "ruleset_name": {
+    "ruleset": {
       "anyOf": [
         {
           "type": "string"
@@ -83,21 +83,8 @@
         }
       ],
       "default": null,
-      "description": "Ruleset URI used for pattern matching. ``None`` when the producing analyser is not ruleset-driven.",
-      "title": "Ruleset Name"
-    },
-    "ruleset_version": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Version of the ruleset referenced by ``ruleset_name``",
-      "title": "Ruleset Version"
+      "description": "Ruleset URI used for pattern matching, in the framework's standard ``provider/name/version`` form (e.g. ``local/personal_data_indicator/1.0.0``). ``None`` when the producing analyser is not ruleset-driven.",
+      "title": "Ruleset"
     },
     "removed_findings": {
       "description": "Findings removed during LLM validation, each paired with its removal reason",

--- a/libs/waivern-schemas/src/waivern_schemas/json_schemas/removed_findings/1.0.0/removed_findings.json
+++ b/libs/waivern-schemas/src/waivern_schemas/json_schemas/removed_findings/1.0.0/removed_findings.json
@@ -1,0 +1,168 @@
+{
+  "$defs": {
+    "JsonValue": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/JsonValue"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonValue"
+          },
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "LLMValidationResultModel": {
+      "description": "Strongly typed model for LLM validation results.\n\nThis model represents a single validation result from the LLM, including\nthe finding ID for explicit matching back to the original finding.\nUsing UUIDs instead of indices makes matching robust against LLM reordering.",
+      "properties": {
+        "finding_id": {
+          "description": "UUID of the finding this result corresponds to (echo back exactly)",
+          "minLength": 1,
+          "title": "Finding Id",
+          "type": "string"
+        },
+        "validation_result": {
+          "default": "TRUE_POSITIVE",
+          "description": "The validation result",
+          "enum": [
+            "TRUE_POSITIVE",
+            "FALSE_POSITIVE"
+          ],
+          "title": "Validation Result",
+          "type": "string"
+        },
+        "confidence": {
+          "default": 0.0,
+          "description": "Confidence score from LLM (0.0-1.0)",
+          "title": "Confidence",
+          "type": "number"
+        },
+        "reasoning": {
+          "default": "No reasoning provided",
+          "description": "Reasoning provided by LLM",
+          "title": "Reasoning",
+          "type": "string"
+        },
+        "recommended_action": {
+          "default": "keep",
+          "description": "Recommended action from LLM",
+          "enum": [
+            "keep",
+            "discard",
+            "flag_for_review"
+          ],
+          "title": "Recommended Action",
+          "type": "string"
+        }
+      },
+      "required": [
+        "finding_id"
+      ],
+      "title": "LLMValidationResultModel",
+      "type": "object"
+    },
+    "RemovedFinding": {
+      "description": "Single finding removed by LLM validation, paired with its verdict.\n\n``original_finding`` is stored as a JSON-serialised dict so that the\naudit-trail schema is decoupled from the producer analyser's specific\nfinding type. Migration across analyser-side schema versions is handled\nby pure forward-migration functions at read time.",
+      "properties": {
+        "original_finding": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonValue"
+          },
+          "description": "Serialised form of the analyser's finding at the time of removal",
+          "title": "Original Finding",
+          "type": "object"
+        },
+        "llm_verdict": {
+          "$ref": "#/$defs/LLMValidationResultModel",
+          "description": "The LLM verdict that caused the finding to be removed"
+        },
+        "removal_timestamp": {
+          "description": "When this finding was removed",
+          "title": "Removal Timestamp",
+          "type": "string"
+        }
+      },
+      "required": [
+        "original_finding",
+        "llm_verdict"
+      ],
+      "title": "RemovedFinding",
+      "type": "object"
+    }
+  },
+  "description": "Sidecar audit-trail payload listing findings removed by LLM validation.\n\nCarries enough context (analyser identity, run ID, ruleset reference) to\nbe interpreted on its own without reference to the primary output, which\nis required for downstream tooling that aggregates audit data across\nruns.",
+  "properties": {
+    "analyser_name": {
+      "description": "Name of the analyser that produced this audit trail",
+      "title": "Analyser Name",
+      "type": "string"
+    },
+    "run_id": {
+      "description": "Run ID for cross-artifact correlation",
+      "title": "Run Id",
+      "type": "string"
+    },
+    "ruleset_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Ruleset URI used for pattern matching. ``None`` when the producing analyser is not ruleset-driven.",
+      "title": "Ruleset Name"
+    },
+    "ruleset_version": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Version of the ruleset referenced by ``ruleset_name``",
+      "title": "Ruleset Version"
+    },
+    "removed_findings": {
+      "description": "Findings removed during LLM validation, each paired with its verdict",
+      "items": {
+        "$ref": "#/$defs/RemovedFinding"
+      },
+      "title": "Removed Findings",
+      "type": "array"
+    }
+  },
+  "required": [
+    "analyser_name",
+    "run_id",
+    "removed_findings"
+  ],
+  "title": "RemovedFindingsOutput",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "version": "1.0.0"
+}

--- a/libs/waivern-schemas/src/waivern_schemas/removed_findings/__init__.py
+++ b/libs/waivern-schemas/src/waivern_schemas/removed_findings/__init__.py
@@ -1,0 +1,14 @@
+"""Removed findings audit-trail schema types.
+
+Re-exports from the current version (v1).
+"""
+
+from waivern_schemas.removed_findings.v1 import (
+    RemovedFinding,
+    RemovedFindingsOutput,
+)
+
+__all__ = [
+    "RemovedFinding",
+    "RemovedFindingsOutput",
+]

--- a/libs/waivern-schemas/src/waivern_schemas/removed_findings/v1.py
+++ b/libs/waivern-schemas/src/waivern_schemas/removed_findings/v1.py
@@ -1,0 +1,77 @@
+"""Schema data models for the removed-findings audit trail.
+
+Persisted as a sidecar Message alongside the primary analyser output when LLM
+validation removes findings. Each entry pairs the original finding's
+serialised form with the LLM verdict that drove its removal.
+"""
+
+from datetime import UTC, datetime
+from typing import Annotated, ClassVar
+
+from pydantic import BaseModel, Field, PlainSerializer
+from waivern_core import LLMValidationResultModel
+from waivern_core.schemas import BaseSchemaOutput
+from waivern_core.types import JsonValue
+
+
+class RemovedFinding(BaseModel):
+    """Single finding removed by LLM validation, paired with its verdict.
+
+    ``original_finding`` is stored as a JSON-serialised dict so that the
+    audit-trail schema is decoupled from the producer analyser's specific
+    finding type. Migration across analyser-side schema versions is handled
+    by pure forward-migration functions at read time.
+    """
+
+    original_finding: dict[str, JsonValue] = Field(
+        description="Serialised form of the analyser's finding at the time of removal",
+    )
+    llm_verdict: LLMValidationResultModel = Field(
+        description="The LLM verdict that caused the finding to be removed",
+    )
+    removal_timestamp: Annotated[
+        datetime,
+        PlainSerializer(lambda v: v.isoformat(), return_type=str, when_used="json"),
+    ] = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="When this finding was removed",
+    )
+
+
+class RemovedFindingsOutput(BaseSchemaOutput):
+    """Sidecar audit-trail payload listing findings removed by LLM validation.
+
+    Carries enough context (analyser identity, run ID, ruleset reference) to
+    be interpreted on its own without reference to the primary output, which
+    is required for downstream tooling that aggregates audit data across
+    runs.
+    """
+
+    __schema_version__: ClassVar[str] = "1.0.0"
+
+    analyser_name: str = Field(
+        description="Name of the analyser that produced this audit trail",
+    )
+    run_id: str = Field(
+        description="Run ID for cross-artifact correlation",
+    )
+    ruleset_name: str | None = Field(
+        default=None,
+        description=(
+            "Ruleset URI used for pattern matching. ``None`` when the producing "
+            "analyser is not ruleset-driven."
+        ),
+    )
+    ruleset_version: str | None = Field(
+        default=None,
+        description="Version of the ruleset referenced by ``ruleset_name``",
+    )
+    removed_findings: list[RemovedFinding] = Field(
+        description="Findings removed during LLM validation, each paired with its verdict",
+    )
+
+
+__all__ = [
+    "RemovedFinding",
+    "RemovedFindingsOutput",
+]

--- a/libs/waivern-schemas/src/waivern_schemas/removed_findings/v1.py
+++ b/libs/waivern-schemas/src/waivern_schemas/removed_findings/v1.py
@@ -2,20 +2,19 @@
 
 Persisted as a sidecar Message alongside the primary analyser output when LLM
 validation removes findings. Each entry pairs the original finding's
-serialised form with the LLM verdict that drove its removal.
+serialised form with a human-readable reason for its removal.
 """
 
 from datetime import UTC, datetime
 from typing import Annotated, ClassVar
 
 from pydantic import BaseModel, Field, PlainSerializer
-from waivern_core import LLMValidationResultModel
 from waivern_core.schemas import BaseSchemaOutput
 from waivern_core.types import JsonValue
 
 
 class RemovedFinding(BaseModel):
-    """Single finding removed by LLM validation, paired with its verdict.
+    """Single finding removed by LLM validation, paired with its removal reason.
 
     ``original_finding`` is stored as a JSON-serialised dict so that the
     audit-trail schema is decoupled from the producer analyser's specific
@@ -26,8 +25,12 @@ class RemovedFinding(BaseModel):
     original_finding: dict[str, JsonValue] = Field(
         description="Serialised form of the analyser's finding at the time of removal",
     )
-    llm_verdict: LLMValidationResultModel = Field(
-        description="The LLM verdict that caused the finding to be removed",
+    reason: str = Field(
+        description=(
+            "Human-readable removal reason. For LLM-direct removals this is the "
+            "LLM's verdict reasoning verbatim; for group cascade removals it is "
+            "a synthesised 'Inferred — …' string explaining the cascade."
+        ),
     )
     removal_timestamp: Annotated[
         datetime,
@@ -67,7 +70,7 @@ class RemovedFindingsOutput(BaseSchemaOutput):
         description="Version of the ruleset referenced by ``ruleset_name``",
     )
     removed_findings: list[RemovedFinding] = Field(
-        description="Findings removed during LLM validation, each paired with its verdict",
+        description="Findings removed during LLM validation, each paired with its removal reason",
     )
 
 

--- a/libs/waivern-schemas/src/waivern_schemas/removed_findings/v1.py
+++ b/libs/waivern-schemas/src/waivern_schemas/removed_findings/v1.py
@@ -58,16 +58,13 @@ class RemovedFindingsOutput(BaseSchemaOutput):
     run_id: str = Field(
         description="Run ID for cross-artifact correlation",
     )
-    ruleset_name: str | None = Field(
+    ruleset: str | None = Field(
         default=None,
         description=(
-            "Ruleset URI used for pattern matching. ``None`` when the producing "
-            "analyser is not ruleset-driven."
+            "Ruleset URI used for pattern matching, in the framework's standard "
+            "``provider/name/version`` form (e.g. ``local/personal_data_indicator/1.0.0``). "
+            "``None`` when the producing analyser is not ruleset-driven."
         ),
-    )
-    ruleset_version: str | None = Field(
-        default=None,
-        description="Version of the ruleset referenced by ``ruleset_name``",
     )
     removed_findings: list[RemovedFinding] = Field(
         description="Findings removed during LLM validation, each paired with its removal reason",

--- a/libs/waivern-security-control-analyser/src/waivern_security_control_analyser/analyser.py
+++ b/libs/waivern-security-control-analyser/src/waivern_security_control_analyser/analyser.py
@@ -149,7 +149,7 @@ class SecurityControlAnalyser(Analyser):
         self,
         inputs: list[Message],
         output_schema: Schema,
-    ) -> Message:
+    ) -> tuple[Message, list[Message]]:
         """Process source code to find security control patterns.
 
         Supports same-schema fan-in: multiple source_code or standard_input
@@ -161,9 +161,11 @@ class SecurityControlAnalyser(Analyser):
             output_schema: Expected output schema.
 
         Returns:
-            Output message with security evidence findings from all inputs combined.
+            ``(primary, [])`` where ``primary`` is the security-evidence
+            findings message from all inputs combined. No sidecars are emitted.
 
         """
         data_items = self._merge_input_data_items(inputs)
         findings = self._find_patterns_in_data_items(data_items)
-        return self._result_builder.build_output_message(findings, output_schema)
+        primary = self._result_builder.build_output_message(findings, output_schema)
+        return primary, []

--- a/libs/waivern-security-control-analyser/tests/waivern_security_control_analyser/test_analyser.py
+++ b/libs/waivern-security-control-analyser/tests/waivern_security_control_analyser/test_analyser.py
@@ -119,7 +119,7 @@ class TestSecurityControlPolarity:
         analyser = SecurityControlAnalyser(config=_make_config())
         message = _make_message("Using test_positive_auth_pattern for login")
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -131,7 +131,7 @@ class TestSecurityControlPolarity:
         analyser = SecurityControlAnalyser(config=_make_config())
         message = _make_message("Using test_negative_network_pattern in firewall")
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -143,7 +143,7 @@ class TestSecurityControlPolarity:
         analyser = SecurityControlAnalyser(config=_make_config())
         message = _make_message("x = a + b")
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         assert result.content["findings"] == []
         assert result.content["summary"]["total_findings"] == 0
@@ -167,7 +167,7 @@ class TestSecurityControlOutputStructure:
         analyser = SecurityControlAnalyser(config=_make_config())
         message = _make_message("Using test_positive_auth_pattern for login")
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         assert isinstance(result, Message)
         assert result.schema == OUTPUT_SCHEMA
@@ -183,7 +183,7 @@ class TestSecurityControlOutputStructure:
             "test_positive_auth_pattern and test_negative_network_pattern"
         )
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         summary = result.content["summary"]
         domain_names = {d["security_domain"] for d in summary["domains"]}
@@ -236,7 +236,7 @@ class TestSecurityControlInputSchemas:
             schema=Schema("source_code", "1.0.0"),
         )
 
-        result = analyser.process([message], OUTPUT_SCHEMA)
+        result, _ = analyser.process([message], OUTPUT_SCHEMA)
 
         assert isinstance(result, Message)
         assert result.schema == OUTPUT_SCHEMA
@@ -264,7 +264,7 @@ class TestSecurityControlFanIn:
         msg_positive = _make_message("Using test_positive_auth_pattern for login")
         msg_negative = _make_message("Using test_negative_network_pattern in firewall")
 
-        result = analyser.process([msg_positive, msg_negative], OUTPUT_SCHEMA)
+        result, _ = analyser.process([msg_positive, msg_negative], OUTPUT_SCHEMA)
 
         findings = result.content["findings"]
         polarities = {f["polarity"] for f in findings}

--- a/libs/waivern-security-document-evidence-extractor/src/waivern_security_document_evidence_extractor/extractor.py
+++ b/libs/waivern-security-document-evidence-extractor/src/waivern_security_document_evidence_extractor/extractor.py
@@ -135,7 +135,7 @@ class SecurityDocumentEvidenceExtractor(Processor):
         state: SecurityDocEvidencePrepareState,
         results: Sequence[DispatchResult],
         output_schema: Schema,
-    ) -> Message:
+    ) -> tuple[Message, list[Message]]:
         """Produce classified document output from state and dispatch results.
 
         1. If LLM result with responses: validate as DomainClassificationResponse.
@@ -146,13 +146,14 @@ class SecurityDocumentEvidenceExtractor(Processor):
         """
         responses, llm_used = self._extract_llm_responses(state, results)
 
-        return build_output_message(
+        primary = build_output_message(
             document_items=state.document_items,
             document_contents=state.document_contents,
             responses=responses,
             output_schema=output_schema,
             llm_classification_enabled=llm_used,
         )
+        return primary, []
 
     def _extract_llm_responses(
         self,

--- a/libs/waivern-security-document-evidence-extractor/tests/waivern_security_document_evidence_extractor/test_distributed.py
+++ b/libs/waivern-security-document-evidence-extractor/tests/waivern_security_document_evidence_extractor/test_distributed.py
@@ -118,7 +118,9 @@ class TestFinalise:
         )
 
         prepare_result = extractor.prepare(inputs=[msg], output_schema=OUTPUT_SCHEMA)
-        result = extractor.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        finalise_outcome = extractor.finalise(prepare_result.state, [], OUTPUT_SCHEMA)
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         output = parse_output(result)
         assert len(output.findings) == 2
@@ -148,7 +150,11 @@ class TestFinalise:
             skipped=[],
         )
 
-        result = extractor.finalise(prepare_result.state, [llm_result], OUTPUT_SCHEMA)
+        finalise_outcome = extractor.finalise(
+            prepare_result.state, [llm_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         output = parse_output(result)
         finding = output.findings[0]
@@ -176,7 +182,11 @@ class TestFinalise:
             skipped=[],
         )
 
-        result = extractor.finalise(prepare_result.state, [llm_result], OUTPUT_SCHEMA)
+        finalise_outcome = extractor.finalise(
+            prepare_result.state, [llm_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         output = parse_output(result)
         finding = output.findings[0]
@@ -215,7 +225,11 @@ class TestFinalise:
             skipped=[],
         )
 
-        result = extractor.finalise(prepare_result.state, [llm_result], OUTPUT_SCHEMA)
+        finalise_outcome = extractor.finalise(
+            prepare_result.state, [llm_result], OUTPUT_SCHEMA
+        )
+        assert isinstance(finalise_outcome, tuple)
+        result, _sidecars = finalise_outcome
 
         output = parse_output(result)
         assert output.summary.total_documents == 3

--- a/libs/waivern-security-evidence-normaliser/src/waivern_security_evidence_normaliser/analyser.py
+++ b/libs/waivern-security-evidence-normaliser/src/waivern_security_evidence_normaliser/analyser.py
@@ -502,7 +502,7 @@ class SecurityEvidenceNormaliser(Analyser):
         self,
         inputs: list[Message],
         output_schema: Schema,
-    ) -> Message:
+    ) -> tuple[Message, list[Message]]:
         """Normalise indicator findings into security evidence items.
 
         Dispatches to the appropriate handler based on the input schema name.
@@ -513,7 +513,8 @@ class SecurityEvidenceNormaliser(Analyser):
             output_schema: Expected output schema (security_evidence/1.0.0).
 
         Returns:
-            Output message with normalised security evidence items.
+            ``(primary, [])`` where ``primary`` is the normalised security
+            evidence items message. No sidecars are emitted.
 
         Raises:
             ValueError: If the input schema is not supported.
@@ -541,4 +542,5 @@ class SecurityEvidenceNormaliser(Analyser):
                 )
                 raise ValueError(msg)
 
-        return self._result_builder.build_output_message(findings, output_schema)
+        primary = self._result_builder.build_output_message(findings, output_schema)
+        return primary, []

--- a/libs/waivern-security-evidence-normaliser/tests/waivern_security_evidence_normaliser/test_analyser.py
+++ b/libs/waivern-security-evidence-normaliser/tests/waivern_security_evidence_normaliser/test_analyser.py
@@ -93,7 +93,7 @@ class TestNormalisePersonalData:
         analyser = SecurityEvidenceNormaliser(valid_config)
         msg = self._make_message("email", "user.php")
 
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -128,7 +128,7 @@ class TestNormalisePersonalData:
         )
 
         analyser = SecurityEvidenceNormaliser(valid_config)
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -143,7 +143,7 @@ class TestNormalisePersonalData:
         analyser = SecurityEvidenceNormaliser(valid_config)
         msg = self._make_message("health", "health.php")
 
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         domains = {f["security_domain"] for f in findings}
@@ -159,7 +159,7 @@ class TestNormalisePersonalData:
         msg = self._make_message("unknown_xyz", "file.php")
 
         with caplog.at_level(logging.DEBUG):
-            result = analyser.process([msg], Schema("security_evidence", "1.0.0"))
+            result, _ = analyser.process([msg], Schema("security_evidence", "1.0.0"))
 
         assert result.content["findings"] == []
         assert "unknown_xyz" in caplog.text
@@ -219,7 +219,7 @@ class TestNormaliseProcessingPurpose:
         analyser = SecurityEvidenceNormaliser(valid_config)
         msg = self._make_message("user_identity_login", "auth.php")
 
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -259,7 +259,7 @@ class TestNormaliseProcessingPurpose:
         )
 
         analyser = SecurityEvidenceNormaliser(valid_config)
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -273,7 +273,7 @@ class TestNormaliseProcessingPurpose:
         msg = self._make_message("unknown_purpose_xyz", "file.php")
 
         with caplog.at_level(logging.DEBUG):
-            result = analyser.process([msg], Schema("security_evidence", "1.0.0"))
+            result, _ = analyser.process([msg], Schema("security_evidence", "1.0.0"))
 
         assert result.content["findings"] == []
         assert "unknown_purpose_xyz" in caplog.text
@@ -337,7 +337,7 @@ class TestNormaliseCryptoQuality:
         analyser = SecurityEvidenceNormaliser(valid_config)
         msg = self._make_message("bcrypt", "strong", "positive")
 
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -353,7 +353,7 @@ class TestNormaliseCryptoQuality:
         analyser = SecurityEvidenceNormaliser(valid_config)
         msg = self._make_message("md5", "deprecated", "negative")
 
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -369,7 +369,7 @@ class TestNormaliseCryptoQuality:
         analyser = SecurityEvidenceNormaliser(valid_config)
         msg = self._make_message("bcrypt", "strong", "positive")
 
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         finding = result.content["findings"][0]
         assert len(finding["evidence"]) == 1
@@ -412,7 +412,7 @@ class TestNormaliseCryptoQuality:
         )
 
         analyser = SecurityEvidenceNormaliser(SecurityEvidenceNormaliserConfig())
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         finding = result.content["findings"][0]
         contents = [e["content"] for e in finding["evidence"]]
@@ -450,7 +450,7 @@ class TestNormaliseCryptoQuality:
 
         config = SecurityEvidenceNormaliserConfig(maximum_evidence_items=2)
         analyser = SecurityEvidenceNormaliser(config)
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         assert len(result.content["findings"][0]["evidence"]) == 2
 
@@ -462,7 +462,7 @@ class TestNormaliseCryptoQuality:
         msg = self._make_message("unknown_algo_xyz", "weak", "negative")
 
         with caplog.at_level(logging.DEBUG):
-            result = analyser.process([msg], Schema("security_evidence", "1.0.0"))
+            result, _ = analyser.process([msg], Schema("security_evidence", "1.0.0"))
 
         assert result.content["findings"] == []
         assert "unknown_algo_xyz" in caplog.text
@@ -503,7 +503,7 @@ class TestRequireReviewPropagation:
         )
 
         analyser = SecurityEvidenceNormaliser(SecurityEvidenceNormaliserConfig())
-        result = analyser.process([msg], Schema("security_evidence", "1.0.0"))
+        result, _ = analyser.process([msg], Schema("security_evidence", "1.0.0"))
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -547,7 +547,7 @@ class TestFanIn:
         msg2 = self._make_pd_message("msg2", "phone", "contact.php")
 
         analyser = SecurityEvidenceNormaliser(SecurityEvidenceNormaliserConfig())
-        result = analyser.process([msg1, msg2], Schema("security_evidence", "1.0.0"))
+        result, _ = analyser.process([msg1, msg2], Schema("security_evidence", "1.0.0"))
 
         findings = result.content["findings"]
         source_locations = {f["metadata"]["source"] for f in findings}
@@ -588,7 +588,7 @@ class TestOutputMessageStructure:
         output_schema = Schema("security_evidence", "1.0.0")
 
         analyser = SecurityEvidenceNormaliser(SecurityEvidenceNormaliserConfig())
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         assert isinstance(result, Message)
         assert result.schema == output_schema
@@ -645,7 +645,7 @@ class TestSummaryDomainBreakdown:
         msg2 = self._make_cq_message("bcrypt", "strong", "positive", "file_b.php")
 
         analyser = SecurityEvidenceNormaliser(SecurityEvidenceNormaliserConfig())
-        result = analyser.process([msg1, msg2], Schema("security_evidence", "1.0.0"))
+        result, _ = analyser.process([msg1, msg2], Schema("security_evidence", "1.0.0"))
 
         summary = result.content["summary"]
         assert summary["domains_identified"] == 1
@@ -706,7 +706,7 @@ class TestSummaryDomainBreakdown:
         )
 
         analyser = SecurityEvidenceNormaliser(SecurityEvidenceNormaliserConfig())
-        result = analyser.process([msg], Schema("security_evidence", "1.0.0"))
+        result, _ = analyser.process([msg], Schema("security_evidence", "1.0.0"))
         domains = result.content["summary"]["domains"]
 
         # authentication (2 findings) must come before logging_monitoring (1 finding)
@@ -785,7 +785,7 @@ class TestNormaliseServiceIntegration:
         analyser = SecurityEvidenceNormaliser(valid_config)
         msg = self._make_message("cloud_infrastructure", "operational", "aws.php")
 
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -830,7 +830,7 @@ class TestNormaliseServiceIntegration:
         )
 
         analyser = SecurityEvidenceNormaliser(valid_config)
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -844,7 +844,7 @@ class TestNormaliseServiceIntegration:
         msg = self._make_message("unknown_service_xyz", "operational", "file.php")
 
         with caplog.at_level(logging.DEBUG):
-            result = analyser.process([msg], Schema("security_evidence", "1.0.0"))
+            result, _ = analyser.process([msg], Schema("security_evidence", "1.0.0"))
 
         assert result.content["findings"] == []
         assert "unknown_service_xyz" in caplog.text
@@ -858,7 +858,7 @@ class TestNormaliseServiceIntegration:
         analyser = SecurityEvidenceNormaliser(valid_config)
         msg = self._make_message("identity_management", "operational", "auth.php")
 
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         domains = {f["security_domain"] for f in findings}
@@ -936,7 +936,7 @@ class TestNormaliseDataCollection:
         analyser = SecurityEvidenceNormaliser(valid_config)
         msg = self._make_message("form_data", "http_post", "contact.php")
 
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -978,7 +978,7 @@ class TestNormaliseDataCollection:
         )
 
         analyser = SecurityEvidenceNormaliser(valid_config)
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         assert len(findings) == 1
@@ -992,7 +992,7 @@ class TestNormaliseDataCollection:
         msg = self._make_message("unknown_type_xyz", "unknown", "file.php")
 
         with caplog.at_level(logging.DEBUG):
-            result = analyser.process([msg], Schema("security_evidence", "1.0.0"))
+            result, _ = analyser.process([msg], Schema("security_evidence", "1.0.0"))
 
         assert result.content["findings"] == []
         assert "unknown_type_xyz" in caplog.text
@@ -1006,7 +1006,7 @@ class TestNormaliseDataCollection:
         analyser = SecurityEvidenceNormaliser(valid_config)
         msg = self._make_message("file_upload", "uploaded_files", "upload.php")
 
-        result = analyser.process([msg], output_schema)
+        result, _ = analyser.process([msg], output_schema)
 
         findings = result.content["findings"]
         assert len(findings) == 1

--- a/libs/waivern-service-integration-analyser/src/waivern_service_integration_analyser/analyser.py
+++ b/libs/waivern-service-integration-analyser/src/waivern_service_integration_analyser/analyser.py
@@ -70,7 +70,7 @@ class ServiceIntegrationAnalyser(Analyser):
         self,
         inputs: list[Message],
         output_schema: Schema,
-    ) -> Message:
+    ) -> tuple[Message, list[Message]]:
         """Process source code to find service integration patterns.
 
         Orchestrates the analysis flow:
@@ -83,7 +83,8 @@ class ServiceIntegrationAnalyser(Analyser):
             output_schema: Expected output schema.
 
         Returns:
-            Output message with service integration findings.
+            ``(primary, [])`` where ``primary`` is the service-integration
+            findings message. No sidecars are emitted.
 
         """
         findings: list[ServiceIntegrationIndicatorModel] = []
@@ -92,7 +93,8 @@ class ServiceIntegrationAnalyser(Analyser):
             source_data = reader.read(message.content)
             findings.extend(self._handler.analyse(source_data))
 
-        return self._result_builder.build_output_message(findings, output_schema)
+        primary = self._result_builder.build_output_message(findings, output_schema)
+        return primary, []
 
     def _load_reader(self, schema: Schema) -> SchemaReader[SourceCodeDataModel]:
         """Dynamically import reader module for the given input schema.

--- a/libs/waivern-service-integration-analyser/tests/waivern_service_integration_analyser/test_analyser.py
+++ b/libs/waivern-service-integration-analyser/tests/waivern_service_integration_analyser/test_analyser.py
@@ -260,7 +260,7 @@ class TestServiceIntegrationOutputStructure:
             schema=Schema("source_code", "1.0.0"),
         )
 
-        result = analyser.process([message], output_schema)
+        result, _ = analyser.process([message], output_schema)
 
         assert isinstance(result, Message)
         assert result.schema == output_schema
@@ -301,7 +301,7 @@ class TestServiceIntegrationOutputStructure:
             schema=Schema("source_code", "1.0.0"),
         )
 
-        result = analyser.process([message], output_schema)
+        result, _ = analyser.process([message], output_schema)
 
         summary = result.content["summary"]
         category_names = {c["service_category"] for c in summary["categories"]}
@@ -357,7 +357,7 @@ class TestServiceIntegrationSourceCodeInput:
             schema=Schema("source_code", "1.0.0"),
         )
 
-        result = analyser.process([message], output_schema)
+        result, _ = analyser.process([message], output_schema)
 
         assert isinstance(result, Message)
         assert result.schema == output_schema
@@ -425,7 +425,7 @@ class TestServiceIntegrationSourceCodeInput:
             schema=Schema("source_code", "1.0.0"),
         )
 
-        result = analyser.process([message_a, message_b], output_schema)
+        result, _ = analyser.process([message_a, message_b], output_schema)
 
         sources = {f["metadata"]["source"] for f in result.content["findings"]}
         assert "a/billing.php" in sources

--- a/libs/waivern-source-code-analyser/src/waivern_source_code_analyser/analyser.py
+++ b/libs/waivern-source-code-analyser/src/waivern_source_code_analyser/analyser.py
@@ -74,7 +74,7 @@ class SourceCodeAnalyser(Analyser):
         self,
         inputs: list[Message],
         output_schema: Schema,
-    ) -> Message:
+    ) -> tuple[Message, list[Message]]:
         """Process standard_input data to produce source_code output.
 
         Supports same-schema fan-in: multiple standard_input messages are merged
@@ -85,7 +85,8 @@ class SourceCodeAnalyser(Analyser):
             output_schema: Output schema (source_code)
 
         Returns:
-            Message containing source code with language detection
+            ``(primary, [])`` where ``primary`` is the source-code analysis
+            message with language detection. No sidecars are emitted.
 
         Raises:
             AnalyserProcessingError: If processing fails
@@ -191,7 +192,7 @@ class SourceCodeAnalyser(Analyser):
                 f"SourceCodeAnalyser processed {total_files} files, {total_lines} lines"
             )
 
-            return output_message
+            return output_message, []
 
         except Exception as e:
             logger.error(f"Failed to process source code: {e}")

--- a/libs/waivern-source-code-analyser/tests/waivern_source_code_analyser/test_analyser.py
+++ b/libs/waivern-source-code-analyser/tests/waivern_source_code_analyser/test_analyser.py
@@ -121,7 +121,7 @@ class UserManager {
         analyser = SourceCodeAnalyser(config)
 
         # Act
-        result = analyser.process(
+        result, _ = analyser.process(
             [message],
             Schema("source_code", "1.0.0"),
         )
@@ -204,7 +204,7 @@ class UserManager {
         analyser = SourceCodeAnalyser(config)
 
         # Act
-        result = analyser.process(
+        result, _ = analyser.process(
             [message],
             Schema("source_code", "1.0.0"),
         )
@@ -268,7 +268,7 @@ class UserManager {
         analyser = SourceCodeAnalyser(config)
 
         # Act
-        result = analyser.process(
+        result, _ = analyser.process(
             [message],
             Schema("source_code", "1.0.0"),
         )
@@ -313,7 +313,7 @@ class UserManager {
         analyser = SourceCodeAnalyser(config)
 
         # Act
-        result = analyser.process(
+        result, _ = analyser.process(
             [message],
             Schema("source_code", "1.0.0"),
         )
@@ -356,7 +356,7 @@ class UserManager {
         analyser = SourceCodeAnalyser(config)
 
         # Act - should not raise exception
-        result = analyser.process(
+        result, _ = analyser.process(
             [message],
             Schema("source_code", "1.0.0"),
         )
@@ -388,7 +388,7 @@ class UserManager {
         analyser = SourceCodeAnalyser(config)
 
         # Act
-        result = analyser.process(
+        result, _ = analyser.process(
             [message],
             Schema("source_code", "1.0.0"),
         )
@@ -440,7 +440,7 @@ class UserManager {
             analyser = SourceCodeAnalyser(config)
 
             # Act
-            result = analyser.process(
+            result, _ = analyser.process(
                 [message],
                 Schema("source_code", "1.0.0"),
             )
@@ -494,7 +494,7 @@ class UserManager {
         analyser = SourceCodeAnalyser(config)
 
         # Act
-        result = analyser.process(
+        result, _ = analyser.process(
             [message],
             Schema("source_code", "1.0.0"),
         )
@@ -538,7 +538,7 @@ class UserManager {
         analyser = SourceCodeAnalyser(config)
 
         # Act
-        result = analyser.process(
+        result, _ = analyser.process(
             [message],
             Schema("source_code", "1.0.0"),
         )
@@ -608,7 +608,7 @@ class UserManager {
         analyser = SourceCodeAnalyser(config)
 
         # Act
-        result = analyser.process(
+        result, _ = analyser.process(
             [message],
             Schema("source_code", "1.0.0"),
         )
@@ -664,7 +664,7 @@ class UserManager {
         analyser = SourceCodeAnalyser(config)
 
         # Act - should not raise exception
-        result = analyser.process(
+        result, _ = analyser.process(
             [message],
             Schema("source_code", "1.0.0"),
         )
@@ -723,7 +723,7 @@ export default Greeting;
         analyser = SourceCodeAnalyser(config)
 
         # Act
-        result = analyser.process(
+        result, _ = analyser.process(
             [message],
             Schema("source_code", "1.0.0"),
         )


### PR DESCRIPTION
## Summary

- Widen the processor return contract to `(primary, sidecars)` on both `Processor.process` and `DistributedProcessor.finalise`, opening a typed write-once side-channel for analyser output without flowing extra messages downstream.
- Add `RemovedFindingsOutput` schema and emit one sidecar per LLM-validating analyser (`personal_data`, `data_subject`, `processing_purpose`) when validation removes findings. Each removed finding is paired with a human-readable reason — either the LLM's own verdict prose or a synthesised cascade reason for group-removed members.
- Persist sidecars via `DAGExecutor` at `{run_id}/{artifact_name}.{sidecar.schema.name}.json` (saved before the primary to keep resume idempotent) and stamp `removed_findings_artifact_id` into the primary's `validation_summary` so consumers can navigate from primary output to its audit trail.

## Test plan

- [x] `./scripts/dev-checks.sh` passes (format, lint, type-check, full pytest)
- [x] New `test_executor_sidecars.py` covers both sync and distributed persistence paths, sidecar-before-primary ordering, and back-reference stamping
- [x] Each LLM-validating analyser test suite asserts that `validation_summary` pre-emits `removed_findings_artifact_id: None`
- [x] Run a real LLM-validating runbook locally and verify the sidecar file is written alongside the primary output with a populated `removed_findings_artifact_id`