### PR TITLE
refactor: translate connector config errors via validate_or_raise

### DIFF
--- a/libs/waivern-filesystem/src/waivern_filesystem/config.py
+++ b/libs/waivern-filesystem/src/waivern_filesystem/config.py
@@ -6,10 +6,10 @@ from typing import Annotated, Any, Self, override
 from pydantic import (
     BeforeValidator,
     Field,
-    ValidationError,
     field_validator,
 )
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
 from waivern_core.errors import ConnectorConfigError
 
 
@@ -98,22 +98,6 @@ class FilesystemConnectorConfig(BaseComponentConfiguration):
             ConnectorConfigError: If validation fails or required properties are missing
 
         """
-        try:
-            return cls.model_validate(properties)
-        except ValidationError as e:
-            # Extract specific error messages for better user experience
-            for error in e.errors():
-                if error["loc"] == ("path",):
-                    msg = error.get("msg", "")
-                    if "path property is required" in msg:
-                        raise ConnectorConfigError("path property is required") from e
-                    elif error["type"] == "missing":
-                        raise ConnectorConfigError("path property is required") from e
-            # Fall back to general error message
-            raise ConnectorConfigError(
-                f"Invalid filesystem connector configuration: {e}"
-            ) from e
-        except ValueError as e:
-            raise ConnectorConfigError(
-                f"Invalid filesystem connector configuration: {e}"
-            ) from e
+        if not properties.get("path"):
+            raise ConnectorConfigError("path property is required")
+        return validate_or_raise(cls, properties, ConnectorConfigError)

--- a/libs/waivern-github/src/waivern_github/config.py
+++ b/libs/waivern-github/src/waivern_github/config.py
@@ -6,6 +6,7 @@ from typing import Any, Literal, Self, override
 
 from pydantic import Field, field_validator, model_validator
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
 from waivern_core.errors import ConnectorConfigError
 
 # Type alias for clone strategy - single source of truth
@@ -132,70 +133,64 @@ class GitHubConnectorConfig(BaseComponentConfiguration):
             ConnectorConfigError: If validation fails or required properties are missing
 
         """
-        try:
-            config_data = properties.copy()
+        config_data = properties.copy()
 
-            # Validate required repository field
-            if "repository" not in config_data or not config_data["repository"]:
-                raise ConnectorConfigError("repository property is required")
+        # Validate required repository field
+        if "repository" not in config_data or not config_data["repository"]:
+            raise ConnectorConfigError("repository property is required")
 
-            # Create the config instance first
-            config = cls.model_validate(config_data)
+        # Create the config instance first
+        config = validate_or_raise(cls, config_data, ConnectorConfigError)
 
-            # Handle authentication based on auth_method
-            match config.auth_method:
-                case "pat":
-                    token = os.environ.get("GITHUB_TOKEN")
-                    if token:
-                        object.__setattr__(config, "_token", token)
-                    # Token is optional for public repos
+        # Handle authentication based on auth_method
+        match config.auth_method:
+            case "pat":
+                token = os.environ.get("GITHUB_TOKEN")
+                if token:
+                    object.__setattr__(config, "_token", token)
+                # Token is optional for public repos
 
-                case "app":
-                    # All three are required for GitHub App auth
-                    app_id_str = os.environ.get("GITHUB_APP_ID")
-                    private_key_path_str = os.environ.get("GITHUB_PRIVATE_KEY_PATH")
-                    installation_id_str = os.environ.get("GITHUB_INSTALLATION_ID")
+            case "app":
+                # All three are required for GitHub App auth
+                app_id_str = os.environ.get("GITHUB_APP_ID")
+                private_key_path_str = os.environ.get("GITHUB_PRIVATE_KEY_PATH")
+                installation_id_str = os.environ.get("GITHUB_INSTALLATION_ID")
 
-                    if not app_id_str:
-                        raise ConnectorConfigError(
-                            "GITHUB_APP_ID environment variable is required for GitHub App authentication"
-                        )
-                    if not private_key_path_str:
-                        raise ConnectorConfigError(
-                            "GITHUB_PRIVATE_KEY_PATH environment variable is required for GitHub App authentication"
-                        )
-                    if not installation_id_str:
-                        raise ConnectorConfigError(
-                            "GITHUB_INSTALLATION_ID environment variable is required for GitHub App authentication"
-                        )
+                if not app_id_str:
+                    raise ConnectorConfigError(
+                        "GITHUB_APP_ID environment variable is required for GitHub App authentication"
+                    )
+                if not private_key_path_str:
+                    raise ConnectorConfigError(
+                        "GITHUB_PRIVATE_KEY_PATH environment variable is required for GitHub App authentication"
+                    )
+                if not installation_id_str:
+                    raise ConnectorConfigError(
+                        "GITHUB_INSTALLATION_ID environment variable is required for GitHub App authentication"
+                    )
 
-                    try:
-                        app_id = int(app_id_str)
-                    except ValueError as e:
-                        raise ConnectorConfigError(
-                            f"Invalid GITHUB_APP_ID: must be an integer, got '{app_id_str}'"
-                        ) from e
+                try:
+                    app_id = int(app_id_str)
+                except ValueError as e:
+                    raise ConnectorConfigError(
+                        f"Invalid GITHUB_APP_ID: must be an integer, got '{app_id_str}'"
+                    ) from e
 
-                    try:
-                        installation_id = int(installation_id_str)
-                    except ValueError as e:
-                        raise ConnectorConfigError(
-                            f"Invalid GITHUB_INSTALLATION_ID: must be an integer, got '{installation_id_str}'"
-                        ) from e
+                try:
+                    installation_id = int(installation_id_str)
+                except ValueError as e:
+                    raise ConnectorConfigError(
+                        f"Invalid GITHUB_INSTALLATION_ID: must be an integer, got '{installation_id_str}'"
+                    ) from e
 
-                    private_key_path = Path(private_key_path_str)
-                    if not private_key_path.exists():
-                        raise ConnectorConfigError(
-                            f"GitHub App private key file not found: {private_key_path}"
-                        )
+                private_key_path = Path(private_key_path_str)
+                if not private_key_path.exists():
+                    raise ConnectorConfigError(
+                        f"GitHub App private key file not found: {private_key_path}"
+                    )
 
-                    object.__setattr__(config, "_app_id", app_id)
-                    object.__setattr__(config, "_private_key_path", private_key_path)
-                    object.__setattr__(config, "_installation_id", installation_id)
+                object.__setattr__(config, "_app_id", app_id)
+                object.__setattr__(config, "_private_key_path", private_key_path)
+                object.__setattr__(config, "_installation_id", installation_id)
 
-            return config
-
-        except ValueError as e:
-            raise ConnectorConfigError(
-                f"Invalid GitHub connector configuration: {e}"
-            ) from e
+        return config

--- a/libs/waivern-mongodb/src/waivern_mongodb/config.py
+++ b/libs/waivern-mongodb/src/waivern_mongodb/config.py
@@ -5,6 +5,7 @@ from typing import Any, Self, override
 
 from pydantic import Field, field_validator
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
 from waivern_core.errors import ConnectorConfigError
 
 
@@ -58,30 +59,24 @@ class MongoDBConnectorConfig(BaseComponentConfiguration):
             ConnectorConfigError: If validation fails or required properties are missing
 
         """
-        try:
-            # Merge environment variables with properties (env vars take precedence)
-            config_data = properties.copy()
+        # Merge environment variables with properties (env vars take precedence)
+        config_data = properties.copy()
 
-            # Environment variable overrides
-            if "MONGODB_URI" in os.environ:
-                config_data["uri"] = os.environ["MONGODB_URI"]
-            if "MONGODB_DATABASE" in os.environ:
-                config_data["database"] = os.environ["MONGODB_DATABASE"]
+        # Environment variable overrides
+        if "MONGODB_URI" in os.environ:
+            config_data["uri"] = os.environ["MONGODB_URI"]
+        if "MONGODB_DATABASE" in os.environ:
+            config_data["database"] = os.environ["MONGODB_DATABASE"]
 
-            # Validate required fields are present (either from properties or env)
-            if "uri" not in config_data or config_data["uri"] is None:
-                raise ConnectorConfigError(
-                    "MongoDB uri is required (either 'uri' property or MONGODB_URI env var)"
-                )
-            if "database" not in config_data or config_data["database"] is None:
-                raise ConnectorConfigError(
-                    "MongoDB database is required "
-                    "(either 'database' property or MONGODB_DATABASE env var)"
-                )
-
-            return cls.model_validate(config_data)
-        except ValueError as e:
-            # Convert Pydantic validation errors to ConnectorConfigError
+        # Validate required fields are present (either from properties or env)
+        if "uri" not in config_data or config_data["uri"] is None:
             raise ConnectorConfigError(
-                f"Invalid MongoDB connector configuration: {e}"
-            ) from e
+                "MongoDB uri is required (either 'uri' property or MONGODB_URI env var)"
+            )
+        if "database" not in config_data or config_data["database"] is None:
+            raise ConnectorConfigError(
+                "MongoDB database is required "
+                "(either 'database' property or MONGODB_DATABASE env var)"
+            )
+
+        return validate_or_raise(cls, config_data, ConnectorConfigError)

--- a/libs/waivern-mysql/src/waivern_mysql/config.py
+++ b/libs/waivern-mysql/src/waivern_mysql/config.py
@@ -5,6 +5,7 @@ from typing import Any, Self, override
 
 from pydantic import Field, field_validator
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
 from waivern_core.errors import ConnectorConfigError
 
 
@@ -96,44 +97,38 @@ class MySQLConnectorConfig(BaseComponentConfiguration):
             ConnectorConfigError: If validation fails or required properties are missing
 
         """
-        try:
-            # Merge environment variables with properties (env vars take precedence)
-            config_data = properties.copy()
+        # Merge environment variables with properties (env vars take precedence)
+        config_data = properties.copy()
 
-            # Required properties with env var fallback
-            if "MYSQL_HOST" in os.environ:
-                config_data["host"] = os.environ["MYSQL_HOST"]
-            if "MYSQL_USER" in os.environ:
-                config_data["user"] = os.environ["MYSQL_USER"]
+        # Required properties with env var fallback
+        if "MYSQL_HOST" in os.environ:
+            config_data["host"] = os.environ["MYSQL_HOST"]
+        if "MYSQL_USER" in os.environ:
+            config_data["user"] = os.environ["MYSQL_USER"]
 
-            # Optional properties with env var fallback
-            if "MYSQL_PASSWORD" in os.environ:
-                config_data["password"] = os.environ["MYSQL_PASSWORD"]
-            if "MYSQL_DATABASE" in os.environ:
-                config_data["database"] = os.environ["MYSQL_DATABASE"]
+        # Optional properties with env var fallback
+        if "MYSQL_PASSWORD" in os.environ:
+            config_data["password"] = os.environ["MYSQL_PASSWORD"]
+        if "MYSQL_DATABASE" in os.environ:
+            config_data["database"] = os.environ["MYSQL_DATABASE"]
 
-            # Handle port with validation
-            if "MYSQL_PORT" in os.environ:
-                try:
-                    config_data["port"] = int(os.environ["MYSQL_PORT"])
-                except ValueError as e:
-                    raise ConnectorConfigError(
-                        f"Invalid MYSQL_PORT environment variable: {os.environ['MYSQL_PORT']}"
-                    ) from e
-
-            # Validate required fields are present (either from properties or env)
-            if "host" not in config_data or config_data["host"] is None:
+        # Handle port with validation
+        if "MYSQL_PORT" in os.environ:
+            try:
+                config_data["port"] = int(os.environ["MYSQL_PORT"])
+            except ValueError as e:
                 raise ConnectorConfigError(
-                    "MySQL host info is required (either 'host' property or MYSQL_HOST env var)"
-                )
-            if "user" not in config_data or config_data["user"] is None:
-                raise ConnectorConfigError(
-                    "MySQL user info is required (either 'user' property or MYSQL_USER env var)"
-                )
+                    f"Invalid MYSQL_PORT environment variable: {os.environ['MYSQL_PORT']}"
+                ) from e
 
-            return cls.model_validate(config_data)
-        except ValueError as e:
-            # Convert Pydantic validation errors to ConnectorConfigError
+        # Validate required fields are present (either from properties or env)
+        if "host" not in config_data or config_data["host"] is None:
             raise ConnectorConfigError(
-                f"Invalid MySQL connector configuration: {e}"
-            ) from e
+                "MySQL host info is required (either 'host' property or MYSQL_HOST env var)"
+            )
+        if "user" not in config_data or config_data["user"] is None:
+            raise ConnectorConfigError(
+                "MySQL user info is required (either 'user' property or MYSQL_USER env var)"
+            )
+
+        return validate_or_raise(cls, config_data, ConnectorConfigError)

--- a/libs/waivern-sqlite/src/waivern_sqlite/config.py
+++ b/libs/waivern-sqlite/src/waivern_sqlite/config.py
@@ -3,8 +3,9 @@
 import os
 from typing import Any, Self, override
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, field_validator
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
 from waivern_core.errors import ConnectorConfigError
 
 
@@ -48,17 +49,12 @@ class SQLiteConnectorConfig(BaseComponentConfiguration):
             ConnectorConfigError: If validation fails or required properties are missing
 
         """
-        try:
-            # Environment variables take precedence
-            database_path = os.getenv(
+        # Environment variables take precedence
+        config_data = {
+            "database_path": os.getenv(
                 "SQLITE_DATABASE_PATH", properties.get("database_path", "")
-            )
-            max_rows_per_table = int(properties.get("max_rows_per_table", 10))
+            ),
+            "max_rows_per_table": properties.get("max_rows_per_table", 10),
+        }
 
-            return cls(
-                database_path=database_path,
-                max_rows_per_table=max_rows_per_table,
-            )
-
-        except (ValueError, TypeError, ValidationError) as e:
-            raise ConnectorConfigError(f"SQLite configuration error: {e}") from e
+        return validate_or_raise(cls, config_data, ConnectorConfigError)


### PR DESCRIPTION
## Summary

Replaces each connector config's inline `try/except` with the shared `validate_or_raise` helper, so every `from_properties` translates Pydantic validation failures into `ConnectorConfigError` while preserving the structured `.errors()` data on `error.validation_errors`.

Each override keeps its own assembly logic — the helper holds only the mechanical validate-and-translate tail:

- **Filesystem** — guards the missing path with an explicit pre-check rather than remapping Pydantic's missing-field error.
- **MongoDB / MySQL** — retain environment-variable overlay and required-field pre-checks; MySQL keeps its narrow `MYSQL_PORT` int-cast guard.
- **SQLite** — lets Pydantic coerce `max_rows_per_table` instead of a manual `int()` cast, so malformed input also routes through the helper instead of escaping as a raw `ValueError`.
- **GitHub** — keeps its `auth_method` dispatch and frozen-field enrichment via `object.__setattr__` after validation.

## Verification

No new tests added — this is a pure refactor of the failure path, and the existing per-connector config suites already pin every translated message. Full `dev-checks.sh` (format, lint, basedpyright strict, tests) passes.