### PR TITLE
refactor: translate analyser config errors via validate_or_raise

### DIFF
--- a/libs/waivern-crypto-quality-analyser/src/waivern_crypto_quality_analyser/types.py
+++ b/libs/waivern-crypto-quality-analyser/src/waivern_crypto_quality_analyser/types.py
@@ -1,8 +1,12 @@
 """Configuration types for crypto quality analyser."""
 
+from typing import Any, Self, override
+
 from pydantic import Field
 from waivern_analysers_shared.types import PatternMatchingConfig
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 
 
 class CryptoQualityAnalyserConfig(BaseComponentConfiguration):
@@ -11,7 +15,6 @@ class CryptoQualityAnalyserConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen dataclass)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
 
     No LLM validation config — crypto quality assessment is deterministic.
@@ -26,4 +29,19 @@ class CryptoQualityAnalyserConfig(BaseComponentConfiguration):
         description="Pattern matching configuration for crypto algorithm detection",
     )
 
-    # from_properties() inherited from BaseComponentConfiguration
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)

--- a/libs/waivern-data-collection-analyser/src/waivern_data_collection_analyser/types.py
+++ b/libs/waivern-data-collection-analyser/src/waivern_data_collection_analyser/types.py
@@ -1,10 +1,12 @@
 """Configuration types for data collection analyser."""
 
-from typing import Literal
+from typing import Any, Literal, Self, override
 
 from pydantic import Field
 from waivern_analysers_shared.types import PatternMatchingConfig
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 
 SourceCodeContextWindow = Literal["small", "medium", "large", "full"]
 
@@ -15,7 +17,6 @@ class DataCollectionAnalyserConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen dataclass)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
 
     No LLM validation config — data collection detection is deterministic.
@@ -32,3 +33,20 @@ class DataCollectionAnalyserConfig(BaseComponentConfiguration):
         default="small",
         description="Size of source code context window around matches",
     )
+
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/types.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/types.py
@@ -1,6 +1,6 @@
 """Configuration and state types for data subject analyser."""
 
-from typing import Literal
+from typing import Any, Literal, Self, override
 
 from pydantic import BaseModel, Field
 from waivern_analysers_shared.llm_validation.validation_orchestrator import (
@@ -11,6 +11,8 @@ from waivern_analysers_shared.types import (
     PatternMatchingConfig,
 )
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 from waivern_schemas.data_subject_indicator import DataSubjectIndicatorModel
 
 # Type alias for source code context window sizes
@@ -43,6 +45,23 @@ class DataSubjectAnalyserConfig(BaseComponentConfiguration):
             "'large' (±50 lines), 'full' (entire file)"
         ),
     )
+
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)
 
 
 class DataSubjectPrepareState(BaseModel):

--- a/libs/waivern-gdpr-data-collection-classifier/src/waivern_gdpr_data_collection_classifier/types.py
+++ b/libs/waivern-gdpr-data-collection-classifier/src/waivern_gdpr_data_collection_classifier/types.py
@@ -1,7 +1,11 @@
 """Configuration types for GDPR data collection classifier."""
 
+from typing import Any, Self, override
+
 from pydantic import Field
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 
 
 class GDPRDataCollectionClassifierConfig(BaseComponentConfiguration):
@@ -10,7 +14,6 @@ class GDPRDataCollectionClassifierConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
     """
 
@@ -18,3 +21,20 @@ class GDPRDataCollectionClassifierConfig(BaseComponentConfiguration):
         default="local/gdpr_data_collection_classification/1.0.0",
         description="Ruleset URI for GDPR data collection classification rules",
     )
+
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)

--- a/libs/waivern-gdpr-data-subject-classifier/src/waivern_gdpr_data_subject_classifier/types.py
+++ b/libs/waivern-gdpr-data-subject-classifier/src/waivern_gdpr_data_subject_classifier/types.py
@@ -1,8 +1,12 @@
 """Configuration and state types for GDPR data subject classifier."""
 
+from typing import Any, Self, override
+
 from pydantic import BaseModel, Field
 from waivern_analysers_shared.types import LLMValidationConfig
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 from waivern_schemas.gdpr_data_subject import GDPRDataSubjectFindingModel
 
 
@@ -12,7 +16,6 @@ class GDPRDataSubjectClassifierConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
     """
 
@@ -24,6 +27,23 @@ class GDPRDataSubjectClassifierConfig(BaseComponentConfiguration):
         default_factory=LLMValidationConfig,
         description="LLM validation configuration for risk modifier detection",
     )
+
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)
 
 
 class GDPRDataSubjectPrepareState(BaseModel):

--- a/libs/waivern-gdpr-personal-data-classifier/src/waivern_gdpr_personal_data_classifier/types.py
+++ b/libs/waivern-gdpr-personal-data-classifier/src/waivern_gdpr_personal_data_classifier/types.py
@@ -1,7 +1,11 @@
 """Configuration types for GDPR personal data classifier."""
 
+from typing import Any, Self, override
+
 from pydantic import Field
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 
 
 class GDPRPersonalDataClassifierConfig(BaseComponentConfiguration):
@@ -10,7 +14,6 @@ class GDPRPersonalDataClassifierConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
     """
 
@@ -18,3 +21,20 @@ class GDPRPersonalDataClassifierConfig(BaseComponentConfiguration):
         default="local/gdpr_personal_data_classification/1.0.0",
         description="Ruleset URI for GDPR personal data classification rules",
     )
+
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)

--- a/libs/waivern-gdpr-processing-purpose-classifier/src/waivern_gdpr_processing_purpose_classifier/types.py
+++ b/libs/waivern-gdpr-processing-purpose-classifier/src/waivern_gdpr_processing_purpose_classifier/types.py
@@ -1,7 +1,11 @@
 """Configuration types for GDPR processing purpose classifier."""
 
+from typing import Any, Self, override
+
 from pydantic import Field
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 
 
 class GDPRProcessingPurposeClassifierConfig(BaseComponentConfiguration):
@@ -10,7 +14,6 @@ class GDPRProcessingPurposeClassifierConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
     """
 
@@ -18,3 +21,20 @@ class GDPRProcessingPurposeClassifierConfig(BaseComponentConfiguration):
         default="local/gdpr_processing_purpose_classification/1.0.0",
         description="Ruleset URI for GDPR processing purpose classification rules",
     )
+
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)

--- a/libs/waivern-gdpr-service-integration-classifier/src/waivern_gdpr_service_integration_classifier/types.py
+++ b/libs/waivern-gdpr-service-integration-classifier/src/waivern_gdpr_service_integration_classifier/types.py
@@ -1,7 +1,11 @@
 """Configuration types for GDPR service integration classifier."""
 
+from typing import Any, Self, override
+
 from pydantic import Field
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 
 
 class GDPRServiceIntegrationClassifierConfig(BaseComponentConfiguration):
@@ -10,7 +14,6 @@ class GDPRServiceIntegrationClassifierConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
     """
 
@@ -18,3 +21,20 @@ class GDPRServiceIntegrationClassifierConfig(BaseComponentConfiguration):
         default="local/gdpr_service_integration_classification/1.0.0",
         description="Ruleset URI for GDPR service integration classification rules",
     )
+
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)

--- a/libs/waivern-iso27001-control-assessor/src/waivern_iso27001_control_assessor/types.py
+++ b/libs/waivern-iso27001-control-assessor/src/waivern_iso27001_control_assessor/types.py
@@ -1,7 +1,11 @@
 """Configuration and state types for ISO 27001 control assessor."""
 
+from typing import Any, Self, override
+
 from pydantic import BaseModel, ConfigDict, Field
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 from waivern_rulesets.iso27001_domains import ISO27001DomainsRule
 from waivern_schemas.iso27001_assessment import EvidenceStatus
 from waivern_schemas.security_document_context import SecurityDocumentContextModel
@@ -41,7 +45,6 @@ class ISO27001AssessorConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen dataclass)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
     """
 
@@ -57,6 +60,23 @@ class ISO27001AssessorConfig(BaseComponentConfiguration):
         default_factory=EvidenceSamplingConfig,
         description="Stratified evidence sampling configuration",
     )
+
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)
 
 
 class ISO27001PrepareState(BaseModel):

--- a/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/types.py
+++ b/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/types.py
@@ -1,5 +1,7 @@
 """Configuration and state types for personal data analysis analyser."""
 
+from typing import Any, Self, override
+
 from pydantic import BaseModel, Field
 from waivern_analysers_shared.llm_validation.validation_orchestrator import (
     OrchestratorPrepareState,
@@ -9,6 +11,8 @@ from waivern_analysers_shared.types import (
     PatternMatchingConfig,
 )
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 from waivern_schemas.personal_data_indicator import PersonalDataIndicatorModel
 
 
@@ -21,7 +25,6 @@ class PersonalDataAnalyserConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen dataclass)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
     """
 
@@ -36,7 +39,22 @@ class PersonalDataAnalyserConfig(BaseComponentConfiguration):
         description="LLM validation configuration for filtering false positives",
     )
 
-    # from_properties() inherited from BaseComponentConfiguration
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)
 
 
 class PersonalDataPrepareState(BaseModel):

--- a/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/types.py
+++ b/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/types.py
@@ -1,6 +1,6 @@
 """Configuration and state types for processing purpose analyser."""
 
-from typing import Literal
+from typing import Any, Literal, Self, override
 
 from pydantic import BaseModel, Field
 from waivern_analysers_shared.llm_validation.validation_orchestrator import (
@@ -11,6 +11,8 @@ from waivern_analysers_shared.types import (
     PatternMatchingConfig,
 )
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 from waivern_schemas.processing_purpose_indicator import ProcessingPurposeIndicatorModel
 
 # Type alias for source code context window sizes
@@ -26,7 +28,6 @@ class ProcessingPurposeAnalyserConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen dataclass)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
     """
 
@@ -46,7 +47,22 @@ class ProcessingPurposeAnalyserConfig(BaseComponentConfiguration):
         description="Context window size for source code evidence: 'small' (±3 lines), 'medium' (±15 lines), 'large' (±50 lines), 'full' (entire file)",
     )
 
-    # from_properties() inherited from BaseComponentConfiguration
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)
 
 
 class ProcessingPurposePrepareState(BaseModel):

--- a/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_config.py
+++ b/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_config.py
@@ -1,7 +1,7 @@
 """Tests for ProcessingPurposeAnalyserConfig."""
 
 import pytest
-from pydantic import ValidationError
+from waivern_core.errors import ProcessorConfigError
 
 from waivern_processing_purpose_analyser.types import (
     ProcessingPurposeAnalyserConfig,
@@ -49,17 +49,17 @@ class TestProcessingPurposeAnalyserConfig:
         assert config.llm_validation.enable_llm_validation is True
         assert config.llm_validation.llm_validation_mode == "conservative"
 
-    def test_from_properties_invalid_ruleset_type_raises_validation_error(self):
+    def test_from_properties_invalid_ruleset_type_raises_processor_config_error(self):
         """Test from_properties rejects invalid ruleset type."""
         invalid_properties = {"pattern_matching": {"ruleset": 123}}
 
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ProcessorConfigError) as exc_info:
             ProcessingPurposeAnalyserConfig.from_properties(invalid_properties)
 
         # Verify error mentions the field with type issue
         assert "ruleset" in str(exc_info.value)
 
-    def test_from_properties_invalid_evidence_context_size_raises_validation_error(
+    def test_from_properties_invalid_evidence_context_size_raises_processor_config_error(
         self,
     ):
         """Test from_properties rejects invalid evidence context size enum."""
@@ -67,7 +67,7 @@ class TestProcessingPurposeAnalyserConfig:
             "pattern_matching": {"evidence_context_size": "invalid_size"}
         }
 
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ProcessorConfigError) as exc_info:
             ProcessingPurposeAnalyserConfig.from_properties(invalid_properties)
 
         # Verify error mentions the invalid enum value
@@ -75,14 +75,14 @@ class TestProcessingPurposeAnalyserConfig:
         assert "evidence_context_size" in error_message
         assert "small" in error_message or "medium" in error_message
 
-    def test_from_properties_invalid_maximum_evidence_count_raises_validation_error(
+    def test_from_properties_invalid_maximum_evidence_count_raises_processor_config_error(
         self,
     ):
         """Test from_properties rejects maximum evidence count outside valid range."""
         # Test below minimum (< 1)
         invalid_properties_low = {"pattern_matching": {"maximum_evidence_count": 0}}
 
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ProcessorConfigError) as exc_info:
             ProcessingPurposeAnalyserConfig.from_properties(invalid_properties_low)
 
         assert "maximum_evidence_count" in str(exc_info.value)
@@ -90,7 +90,7 @@ class TestProcessingPurposeAnalyserConfig:
         # Test above maximum (> 20)
         invalid_properties_high = {"pattern_matching": {"maximum_evidence_count": 21}}
 
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ProcessorConfigError) as exc_info:
             ProcessingPurposeAnalyserConfig.from_properties(invalid_properties_high)
 
         assert "maximum_evidence_count" in str(exc_info.value)
@@ -102,7 +102,7 @@ class TestProcessingPurposeAnalyserConfig:
             "unknown_field": "should_not_be_accepted",
         }
 
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ProcessorConfigError) as exc_info:
             ProcessingPurposeAnalyserConfig.from_properties(invalid_properties)
 
         # Verify error mentions extra field
@@ -129,7 +129,7 @@ class TestSourceCodeContextWindowConfig:
         invalid_properties = {"source_code_context_window": "invalid_size"}
 
         # Act & Assert
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ProcessorConfigError) as exc_info:
             ProcessingPurposeAnalyserConfig.from_properties(invalid_properties)
 
         # Verify error mentions the field

--- a/libs/waivern-security-control-analyser/src/waivern_security_control_analyser/types.py
+++ b/libs/waivern-security-control-analyser/src/waivern_security_control_analyser/types.py
@@ -1,8 +1,12 @@
 """Configuration types for security control analyser."""
 
+from typing import Any, Self, override
+
 from pydantic import Field
 from waivern_analysers_shared.types import PatternMatchingConfig
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 
 
 class SecurityControlAnalyserConfig(BaseComponentConfiguration):
@@ -11,7 +15,6 @@ class SecurityControlAnalyserConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen dataclass)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
 
     No LLM validation config — security control detection is deterministic.
@@ -26,4 +29,19 @@ class SecurityControlAnalyserConfig(BaseComponentConfiguration):
         description="Pattern matching configuration for security control detection",
     )
 
-    # from_properties() inherited from BaseComponentConfiguration
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)

--- a/libs/waivern-security-document-evidence-extractor/src/waivern_security_document_evidence_extractor/types.py
+++ b/libs/waivern-security-document-evidence-extractor/src/waivern_security_document_evidence_extractor/types.py
@@ -1,9 +1,12 @@
 """Configuration and LLM interaction types for the extractor."""
 
 import uuid
+from typing import Any, Self, override
 
 from pydantic import BaseModel, Field
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 from waivern_schemas.security_document_context import SecurityDocumentContextMetadata
 from waivern_schemas.security_domain import SecurityDomain
 
@@ -14,6 +17,23 @@ class SecurityDocumentEvidenceExtractorConfig(BaseComponentConfiguration):
     Domain vocabulary comes from the SecurityDomain enum directly —
     no ruleset config needed.
     """
+
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)
 
 
 class DocumentItem(BaseModel):

--- a/libs/waivern-security-evidence-normaliser/src/waivern_security_evidence_normaliser/types.py
+++ b/libs/waivern-security-evidence-normaliser/src/waivern_security_evidence_normaliser/types.py
@@ -1,7 +1,11 @@
 """Configuration types for security evidence normaliser."""
 
+from typing import Any, Self, override
+
 from pydantic import Field
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 
 
 class SecurityEvidenceNormaliserConfig(BaseComponentConfiguration):
@@ -9,7 +13,6 @@ class SecurityEvidenceNormaliserConfig(BaseComponentConfiguration):
 
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
 
     No LLM configuration — normalisation is fully deterministic.
@@ -28,3 +31,20 @@ class SecurityEvidenceNormaliserConfig(BaseComponentConfiguration):
             "Snippets are collected across all findings in a group and capped at this value."
         ),
     )
+
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)

--- a/libs/waivern-security-evidence-normaliser/tests/waivern_security_evidence_normaliser/test_analyser.py
+++ b/libs/waivern-security-evidence-normaliser/tests/waivern_security_evidence_normaliser/test_analyser.py
@@ -3,8 +3,8 @@
 import logging
 
 import pytest
-from pydantic import ValidationError
 from waivern_core import AnalyserContractTests
+from waivern_core.errors import ProcessorConfigError
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
 
@@ -20,9 +20,11 @@ class TestSecurityEvidenceNormaliserConfig:
     """Tests for SecurityEvidenceNormaliserConfig validation."""
 
     def test_maximum_evidence_items_must_be_at_least_one(self) -> None:
-        """maximum_evidence_items=0 raises a validation error."""
-        with pytest.raises(ValidationError):
-            SecurityEvidenceNormaliserConfig(maximum_evidence_items=0)
+        """from_properties rejects maximum_evidence_items=0 with a config error."""
+        with pytest.raises(ProcessorConfigError):
+            SecurityEvidenceNormaliserConfig.from_properties(
+                {"maximum_evidence_items": 0}
+            )
 
 
 class TestSecurityEvidenceNormaliserContract(

--- a/libs/waivern-service-integration-analyser/src/waivern_service_integration_analyser/types.py
+++ b/libs/waivern-service-integration-analyser/src/waivern_service_integration_analyser/types.py
@@ -1,10 +1,12 @@
 """Configuration types for service integration analyser."""
 
-from typing import Literal
+from typing import Any, Literal, Self, override
 
 from pydantic import Field
 from waivern_analysers_shared.types import PatternMatchingConfig
 from waivern_core import BaseComponentConfiguration
+from waivern_core.config_validation import validate_or_raise
+from waivern_core.errors import ProcessorConfigError
 
 SourceCodeContextWindow = Literal["small", "medium", "large", "full"]
 
@@ -15,7 +17,6 @@ class ServiceIntegrationAnalyserConfig(BaseComponentConfiguration):
     Inherits from BaseComponentConfiguration to support:
     - Pydantic validation for type safety
     - Immutability (frozen dataclass)
-    - from_properties() factory method (inherited)
     - Strict validation (no extra fields)
 
     No LLM validation config — service integration detection is deterministic.
@@ -32,3 +33,20 @@ class ServiceIntegrationAnalyserConfig(BaseComponentConfiguration):
         default="small",
         description="Size of source code context window around matches",
     )
+
+    @classmethod
+    @override
+    def from_properties(cls, properties: dict[str, Any]) -> Self:
+        """Create configuration from runbook properties.
+
+        Args:
+            properties: Raw properties from runbook configuration
+
+        Returns:
+            Validated configuration object
+
+        Raises:
+            ProcessorConfigError: If validation fails
+
+        """
+        return validate_or_raise(cls, properties, ProcessorConfigError)


### PR DESCRIPTION
## Summary

Every analyser and classifier configuration now overrides `from_properties` to translate Pydantic validation failures into `ProcessorConfigError` via the shared `validate_or_raise` helper. Callers receive a uniform framework error at the configuration boundary instead of a raw `ValidationError`, matching the contract the source-code analyser config already follows.

The override is the bare canonical form — these configs carry no environment-variable overlay or pre-checks, so assembly is just validate-and-translate.

## Changes

- Add a translating `from_properties` override to the 15 analyser/classifier configs that previously inherited the default.
- Standardise the two affected config test suites to assert the translated error through `from_properties` (the public assembly seam) rather than a raw `ValidationError`; the security evidence normaliser test moves off direct construction onto that seam.
- Drop the now-inaccurate "inherited" `from_properties` markers from the class docstrings.

## Verification

No new tests beyond the two standardised suites: the translation helper is unit-tested already, and the per-config override carries no assembly logic to exercise. Existing config test suites pin the translated messages. Full `dev-checks.sh` passes (lint, format, basedpyright strict, tests).