### PR TITLE
feat: add Claude 4.6 model capabilities to registry

### DIFF
--- a/libs/waivern-llm/src/waivern_llm/model_capabilities.py
+++ b/libs/waivern-llm/src/waivern_llm/model_capabilities.py
@@ -51,6 +51,9 @@ _DEFAULT_CAPABILITIES = ModelCapabilities(
 )
 
 _MODEL_CAPABILITIES: dict[str, ModelCapabilities] = {
+    # Anthropic Claude 4.6 family (1M context window)
+    "claude-sonnet-4-6": ModelCapabilities(1_000_000, 64_000),
+    "claude-opus-4-6": ModelCapabilities(1_000_000, 128_000),
     # Anthropic Claude 4.5 family
     "claude-opus-4-5": ModelCapabilities(200_000, 8192),
     "claude-sonnet-4-5": ModelCapabilities(200_000, 8192),


### PR DESCRIPTION
## Summary

Registers the Claude 4.6 family in the LLM model capabilities registry so these models resolve to their true context and output limits.

- `claude-sonnet-4-6` → 1M context window, 64K max output
- `claude-opus-4-6` → 1M context window, 128K max output

## Problem

Without explicit entries, `claude-sonnet-4-6` fuzzy-matched the generic `claude-sonnet-4` key, resolving to 200K context / 8192 output. Token-aware batching therefore sized against 200K instead of the model's real 1M window, and the output cap was understated.

## How it works

`ModelCapabilities.get()` matches registry keys longest-first, so the explicit 17-character `claude-sonnet-4-6` key takes precedence over the shorter `claude-sonnet-4` base-family key. The 4.5 entries are unaffected.