### PR TITLE
feat: standardise configuration error translation in waivern-core

### DIFF
--- a/libs/waivern-core/src/waivern_core/__init__.py
+++ b/libs/waivern-core/src/waivern_core/__init__.py
@@ -23,7 +23,6 @@ from waivern_core.dispatch import (
     RequestDispatcher,
 )
 from waivern_core.errors import (
-    AnalyserConfigError,
     AnalyserError,
     AnalyserInputError,
     AnalyserProcessingError,
@@ -137,7 +136,6 @@ __all__ = [
     "validate_output_schema",
     # Errors
     "WaivernError",
-    "AnalyserConfigError",
     "AnalyserError",
     "AnalyserInputError",
     "AnalyserProcessingError",

--- a/libs/waivern-core/src/waivern_core/__init__.py
+++ b/libs/waivern-core/src/waivern_core/__init__.py
@@ -36,6 +36,7 @@ from waivern_core.errors import (
     ProcessorError,
     ProcessorInputError,
     ProcessorProcessingError,
+    ServiceConfigError,
     WaivernError,
 )
 from waivern_core.llm_validation_types import (
@@ -149,6 +150,7 @@ __all__ = [
     "ProcessorError",
     "ProcessorInputError",
     "ProcessorProcessingError",
+    "ServiceConfigError",
     "RulesetError",
     "SchemaLoadError",
 ]

--- a/libs/waivern-core/src/waivern_core/config_validation.py
+++ b/libs/waivern-core/src/waivern_core/config_validation.py
@@ -1,0 +1,43 @@
+"""Mechanical helper for translating configuration validation failures.
+
+``validate_or_raise`` performs only the ``model_validate``-and-translate step. It
+holds no policy and never reaches into the environment: each component owns its own
+``from_properties`` assembly (env-var merging, secret resolution, field dispatch) and
+names the category error class to translate into.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from waivern_core.errors import WaivernError
+
+
+def validate_or_raise[T: BaseModel](
+    model: type[T], data: dict[str, Any], error_cls: type[WaivernError]
+) -> T:
+    """Validate ``data`` against ``model``, translating failures to ``error_cls``.
+
+    Args:
+        model: The Pydantic model to validate against.
+        data: The assembled configuration data to validate.
+        error_cls: The framework error class to raise on failure.
+
+    Returns:
+        The validated model instance.
+
+    Raises:
+        WaivernError: An instance of ``error_cls`` if validation fails. For a
+            ``ValidationError`` source the structured ``.errors()`` data is carried
+            on ``error.validation_errors``; for a plain ``ValueError`` it stays
+            ``None``. The original exception is always chained via ``__cause__``.
+
+    """
+    try:
+        return model.model_validate(data)
+    except ValidationError as e:
+        raise error_cls(
+            f"Invalid {model.__name__}: {e}", validation_errors=e.errors()
+        ) from e
+    except ValueError as e:  # env-preprocessing raise; no structured .errors()
+        raise error_cls(f"Invalid {model.__name__}: {e}") from e

--- a/libs/waivern-core/src/waivern_core/errors.py
+++ b/libs/waivern-core/src/waivern_core/errors.py
@@ -6,6 +6,7 @@ This module provides:
 - ConnectorError, ConnectorConfigError, ConnectorExtractionError: Connector exceptions
 - ProcessorError: Base exception for processor-related errors
 - AnalyserError, AnalyserConfigError, AnalyserInputError, AnalyserProcessingError: Analyser exceptions
+- ServiceConfigError: Raised when service configuration is invalid
 - ParserError: Parser-related exception
 - MessageValidationError: Message validation exception
 """
@@ -91,6 +92,12 @@ class AnalyserInputError(AnalyserError):
 
 class AnalyserProcessingError(AnalyserError):
     """Raised when analyser processing fails."""
+
+    pass
+
+
+class ServiceConfigError(WaivernError):
+    """Raised when service configuration is invalid."""
 
     pass
 

--- a/libs/waivern-core/src/waivern_core/errors.py
+++ b/libs/waivern-core/src/waivern_core/errors.py
@@ -10,11 +10,22 @@ This module provides:
 - MessageValidationError: Message validation exception
 """
 
+from pydantic_core import ErrorDetails
+
 
 class WaivernError(Exception):
-    """Base exception for all Waivern Compliance Framework errors."""
+    """Base exception for all Waivern Compliance Framework errors.
 
-    pass
+    Carries optional Pydantic structured error data so configuration failures
+    translated into framework errors can expose ``.errors()`` to callers.
+    """
+
+    def __init__(
+        self, *args: object, validation_errors: list[ErrorDetails] | None = None
+    ) -> None:
+        """Store optional Pydantic structured error data alongside the message."""
+        super().__init__(*args)
+        self.validation_errors = validation_errors
 
 
 class ConnectorError(WaivernError):

--- a/libs/waivern-core/src/waivern_core/errors.py
+++ b/libs/waivern-core/src/waivern_core/errors.py
@@ -5,7 +5,7 @@ This module provides:
 - PendingProcessingError: Marker for async processing pending (batch APIs)
 - ConnectorError, ConnectorConfigError, ConnectorExtractionError: Connector exceptions
 - ProcessorError: Base exception for processor-related errors
-- AnalyserError, AnalyserConfigError, AnalyserInputError, AnalyserProcessingError: Analyser exceptions
+- AnalyserError, AnalyserInputError, AnalyserProcessingError: Analyser exceptions
 - ServiceConfigError: Raised when service configuration is invalid
 - ParserError: Parser-related exception
 - MessageValidationError: Message validation exception
@@ -74,12 +74,6 @@ class ProcessorProcessingError(ProcessorError):
 # Analyser-specific errors (extend ProcessorError for backwards compatibility)
 class AnalyserError(ProcessorError):
     """Base exception for analyser-related errors."""
-
-    pass
-
-
-class AnalyserConfigError(AnalyserError):
-    """Raised when analyser configuration is invalid."""
 
     pass
 

--- a/libs/waivern-core/tests/waivern_core/test_config_validation.py
+++ b/libs/waivern-core/tests/waivern_core/test_config_validation.py
@@ -1,0 +1,75 @@
+"""Tests for the validate_or_raise configuration-translation helper."""
+
+from typing import Any, override
+
+import pytest
+from pydantic import BaseModel
+
+
+class _SampleConfig(BaseModel):
+    """Minimal model standing in for a component configuration."""
+
+    name: str
+    count: int
+
+
+class _RawValueErrorConfig(BaseModel):
+    """Model whose validation raises a plain ValueError (not a ValidationError).
+
+    Pydantic wraps validator-raised ``ValueError``s into ``ValidationError``, so a
+    raw ``ValueError`` only escapes when ``model_validate`` itself raises one. This
+    stub forces that path to exercise the helper's defensive branch.
+    """
+
+    @classmethod
+    @override
+    def model_validate(cls, *_args: Any, **_kwargs: Any) -> "_RawValueErrorConfig":
+        raise ValueError("environment preprocessing failed")
+
+
+class TestValidateOrRaise:
+    """validate_or_raise validates a model and translates failures."""
+
+    def test_returns_validated_instance_on_valid_data(self) -> None:
+        """Valid data returns a populated instance of the model type."""
+        from waivern_core.config_validation import validate_or_raise
+        from waivern_core.errors import ConnectorConfigError
+
+        result = validate_or_raise(
+            _SampleConfig, {"name": "db", "count": 3}, ConnectorConfigError
+        )
+
+        assert isinstance(result, _SampleConfig)
+        assert result.name == "db"
+        assert result.count == 3
+
+    def test_translates_validation_error_with_structured_errors(self) -> None:
+        """ValidationError becomes error_cls carrying .errors() and chained cause."""
+        from pydantic import ValidationError
+
+        from waivern_core.config_validation import validate_or_raise
+        from waivern_core.errors import ConnectorConfigError
+
+        with pytest.raises(ConnectorConfigError) as exc_info:
+            validate_or_raise(_SampleConfig, {"name": "db"}, ConnectorConfigError)
+
+        error = exc_info.value
+        assert "_SampleConfig" in str(error)
+        assert error.validation_errors is not None
+        assert any(detail["loc"] == ("count",) for detail in error.validation_errors)
+        assert isinstance(error.__cause__, ValidationError)
+
+    def test_translates_plain_value_error_without_structured_errors(self) -> None:
+        """A plain ValueError becomes error_cls with no structured errors."""
+        from pydantic import ValidationError
+
+        from waivern_core.config_validation import validate_or_raise
+        from waivern_core.errors import ConnectorConfigError
+
+        with pytest.raises(ConnectorConfigError) as exc_info:
+            validate_or_raise(_RawValueErrorConfig, {}, ConnectorConfigError)
+
+        error = exc_info.value
+        assert error.validation_errors is None
+        assert isinstance(error.__cause__, ValueError)
+        assert not isinstance(error.__cause__, ValidationError)

--- a/libs/waivern-core/tests/waivern_core/test_errors.py
+++ b/libs/waivern-core/tests/waivern_core/test_errors.py
@@ -1,0 +1,46 @@
+"""Tests for WaivernError carrying structured validation errors."""
+
+from typing import cast
+
+from pydantic_core import ErrorDetails
+
+
+def _error_detail() -> ErrorDetails:
+    """A representative Pydantic ErrorDetails entry."""
+    return cast(
+        ErrorDetails,
+        {"type": "missing", "loc": ("path",), "msg": "Field required", "input": {}},
+    )
+
+
+class TestWaivernErrorValidationErrors:
+    """WaivernError can carry Pydantic structured error data."""
+
+    def test_defaults_to_none_and_preserves_message(self) -> None:
+        """WaivernError("msg") stores no validation errors and keeps its message."""
+        from waivern_core.errors import WaivernError
+
+        error = WaivernError("something went wrong")
+
+        assert error.validation_errors is None
+        assert str(error) == "something went wrong"
+
+    def test_stores_provided_validation_errors(self) -> None:
+        """WaivernError stores a provided list of validation errors."""
+        from waivern_core.errors import WaivernError
+
+        details = [_error_detail()]
+        error = WaivernError("invalid config", validation_errors=details)
+
+        assert error.validation_errors == details
+
+    def test_subclass_inherits_validation_errors_parameter(self) -> None:
+        """Category subclasses inherit the validation_errors parameter."""
+        from waivern_core.errors import ConnectorConfigError
+
+        details = [_error_detail()]
+        error = ConnectorConfigError(
+            "invalid connector config", validation_errors=details
+        )
+
+        assert error.validation_errors == details

--- a/libs/waivern-llm/src/waivern_llm/errors.py
+++ b/libs/waivern-llm/src/waivern_llm/errors.py
@@ -1,6 +1,10 @@
 """LLM service exceptions."""
 
-from waivern_core.errors import PendingProcessingError, WaivernError
+from waivern_core.errors import (
+    PendingProcessingError,
+    ServiceConfigError,
+    WaivernError,
+)
 
 
 class LLMServiceError(WaivernError):
@@ -9,8 +13,13 @@ class LLMServiceError(WaivernError):
     pass
 
 
-class LLMConfigurationError(LLMServiceError):
-    """Exception raised when LLM service is misconfigured."""
+class LLMConfigurationError(LLMServiceError, ServiceConfigError):
+    """Exception raised when LLM service is misconfigured.
+
+    An LLM-domain error (``LLMServiceError``) that also participates in the
+    cross-service configuration category (``ServiceConfigError``), so callers can
+    catch any service misconfiguration uniformly.
+    """
 
     pass
 

--- a/libs/waivern-llm/tests/waivern_llm/test_errors.py
+++ b/libs/waivern-llm/tests/waivern_llm/test_errors.py
@@ -1,6 +1,18 @@
 """Tests for LLM service error types."""
 
-from waivern_llm.errors import LLMServiceError, PendingBatchError
+from waivern_core.errors import ServiceConfigError
+
+from waivern_llm.errors import LLMConfigurationError, LLMServiceError, PendingBatchError
+
+
+class TestLLMConfigurationError:
+    """LLMConfigurationError sits on both the domain and category axes."""
+
+    def test_is_service_config_error_subclass(self) -> None:
+        assert isinstance(LLMConfigurationError("missing key"), ServiceConfigError)
+
+    def test_remains_llm_service_error_subclass(self) -> None:
+        assert isinstance(LLMConfigurationError("missing key"), LLMServiceError)
 
 
 class TestPendingBatchError:

--- a/libs/waivern-source-code-analyser/docs/architecture.md
+++ b/libs/waivern-source-code-analyser/docs/architecture.md
@@ -220,7 +220,7 @@ The analyser implements graceful degradation:
 | ---------------------------- | ---------------------------------------- |
 | File exceeds `max_file_size` | Skipped with warning, analysis continues |
 | Unsupported file extension   | Skipped, no error                        |
-| Invalid configuration        | `AnalyserConfigError` raised at startup  |
+| Invalid configuration        | `ProcessorConfigError` raised at startup |
 
 ## Configuration
 

--- a/libs/waivern-source-code-analyser/src/waivern_source_code_analyser/analyser_config.py
+++ b/libs/waivern-source-code-analyser/src/waivern_source_code_analyser/analyser_config.py
@@ -2,9 +2,10 @@
 
 from typing import Any, Self, override
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 from waivern_core import BaseComponentConfiguration
-from waivern_core.errors import AnalyserConfigError
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 
 from waivern_source_code_analyser.validators import validate_and_normalise_language
 
@@ -48,17 +49,7 @@ class SourceCodeAnalyserConfig(BaseComponentConfiguration):
             Validated configuration object
 
         Raises:
-            AnalyserConfigError: If validation fails
+            ProcessorConfigError: If validation fails
 
         """
-        try:
-            return cls.model_validate(properties)
-        except ValidationError as e:
-            # Provide clear error messages for validation failures
-            raise AnalyserConfigError(
-                f"Invalid source code analyser configuration: {e}"
-            ) from e
-        except ValueError as e:
-            raise AnalyserConfigError(
-                f"Invalid source code analyser configuration: {e}"
-            ) from e
+        return validate_or_raise(cls, properties, ProcessorConfigError)

--- a/libs/waivern-source-code-analyser/tests/waivern_source_code_analyser/test_analyser_config.py
+++ b/libs/waivern-source-code-analyser/tests/waivern_source_code_analyser/test_analyser_config.py
@@ -1,7 +1,7 @@
 """Tests for SourceCodeAnalyserConfig."""
 
 import pytest
-from waivern_core.errors import AnalyserConfigError
+from waivern_core.errors import ProcessorConfigError
 
 from waivern_source_code_analyser.analyser_config import SourceCodeAnalyserConfig
 
@@ -37,34 +37,34 @@ class TestSourceCodeAnalyserConfig:
         assert config.max_file_size == 10 * 1024 * 1024  # 10MB default
 
     def test_invalid_language_empty_string(self):
-        """Test that empty string language raises AnalyserConfigError."""
+        """Test that empty string language raises ProcessorConfigError."""
         # Setup
         properties = {"language": ""}
 
         # Execute & Assert
-        with pytest.raises(AnalyserConfigError) as exc_info:
+        with pytest.raises(ProcessorConfigError) as exc_info:
             SourceCodeAnalyserConfig.from_properties(properties)
 
         assert "Language must be a non-empty string" in str(exc_info.value)
 
     def test_invalid_max_file_size_zero(self):
-        """Test that zero max_file_size raises AnalyserConfigError."""
+        """Test that zero max_file_size raises ProcessorConfigError."""
         # Setup
         properties = {"max_file_size": 0}
 
         # Execute & Assert
-        with pytest.raises(AnalyserConfigError) as exc_info:
+        with pytest.raises(ProcessorConfigError) as exc_info:
             SourceCodeAnalyserConfig.from_properties(properties)
 
         assert "greater than 0" in str(exc_info.value)
 
     def test_invalid_max_file_size_negative(self):
-        """Test that negative max_file_size raises AnalyserConfigError."""
+        """Test that negative max_file_size raises ProcessorConfigError."""
         # Setup
         properties = {"max_file_size": -1}
 
         # Execute & Assert
-        with pytest.raises(AnalyserConfigError) as exc_info:
+        with pytest.raises(ProcessorConfigError) as exc_info:
             SourceCodeAnalyserConfig.from_properties(properties)
 
         assert "greater than 0" in str(exc_info.value)
@@ -86,15 +86,15 @@ class TestSourceCodeAnalyserConfig:
         assert config.max_file_size == 5242880
 
     def test_from_properties_with_invalid_data(self):
-        """Test from_properties() raises AnalyserConfigError on invalid input."""
+        """Test from_properties() raises ProcessorConfigError on invalid input."""
         # Setup
         properties = {"max_file_size": -100}
 
         # Execute & Assert
-        with pytest.raises(AnalyserConfigError) as exc_info:
+        with pytest.raises(ProcessorConfigError) as exc_info:
             SourceCodeAnalyserConfig.from_properties(properties)
 
-        assert "Invalid source code analyser configuration" in str(exc_info.value)
+        assert "Invalid SourceCodeAnalyserConfig" in str(exc_info.value)
 
     def test_language_normalised_to_lowercase(self):
         """Test that language is normalised to lowercase."""


### PR DESCRIPTION
## Summary

Establishes the shared foundations for translating Pydantic validation
failures into framework error types, so configurations stop leaking raw
`ValidationError` to callers. Subsequent work migrates the individual
connector, processor, and service configs onto these primitives.

## Changes

- **`validate_or_raise` helper** (`waivern_core/config_validation.py`) — a
  mechanical `model_validate`-and-translate step that holds no policy and
  never touches the environment. Each config keeps ownership of its own
  assembly and names the category error class to translate into.
- **`WaivernError.validation_errors`** — `WaivernError.__init__` now accepts
  an optional `validation_errors: list[ErrorDetails] | None`, so any framework
  error can carry Pydantic's structured `.errors()` data. The original
  exception is also chained via `__cause__`.
- **`ServiceConfigError`** added to `waivern-core`; `LLMConfigurationError`
  reparented onto it (alongside `LLMServiceError`) so callers can catch any
  service misconfiguration uniformly while the LLM-domain detail survives.
- **`AnalyserConfigError` removed.** Analysers are processors in WCF, so
  `SourceCodeAnalyserConfig` now raises `ProcessorConfigError` via
  `validate_or_raise`, preserving `.errors()`. No in-repo references to the
  removed class remain.

## Checks

Full `dev-checks.sh` green (1967 passed, 5 skipped); basedpyright strict clean.