### PR TITLE
refactor: propagate config errors from factory create()

### DIFF
--- a/libs/waivern-core/src/waivern_core/component_factory.py
+++ b/libs/waivern-core/src/waivern_core/component_factory.py
@@ -95,6 +95,13 @@ class ComponentFactory[T](ABC):
         with execution-specific configuration. The factory injects any required
         infrastructure services (LLM, database, cache) into the component.
 
+        ``create()`` must let the config's translated error propagate. Do NOT gate it
+        on ``can_create()`` (e.g. ``if not self.can_create(config): raise
+        ValueError(...)``): that collapses the precise category error into a generic
+        one and hides the validation detail from the caller. ``can_create()`` is the
+        boolean shadow for graceful degradation; ``create()`` is the path that
+        surfaces *why* a configuration is invalid.
+
         Args:
             config: Configuration dict from runbook properties.
                    Factory validates and converts to typed config internally.
@@ -103,8 +110,9 @@ class ComponentFactory[T](ABC):
             Configured component instance ready for execution.
 
         Raises:
-            ValueError: If configuration is invalid or missing required fields
-            RuntimeError: If component creation fails (e.g., service unavailable)
+            ConnectorConfigError | ProcessorConfigError: If the configuration is
+                invalid (connectors raise the former, processors the latter).
+            RuntimeError: If component creation fails (e.g., service unavailable).
 
         Example:
             >>> factory = PersonalDataAnalyserFactory(container)
@@ -150,8 +158,12 @@ class ComponentFactory[T](ABC):
         - Remote service health (for SaaS wrappers)
         - Any other prerequisites for component creation
 
-        This is called by the executor before attempting to create the component,
-        allowing graceful degradation when services are unavailable.
+        This is the non-constructing boolean shadow of ``create()``'s preconditions:
+        it reports yes/no only and MUST NOT build the component (a connector may open
+        a socket or database connection in ``__init__``), so it cannot be defined as
+        "try ``create()``". Implement it as ``try: <checks>; return True`` /
+        ``except Exception: return False`` over the same preconditions ``create()``
+        requires, allowing the caller to degrade gracefully when they do not hold.
 
         Args:
             config: Configuration to validate (from runbook properties)

--- a/libs/waivern-crypto-quality-analyser/src/waivern_crypto_quality_analyser/factory.py
+++ b/libs/waivern-crypto-quality-analyser/src/waivern_crypto_quality_analyser/factory.py
@@ -38,12 +38,9 @@ class CryptoQualityAnalyserFactory(ComponentFactory[CryptoQualityAnalyser]):
             Configured CryptoQualityAnalyser instance
 
         Raises:
-            ValueError: If configuration is invalid or ruleset cannot be loaded
+            ProcessorConfigError: If the configuration is invalid
 
         """
-        if not self.can_create(config):
-            raise ValueError("Cannot create analyser with given configuration")
-
         analyser_config = CryptoQualityAnalyserConfig.from_properties(config)
         return CryptoQualityAnalyser(config=analyser_config)
 

--- a/libs/waivern-crypto-quality-analyser/tests/waivern_crypto_quality_analyser/test_factory.py
+++ b/libs/waivern-crypto-quality-analyser/tests/waivern_crypto_quality_analyser/test_factory.py
@@ -15,6 +15,7 @@ from waivern_core import (
     ComponentFactory,
     ComponentFactoryContractTests,
 )
+from waivern_core.errors import ProcessorConfigError
 from waivern_core.services import ServiceContainer
 from waivern_rulesets import AbstractRuleset
 from waivern_rulesets.crypto_quality_indicator import CryptoQualityIndicatorRule
@@ -92,3 +93,12 @@ class TestCryptoQualityAnalyserFactory(
         }
 
         assert factory.can_create(config_with_nonexistent_ruleset) is False
+
+    def test_create_raises_processor_config_error_for_invalid_config(self) -> None:
+        """create() surfaces the translated config error, not a generic ValueError."""
+        factory = CryptoQualityAnalyserFactory(ServiceContainer())
+
+        with pytest.raises(
+            ProcessorConfigError, match="Invalid CryptoQualityAnalyserConfig"
+        ):
+            factory.create({"unknown_field": "value"})

--- a/libs/waivern-data-collection-analyser/src/waivern_data_collection_analyser/factory.py
+++ b/libs/waivern-data-collection-analyser/src/waivern_data_collection_analyser/factory.py
@@ -37,12 +37,9 @@ class DataCollectionAnalyserFactory(ComponentFactory[DataCollectionAnalyser]):
             Configured DataCollectionAnalyser instance.
 
         Raises:
-            ValueError: If configuration is invalid or ruleset cannot be loaded.
+            ProcessorConfigError: If the configuration is invalid.
 
         """
-        if not self.can_create(config):
-            raise ValueError("Cannot create analyser with given configuration")
-
         analyser_config = DataCollectionAnalyserConfig.from_properties(config)
         return DataCollectionAnalyser(config=analyser_config)
 

--- a/libs/waivern-data-collection-analyser/tests/waivern_data_collection_analyser/test_analyser.py
+++ b/libs/waivern-data-collection-analyser/tests/waivern_data_collection_analyser/test_analyser.py
@@ -2,6 +2,7 @@
 
 import pytest
 from waivern_core import AnalyserContractTests
+from waivern_core.errors import ProcessorConfigError
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
 from waivern_core.services import ServiceContainer
@@ -454,3 +455,13 @@ class TestDataCollectionFactory:
             "pattern_matching": {"ruleset": "local/nonexistent/1.0.0"},
         }
         assert factory.can_create(properties) is False
+
+    def test_create_raises_processor_config_error_for_invalid_config(self) -> None:
+        """create() surfaces the translated config error, not a generic ValueError."""
+        container = ServiceContainer()
+        factory = DataCollectionAnalyserFactory(container)
+
+        with pytest.raises(
+            ProcessorConfigError, match="Invalid DataCollectionAnalyserConfig"
+        ):
+            factory.create({"unknown_field": "value"})

--- a/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/factory.py
+++ b/libs/waivern-data-subject-analyser/src/waivern_data_subject_analyser/factory.py
@@ -30,9 +30,6 @@ class DataSubjectAnalyserFactory(ComponentFactory[DataSubjectAnalyser]):
     @override
     def create(self, config: ComponentConfig) -> DataSubjectAnalyser:
         """Create a DataSubjectAnalyser from configuration."""
-        if not self.can_create(config):
-            raise ValueError("Cannot create analyser with given configuration")
-
         return DataSubjectAnalyser(
             config=DataSubjectAnalyserConfig.from_properties(config),
         )

--- a/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_factory.py
+++ b/libs/waivern-data-subject-analyser/tests/waivern_data_subject_analyser/test_factory.py
@@ -15,6 +15,7 @@ from waivern_core import (
     ComponentFactory,
     ComponentFactoryContractTests,
 )
+from waivern_core.errors import ProcessorConfigError
 from waivern_core.services import ServiceContainer
 from waivern_rulesets import AbstractRuleset
 from waivern_rulesets.data_subject_indicator import DataSubjectIndicatorRule
@@ -88,3 +89,12 @@ class TestDataSubjectAnalyserFactory(
         }
 
         assert factory.can_create(config_with_nonexistent_ruleset) is False
+
+    def test_create_raises_processor_config_error_for_invalid_config(self) -> None:
+        """create() surfaces the translated config error, not a generic ValueError."""
+        factory = DataSubjectAnalyserFactory(ServiceContainer())
+
+        with pytest.raises(
+            ProcessorConfigError, match="Invalid DataSubjectAnalyserConfig"
+        ):
+            factory.create({"unknown_field": "value"})

--- a/libs/waivern-gdpr-data-subject-classifier/src/waivern_gdpr_data_subject_classifier/factory.py
+++ b/libs/waivern-gdpr-data-subject-classifier/src/waivern_gdpr_data_subject_classifier/factory.py
@@ -30,9 +30,6 @@ class GDPRDataSubjectClassifierFactory(ComponentFactory[GDPRDataSubjectClassifie
     @override
     def create(self, config: ComponentConfig) -> GDPRDataSubjectClassifier:
         """Create a GDPRDataSubjectClassifier from configuration."""
-        if not self.can_create(config):
-            raise ValueError("Cannot create classifier with given configuration")
-
         return GDPRDataSubjectClassifier(
             config=GDPRDataSubjectClassifierConfig.from_properties(config),
         )

--- a/libs/waivern-gdpr-data-subject-classifier/tests/waivern_gdpr_data_subject_classifier/test_factory.py
+++ b/libs/waivern-gdpr-data-subject-classifier/tests/waivern_gdpr_data_subject_classifier/test_factory.py
@@ -6,6 +6,7 @@ from waivern_core import (
     ComponentFactory,
     ComponentFactoryContractTests,
 )
+from waivern_core.errors import ProcessorConfigError
 from waivern_core.services import ServiceContainer
 
 from waivern_gdpr_data_subject_classifier import GDPRDataSubjectClassifier
@@ -39,3 +40,12 @@ class TestGDPRDataSubjectClassifierFactory(
         assert (
             factory.can_create({"ruleset": "local/nonexistent_ruleset/1.0.0"}) is False
         )
+
+    def test_create_raises_processor_config_error_for_invalid_config(self) -> None:
+        """create() surfaces the translated config error, not a generic ValueError."""
+        factory = GDPRDataSubjectClassifierFactory(ServiceContainer())
+
+        with pytest.raises(
+            ProcessorConfigError, match="Invalid GDPRDataSubjectClassifierConfig"
+        ):
+            factory.create({"unknown_field": "value"})

--- a/libs/waivern-iso27001-control-assessor/src/waivern_iso27001_control_assessor/factory.py
+++ b/libs/waivern-iso27001-control-assessor/src/waivern_iso27001_control_assessor/factory.py
@@ -30,9 +30,6 @@ class ISO27001AssessorFactory(ComponentFactory[ISO27001Assessor]):
     @override
     def create(self, config: ComponentConfig) -> ISO27001Assessor:
         """Create an ISO27001Assessor from configuration."""
-        if not self.can_create(config):
-            raise ValueError("Cannot create assessor with given configuration")
-
         return ISO27001Assessor(
             config=ISO27001AssessorConfig.from_properties(config),
         )

--- a/libs/waivern-iso27001-control-assessor/tests/waivern_iso27001_control_assessor/test_factory.py
+++ b/libs/waivern-iso27001-control-assessor/tests/waivern_iso27001_control_assessor/test_factory.py
@@ -2,6 +2,7 @@
 
 import pytest
 from waivern_core import ComponentConfig, ComponentFactory
+from waivern_core.errors import ProcessorConfigError
 from waivern_core.services import ServiceContainer
 from waivern_core.testing import AnalyserContractTests, ComponentFactoryContractTests
 
@@ -45,3 +46,12 @@ class TestISO27001AssessorFactory:
         result = factory.can_create({"domain_ruleset": "local/iso27001_domains/1.0.0"})
 
         assert result is False
+
+    def test_create_raises_processor_config_error_for_invalid_config(self) -> None:
+        """create() surfaces the translated config error, not a generic ValueError."""
+        factory = ISO27001AssessorFactory(ServiceContainer())
+
+        with pytest.raises(
+            ProcessorConfigError, match="Invalid ISO27001AssessorConfig"
+        ):
+            factory.create({"unknown_field": "value"})

--- a/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/factory.py
+++ b/libs/waivern-personal-data-analyser/src/waivern_personal_data_analyser/factory.py
@@ -41,12 +41,9 @@ class PersonalDataAnalyserFactory(ComponentFactory[PersonalDataAnalyser]):
             Configured PersonalDataAnalyser instance.
 
         Raises:
-            ValueError: If configuration is invalid.
+            ProcessorConfigError: If the configuration is invalid.
 
         """
-        if not self.can_create(config):
-            raise ValueError("Cannot create analyser with given configuration")
-
         return PersonalDataAnalyser(
             config=PersonalDataAnalyserConfig.from_properties(config),
         )

--- a/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_factory.py
+++ b/libs/waivern-personal-data-analyser/tests/waivern_personal_data_analyser/test_factory.py
@@ -15,6 +15,7 @@ from waivern_core import (
     ComponentFactory,
     ComponentFactoryContractTests,
 )
+from waivern_core.errors import ProcessorConfigError
 from waivern_core.services import ServiceContainer
 from waivern_rulesets import AbstractRuleset
 from waivern_rulesets.personal_data_indicator import PersonalDataIndicatorRule
@@ -95,3 +96,12 @@ class TestPersonalDataAnalyserFactory(
         }
 
         assert factory.can_create(config_with_nonexistent_ruleset) is False
+
+    def test_create_raises_processor_config_error_for_invalid_config(self) -> None:
+        """create() surfaces the translated config error, not a generic ValueError."""
+        factory = PersonalDataAnalyserFactory(ServiceContainer())
+
+        with pytest.raises(
+            ProcessorConfigError, match="Invalid PersonalDataAnalyserConfig"
+        ):
+            factory.create({"unknown_field": "value"})

--- a/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/factory.py
+++ b/libs/waivern-processing-purpose-analyser/src/waivern_processing_purpose_analyser/factory.py
@@ -30,9 +30,6 @@ class ProcessingPurposeAnalyserFactory(ComponentFactory[ProcessingPurposeAnalyse
     @override
     def create(self, config: ComponentConfig) -> ProcessingPurposeAnalyser:
         """Create a ProcessingPurposeAnalyser from configuration."""
-        if not self.can_create(config):
-            raise ValueError("Cannot create analyser with given configuration")
-
         return ProcessingPurposeAnalyser(
             config=ProcessingPurposeAnalyserConfig.from_properties(config),
         )

--- a/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_factory.py
+++ b/libs/waivern-processing-purpose-analyser/tests/waivern_processing_purpose_analyser/test_factory.py
@@ -6,6 +6,7 @@ from waivern_core import (
     ComponentFactory,
     ComponentFactoryContractTests,
 )
+from waivern_core.errors import ProcessorConfigError
 from waivern_core.services import ServiceContainer
 
 from waivern_processing_purpose_analyser import ProcessingPurposeAnalyser
@@ -46,3 +47,12 @@ class TestProcessingPurposeAnalyserFactory(
         }
 
         assert factory.can_create(config_with_nonexistent_ruleset) is False
+
+    def test_create_raises_processor_config_error_for_invalid_config(self) -> None:
+        """create() surfaces the translated config error, not a generic ValueError."""
+        factory = ProcessingPurposeAnalyserFactory(ServiceContainer())
+
+        with pytest.raises(
+            ProcessorConfigError, match="Invalid ProcessingPurposeAnalyserConfig"
+        ):
+            factory.create({"unknown_field": "value"})

--- a/libs/waivern-security-control-analyser/src/waivern_security_control_analyser/factory.py
+++ b/libs/waivern-security-control-analyser/src/waivern_security_control_analyser/factory.py
@@ -38,12 +38,9 @@ class SecurityControlAnalyserFactory(ComponentFactory[SecurityControlAnalyser]):
             Configured SecurityControlAnalyser instance
 
         Raises:
-            ValueError: If configuration is invalid or ruleset cannot be loaded
+            ProcessorConfigError: If the configuration is invalid
 
         """
-        if not self.can_create(config):
-            raise ValueError("Cannot create analyser with given configuration")
-
         analyser_config = SecurityControlAnalyserConfig.from_properties(config)
         return SecurityControlAnalyser(config=analyser_config)
 

--- a/libs/waivern-security-control-analyser/tests/waivern_security_control_analyser/test_factory.py
+++ b/libs/waivern-security-control-analyser/tests/waivern_security_control_analyser/test_factory.py
@@ -15,6 +15,7 @@ from waivern_core import (
     ComponentFactory,
     ComponentFactoryContractTests,
 )
+from waivern_core.errors import ProcessorConfigError
 from waivern_core.services import ServiceContainer
 from waivern_rulesets import AbstractRuleset
 from waivern_rulesets.security_control_indicator import SecurityControlIndicatorRule
@@ -93,3 +94,12 @@ class TestSecurityControlAnalyserFactory(
         }
 
         assert factory.can_create(config_with_nonexistent_ruleset) is False
+
+    def test_create_raises_processor_config_error_for_invalid_config(self) -> None:
+        """create() surfaces the translated config error, not a generic ValueError."""
+        factory = SecurityControlAnalyserFactory(ServiceContainer())
+
+        with pytest.raises(
+            ProcessorConfigError, match="Invalid SecurityControlAnalyserConfig"
+        ):
+            factory.create({"unknown_field": "value"})

--- a/libs/waivern-security-document-evidence-extractor/src/waivern_security_document_evidence_extractor/factory.py
+++ b/libs/waivern-security-document-evidence-extractor/src/waivern_security_document_evidence_extractor/factory.py
@@ -34,9 +34,6 @@ class SecurityDocumentEvidenceExtractorFactory(
     @override
     def create(self, config: ComponentConfig) -> SecurityDocumentEvidenceExtractor:
         """Create a SecurityDocumentEvidenceExtractor from configuration."""
-        if not self.can_create(config):
-            raise ValueError("Cannot create extractor with given configuration")
-
         return SecurityDocumentEvidenceExtractor(
             config=SecurityDocumentEvidenceExtractorConfig.from_properties(config),
         )

--- a/libs/waivern-security-document-evidence-extractor/tests/waivern_security_document_evidence_extractor/test_factory.py
+++ b/libs/waivern-security-document-evidence-extractor/tests/waivern_security_document_evidence_extractor/test_factory.py
@@ -2,6 +2,7 @@
 
 import pytest
 from waivern_core import ComponentConfig, ComponentFactory
+from waivern_core.errors import ProcessorConfigError
 from waivern_core.services import ServiceContainer
 from waivern_core.testing import ComponentFactoryContractTests
 
@@ -23,3 +24,13 @@ class TestSecurityDocumentEvidenceExtractorFactoryContract(
     @pytest.fixture
     def valid_config(self) -> ComponentConfig:
         return {}
+
+    def test_create_raises_processor_config_error_for_invalid_config(self) -> None:
+        """create() surfaces the translated config error, not a generic ValueError."""
+        factory = SecurityDocumentEvidenceExtractorFactory(ServiceContainer())
+
+        with pytest.raises(
+            ProcessorConfigError,
+            match="Invalid SecurityDocumentEvidenceExtractorConfig",
+        ):
+            factory.create({"unknown_field": "value"})

--- a/libs/waivern-security-evidence-normaliser/src/waivern_security_evidence_normaliser/factory.py
+++ b/libs/waivern-security-evidence-normaliser/src/waivern_security_evidence_normaliser/factory.py
@@ -40,12 +40,9 @@ class SecurityEvidenceNormaliserFactory(ComponentFactory[SecurityEvidenceNormali
             Configured SecurityEvidenceNormaliser instance
 
         Raises:
-            ValueError: If configuration is invalid or ruleset cannot be loaded
+            ProcessorConfigError: If the configuration is invalid
 
         """
-        if not self.can_create(config):
-            raise ValueError("Cannot create analyser with given configuration")
-
         analyser_config = SecurityEvidenceNormaliserConfig.from_properties(config)
         return SecurityEvidenceNormaliser(config=analyser_config)
 

--- a/libs/waivern-security-evidence-normaliser/tests/waivern_security_evidence_normaliser/test_analyser.py
+++ b/libs/waivern-security-evidence-normaliser/tests/waivern_security_evidence_normaliser/test_analyser.py
@@ -7,8 +7,12 @@ from waivern_core import AnalyserContractTests
 from waivern_core.errors import ProcessorConfigError
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
+from waivern_core.services import ServiceContainer
 
 from waivern_security_evidence_normaliser.analyser import SecurityEvidenceNormaliser
+from waivern_security_evidence_normaliser.factory import (
+    SecurityEvidenceNormaliserFactory,
+)
 from waivern_security_evidence_normaliser.types import SecurityEvidenceNormaliserConfig
 
 # =============================================================================
@@ -25,6 +29,19 @@ class TestSecurityEvidenceNormaliserConfig:
             SecurityEvidenceNormaliserConfig.from_properties(
                 {"maximum_evidence_items": 0}
             )
+
+
+class TestSecurityEvidenceNormaliserFactory:
+    """Factory surfaces translated config errors from create()."""
+
+    def test_create_raises_processor_config_error_for_invalid_config(self) -> None:
+        """create() surfaces the translated config error, not a generic ValueError."""
+        factory = SecurityEvidenceNormaliserFactory(ServiceContainer())
+
+        with pytest.raises(
+            ProcessorConfigError, match="Invalid SecurityEvidenceNormaliserConfig"
+        ):
+            factory.create({"maximum_evidence_items": 0})
 
 
 class TestSecurityEvidenceNormaliserContract(

--- a/libs/waivern-service-integration-analyser/src/waivern_service_integration_analyser/factory.py
+++ b/libs/waivern-service-integration-analyser/src/waivern_service_integration_analyser/factory.py
@@ -37,12 +37,9 @@ class ServiceIntegrationAnalyserFactory(ComponentFactory[ServiceIntegrationAnaly
             Configured ServiceIntegrationAnalyser instance.
 
         Raises:
-            ValueError: If configuration is invalid or ruleset cannot be loaded.
+            ProcessorConfigError: If the configuration is invalid.
 
         """
-        if not self.can_create(config):
-            raise ValueError("Cannot create analyser with given configuration")
-
         analyser_config = ServiceIntegrationAnalyserConfig.from_properties(config)
         return ServiceIntegrationAnalyser(config=analyser_config)
 

--- a/libs/waivern-service-integration-analyser/tests/waivern_service_integration_analyser/test_analyser.py
+++ b/libs/waivern-service-integration-analyser/tests/waivern_service_integration_analyser/test_analyser.py
@@ -2,6 +2,7 @@
 
 import pytest
 from waivern_core import AnalyserContractTests
+from waivern_core.errors import ProcessorConfigError
 from waivern_core.message import Message
 from waivern_core.schemas import Schema
 from waivern_core.services import ServiceContainer
@@ -458,3 +459,13 @@ class TestServiceIntegrationFactory:
             "pattern_matching": {"ruleset": "local/nonexistent/1.0.0"},
         }
         assert factory.can_create(properties) is False
+
+    def test_create_raises_processor_config_error_for_invalid_config(self) -> None:
+        """create() surfaces the translated config error, not a generic ValueError."""
+        container = ServiceContainer()
+        factory = ServiceIntegrationAnalyserFactory(container)
+
+        with pytest.raises(
+            ProcessorConfigError, match="Invalid ServiceIntegrationAnalyserConfig"
+        ):
+            factory.create({"unknown_field": "value"})


### PR DESCRIPTION
## Summary

Processor factories gated `create()` on `can_create()` and raised a generic `ValueError("Cannot create … with given configuration")`, discarding the translated `ProcessorConfigError` (its message and structured validation data). The generic error reached runbook authors via the executor. This removes the gate so `create()` surfaces the precise config error.

## Changes

- Removed the `if not self.can_create(config): raise ValueError(...)` gate from `create()` in 11 processor/classifier factories. Each now constructs from `from_properties`, propagating `ProcessorConfigError`. `can_create()` is unchanged — it remains the boolean precondition probe.
- Documented the contract on `ComponentFactory.create`/`can_create` so the gating pattern is not reintroduced: `create()` propagates the category error and must not gate on `can_create()`; `can_create()` is the non-constructing boolean shadow.
- Corrected the now-inaccurate `Raises: ValueError` docstrings on the affected `create()` methods to `ProcessorConfigError`.
- Added one test per factory asserting `create()` raises `ProcessorConfigError` for an invalid config.

## Verification

Full dev-checks pass (lint, format, type-check, tests).