### PR TITLE
refactor: translate service config validation failures to category errors

### DIFF
--- a/libs/waivern-artifact-store/src/waivern_artifact_store/configuration.py
+++ b/libs/waivern-artifact-store/src/waivern_artifact_store/configuration.py
@@ -13,8 +13,10 @@ from pathlib import Path
 from typing import Annotated, Any, Literal, Protocol, Self
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
+from waivern_core.config_validation import validate_or_raise
 
 from waivern_artifact_store.base import ArtifactStore
+from waivern_artifact_store.errors import ArtifactStoreConfigError
 from waivern_artifact_store.filesystem import LocalFilesystemStore
 from waivern_artifact_store.in_memory import AsyncInMemoryStore
 
@@ -124,7 +126,7 @@ class ArtifactStoreConfiguration(RootModel[_ArtifactStoreConfigUnion]):
             Validated configuration instance
 
         Raises:
-            ValidationError: If configuration is invalid
+            ArtifactStoreConfigError: If configuration is invalid
 
         """
         config_data = properties.copy()
@@ -153,7 +155,7 @@ class ArtifactStoreConfiguration(RootModel[_ArtifactStoreConfigUnion]):
                 if api_key:
                     config_data["api_key"] = api_key
 
-        return cls.model_validate(config_data)
+        return validate_or_raise(cls, config_data, ArtifactStoreConfigError)
 
     def create_store(self) -> ArtifactStore:
         """Create a singleton store instance.

--- a/libs/waivern-artifact-store/src/waivern_artifact_store/errors.py
+++ b/libs/waivern-artifact-store/src/waivern_artifact_store/errors.py
@@ -1,10 +1,21 @@
 """Artifact store exceptions."""
 
-from waivern_core.errors import WaivernError
+from waivern_core.errors import ServiceConfigError, WaivernError
 
 
 class ArtifactStoreError(WaivernError):
     """Base exception for artifact store related errors."""
+
+    pass
+
+
+class ArtifactStoreConfigError(ArtifactStoreError, ServiceConfigError):
+    """Raised when artifact store configuration is invalid.
+
+    An artifact-store-domain error (``ArtifactStoreError``) that also participates
+    in the cross-service configuration category (``ServiceConfigError``), so callers
+    can catch any service misconfiguration uniformly.
+    """
 
     pass
 

--- a/libs/waivern-artifact-store/src/waivern_artifact_store/factory.py
+++ b/libs/waivern-artifact-store/src/waivern_artifact_store/factory.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 
-from pydantic import ValidationError
+from waivern_core.errors import ServiceConfigError
 
 from waivern_artifact_store.base import ArtifactStore
 from waivern_artifact_store.configuration import ArtifactStoreConfiguration
@@ -76,7 +76,7 @@ class ArtifactStoreFactory:
         # Try to create from environment
         try:
             return ArtifactStoreConfiguration.from_properties({})
-        except ValidationError as e:
+        except ServiceConfigError as e:
             logger.debug(f"Cannot create configuration from environment: {e}")
             return None
 

--- a/libs/waivern-artifact-store/tests/waivern_artifact_store/test_configuration.py
+++ b/libs/waivern-artifact-store/tests/waivern_artifact_store/test_configuration.py
@@ -13,6 +13,7 @@ from waivern_artifact_store.configuration import (
     MemoryStoreConfig,
     RemoteStoreConfig,
 )
+from waivern_artifact_store.errors import ArtifactStoreConfigError
 from waivern_artifact_store.filesystem import LocalFilesystemStore
 from waivern_artifact_store.in_memory import AsyncInMemoryStore
 
@@ -120,13 +121,15 @@ class TestArtifactStoreConfigurationFromProperties:
         assert isinstance(config.root, FilesystemStoreConfig)
         assert config.root.base_path == Path("/explicit/path")
 
-    def test_from_properties_raises_for_invalid_type_from_environment(
+    def test_from_properties_raises_config_error_for_invalid_type_from_environment(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Raise ValidationError for invalid type from env var."""
+        """Translate an invalid env-var type into the category config error."""
         monkeypatch.setenv("WAIVERN_STORE_TYPE", "invalid_backend")
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(
+            ArtifactStoreConfigError, match="Invalid ArtifactStoreConfiguration"
+        ):
             ArtifactStoreConfiguration.from_properties({})
 
 

--- a/libs/waivern-artifact-store/tests/waivern_artifact_store/test_errors.py
+++ b/libs/waivern-artifact-store/tests/waivern_artifact_store/test_errors.py
@@ -1,0 +1,17 @@
+"""Tests for artifact store error types."""
+
+from __future__ import annotations
+
+from waivern_core.errors import ServiceConfigError
+
+from waivern_artifact_store.errors import ArtifactStoreConfigError, ArtifactStoreError
+
+
+class TestArtifactStoreConfigError:
+    """ArtifactStoreConfigError sits on both the domain and category axes."""
+
+    def test_is_service_config_error_subclass(self) -> None:
+        assert isinstance(ArtifactStoreConfigError("bad config"), ServiceConfigError)
+
+    def test_is_artifact_store_error_subclass(self) -> None:
+        assert isinstance(ArtifactStoreConfigError("bad config"), ArtifactStoreError)

--- a/libs/waivern-core/src/waivern_core/services/configuration.py
+++ b/libs/waivern-core/src/waivern_core/services/configuration.py
@@ -70,6 +70,15 @@ class BaseServiceConfiguration(BaseModel):
         provider-specific keys and models), layered fallbacks, and post-validation
         enrichment.
 
+        ``from_properties`` is the untrusted-input boundary (runbook properties,
+        environment variables): overriding subclasses translate validation failures
+        into a ``ServiceConfigError``-family error (typically via ``validate_or_raise``)
+        so callers get a uniform, structured config error rather than a raw
+        ``ValidationError``. Direct construction with typed fields
+        (``LLMServiceConfiguration(provider=..., api_key=...)``) is the internal path
+        and surfaces Pydantic's raw ``ValidationError``. The base implementation here
+        does not translate — a subclass relying on it gets the raw error.
+
         Args:
             properties: Dictionary containing configuration properties
 
@@ -77,7 +86,8 @@ class BaseServiceConfiguration(BaseModel):
             Validated configuration instance
 
         Raises:
-            ValidationError: If properties are invalid or missing required fields
+            ValidationError: If properties are invalid (base implementation only;
+                overriding subclasses raise their ``ServiceConfigError``-family error)
 
         Example:
             ```python

--- a/libs/waivern-core/src/waivern_core/services/configuration.py
+++ b/libs/waivern-core/src/waivern_core/services/configuration.py
@@ -172,6 +172,15 @@ class BaseComponentConfiguration(BaseModel):
         on ``auth_method``), resolving secrets, reading the filesystem, and enriching
         frozen fields after validation.
 
+        ``from_properties`` is the untrusted-input boundary (runbook properties,
+        environment variables): overriding subclasses translate validation failures
+        into their component-category error (``ConnectorConfigError`` for connectors,
+        ``ProcessorConfigError`` for analysers), typically via ``validate_or_raise``,
+        so callers get a uniform, structured config error rather than a raw
+        ``ValidationError``. Direct construction with typed fields is the internal path
+        and surfaces Pydantic's raw ``ValidationError``. The base implementation here
+        does not translate — a subclass relying on it gets the raw error.
+
         Args:
             properties: Dictionary containing configuration properties from runbook
 
@@ -179,7 +188,8 @@ class BaseComponentConfiguration(BaseModel):
             Validated configuration instance
 
         Raises:
-            ValidationError: If properties are invalid or missing required fields
+            ValidationError: If properties are invalid (base implementation only;
+                overriding subclasses raise their component-category error)
 
         Example:
             ```python

--- a/libs/waivern-filesystem/src/waivern_filesystem/factory.py
+++ b/libs/waivern-filesystem/src/waivern_filesystem/factory.py
@@ -36,7 +36,7 @@ class FilesystemConnectorFactory(ComponentFactory[FilesystemConnector]):
             Configured FilesystemConnector instance
 
         Raises:
-            ValueError: If configuration is invalid
+            ConnectorConfigError: If the configuration is invalid.
 
         """
         # Parse and validate configuration

--- a/libs/waivern-llm/src/waivern_llm/di/configuration.py
+++ b/libs/waivern-llm/src/waivern_llm/di/configuration.py
@@ -11,7 +11,10 @@ import os
 from typing import Any, Self, override
 
 from pydantic import Field, field_validator
+from waivern_core.config_validation import validate_or_raise
 from waivern_core.services import BaseServiceConfiguration
+
+from waivern_llm.errors import LLMConfigurationError
 
 
 class LLMServiceConfiguration(BaseServiceConfiguration):
@@ -142,7 +145,7 @@ class LLMServiceConfiguration(BaseServiceConfiguration):
             Validated configuration instance
 
         Raises:
-            ValidationError: If configuration is invalid
+            LLMConfigurationError: If configuration is invalid
 
         Example:
             ```python
@@ -214,7 +217,7 @@ class LLMServiceConfiguration(BaseServiceConfiguration):
             except ValueError:
                 pass  # Leave as default (2)
 
-        return cls.model_validate(config_data)
+        return validate_or_raise(cls, config_data, LLMConfigurationError)
 
     def get_default_model(self) -> str:
         """Get provider-specific default model name.

--- a/libs/waivern-llm/src/waivern_llm/dispatcher_factory.py
+++ b/libs/waivern-llm/src/waivern_llm/dispatcher_factory.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from pydantic import ValidationError
 from waivern_artifact_store.base import ArtifactStore
+from waivern_core.errors import ServiceConfigError
 
 from waivern_llm.di.configuration import LLMServiceConfiguration
 from waivern_llm.dispatcher import LLMDispatcher
@@ -65,7 +65,7 @@ class LLMDispatcherFactory:
 
         try:
             return LLMServiceConfiguration.from_properties({})
-        except ValidationError as e:
+        except ServiceConfigError as e:
             logger.debug(f"Cannot create configuration from environment: {e}")
             return None
 

--- a/libs/waivern-llm/tests/di/test_configuration.py
+++ b/libs/waivern-llm/tests/di/test_configuration.py
@@ -117,6 +117,21 @@ class TestLLMServiceConfiguration:
                 or "anthropic" in error_msg
             )
 
+    def test_from_properties_invalid_provider_raises_llm_configuration_error(
+        self,
+    ) -> None:
+        """from_properties translates a validation failure to the category error."""
+        import pytest
+
+        from waivern_llm.errors import LLMConfigurationError
+
+        with pytest.raises(
+            LLMConfigurationError, match="Invalid LLMServiceConfiguration"
+        ):
+            LLMServiceConfiguration.from_properties(
+                {"provider": "invalid_provider", "api_key": "test-key"}
+            )
+
     def test_validation_rejects_empty_api_key(self) -> None:
         """Test API key cannot be empty/whitespace."""
         # Test with empty string

--- a/libs/waivern-mongodb/src/waivern_mongodb/factory.py
+++ b/libs/waivern-mongodb/src/waivern_mongodb/factory.py
@@ -36,7 +36,7 @@ class MongoDBConnectorFactory(ComponentFactory[MongoDBConnector]):
             Configured MongoDBConnector instance
 
         Raises:
-            ValueError: If configuration is invalid
+            ConnectorConfigError: If the configuration is invalid.
 
         """
         # Parse and validate configuration

--- a/libs/waivern-mysql/src/waivern_mysql/factory.py
+++ b/libs/waivern-mysql/src/waivern_mysql/factory.py
@@ -36,7 +36,7 @@ class MySQLConnectorFactory(ComponentFactory[MySQLConnector]):
             Configured MySQLConnector instance
 
         Raises:
-            ValueError: If configuration is invalid
+            ConnectorConfigError: If the configuration is invalid.
 
         """
         # Parse and validate configuration

--- a/libs/waivern-source-code-analyser/src/waivern_source_code_analyser/analyser_factory.py
+++ b/libs/waivern-source-code-analyser/src/waivern_source_code_analyser/analyser_factory.py
@@ -40,7 +40,7 @@ class SourceCodeAnalyserFactory(ComponentFactory[SourceCodeAnalyser]):
             Configured SourceCodeAnalyser instance
 
         Raises:
-            ValueError: If configuration is invalid
+            ProcessorConfigError: If the configuration is invalid.
 
         """
         # Parse and validate configuration

--- a/libs/waivern-sqlite/src/waivern_sqlite/factory.py
+++ b/libs/waivern-sqlite/src/waivern_sqlite/factory.py
@@ -36,7 +36,7 @@ class SQLiteConnectorFactory(ComponentFactory[SQLiteConnector]):
             Configured SQLiteConnector instance
 
         Raises:
-            ValueError: If configuration is invalid
+            ConnectorConfigError: If the configuration is invalid.
 
         """
         # Parse and validate configuration


### PR DESCRIPTION
Standardises service-configuration error handling so a misconfiguration surfaces as a framework error rather than a raw Pydantic `ValidationError`, completing the config-error policy already applied to connectors and analysers.

## Changes

- `LLMServiceConfiguration.from_properties` translates validation failures to `LLMConfigurationError` via `validate_or_raise`.
- `ArtifactStoreConfiguration.from_properties` translates to a new `ArtifactStoreConfigError` — an `ArtifactStoreError` that also participates in the `ServiceConfigError` category, so callers can catch any service misconfiguration uniformly.
- The two service factories' graceful-degradation catch is retyped from `ValidationError` to `ServiceConfigError`, so `can_create()`/`create()` keep degrading cleanly now that `from_properties` no longer raises the raw error.
- The base service-config and component-config `from_properties` docstrings state the translation contract: `from_properties` is the untrusted-input boundary (runbook properties, environment variables) and translates; direct typed construction surfaces Pydantic's raw `ValidationError`.
- Connector (`filesystem`, `mongodb`, `mysql`, `sqlite`) and source-code analyser factory `create()` docstrings corrected to declare the translated `ConnectorConfigError` / `ProcessorConfigError` instead of a stale `ValueError`.

## Verification

Full `dev-checks.sh` passes: ruff format + lint clean, basedpyright strict reports no errors, 1981 tests pass.